### PR TITLE
Generate random color from string

### DIFF
--- a/luda/editor/client/src/timeline/clip/SubtitleClipComponent.ts
+++ b/luda/editor/client/src/timeline/clip/SubtitleClipComponent.ts
@@ -48,10 +48,7 @@ export const SubtitleClipComponent: Render<
     x: width - componentWidth,
     y: height - componentHeight,
   };
-  const color =
-    timelineState.selectedClip?.id === clip.id
-      ? ColorUtil.Green
-      : ColorUtil.getRandomColorFromString(clip.id);
+  const color = ColorUtil.getRandomColorFromString(clip.id);
   const brighterColor = ColorUtil.brighterColor01(color, 0.2);
 
   const strokePath = new CanvasKit.Path()

--- a/luda/editor/client/src/timeline/clip/SubtitleClipComponent.ts
+++ b/luda/editor/client/src/timeline/clip/SubtitleClipComponent.ts
@@ -51,7 +51,7 @@ export const SubtitleClipComponent: Render<
   const color =
     timelineState.selectedClip?.id === clip.id
       ? ColorUtil.Green
-      : ColorUtil.Color0255(34, 167, 240);
+      : ColorUtil.getRandomColorFromString(clip.id);
   const brighterColor = ColorUtil.brighterColor01(color, 0.2);
 
   const strokePath = new CanvasKit.Path()

--- a/namui/src/ColorUtil.ts
+++ b/namui/src/ColorUtil.ts
@@ -66,6 +66,27 @@ export namespace ColorUtil {
     );
   }
 
+  export function getRandomColorFromString(
+    seed: string,
+    withAlpha: boolean = false,
+  ) {
+    const hash = seed.split("").reduce((hash, character) => {
+      hash ^= character.charCodeAt(0);
+      for (let i = 0; i < 8; i++) {
+        hash = (hash >>> 1) ^ (0xedb88320 & -(hash & 1));
+      }
+      return hash;
+    }, 0xffffffff);
+
+    const [r, g, b, a] = [
+      (hash >>> 24) & 0xff,
+      (hash >>> 16) & 0xff,
+      (hash >>> 8) & 0xff,
+      withAlpha ? (hash & 0xff) / 255 : 1,
+    ];
+    return Color0255(r, g, b, a);
+  }
+
   export function brighterColor01(color: CanvasKit.Color, amount: number) {
     const { hue, saturation, lightness, alpha } = Convert.ColorToHsl(color);
 


### PR DESCRIPTION
It uses functions similar to, but not equal to, crc32 hash functions.

`ColorUtil.getRandomColorFromString(seed: string, withAlpha?: boolean)`
Color range is rgba(0-255, 0-255, 0-255, 0-1)
If `withAlpha` option activated, color's alpha also will be random. If not, alpha will be `1`.

It closes #19