### PR TITLE
Support '-' in image name

### DIFF
--- a/luda/editor/client/src/cameraAngleEditor/imageBrowser/SyncBrowserItems.ts
+++ b/luda/editor/client/src/cameraAngleEditor/imageBrowser/SyncBrowserItems.ts
@@ -48,7 +48,8 @@ export const SyncBrowserItems: Render<
     const files = dirents.filter((dirent) => dirent.type === "file");
     const imageFilenameObjects = files.map((dirent) => {
       const splitted = dirent.name.split("-");
-      const [character, pose, emotionAndExtension] = splitted;
+      const [character, pose, ...rest] = splitted;
+      const emotionAndExtension = rest.join("-");
       if (!character || !pose || !emotionAndExtension) {
         throw new Error(`${dirent.name} is invalid`);
       }

--- a/namui/src/image/ImageLoadManager.ts
+++ b/namui/src/image/ImageLoadManager.ts
@@ -28,10 +28,11 @@ export class ImageLoadManager implements IImageLoadManager, IManagerInternal {
   }
   private async startLoad(url: string): Promise<void> {
     try {
-      const response = await fetch(url);
+      const encodedUrl = encodeURI(url);
+      const response = await fetch(encodedUrl);
       if (!response.ok) {
         console.error(
-          `Failed to load image: ${url}, status: ${
+          `Failed to load image: ${encodedUrl}, status: ${
             response.status
           }, ${await response.text()}`,
         );


### PR DESCRIPTION
'-' is the separator of image name.
But some of image, it use '-' to describe emotion.

![image](https://user-images.githubusercontent.com/3580430/143373198-b7b97238-60eb-4369-8e97-bd43797d6e66.png)

Not only '-' to describe emotion

![image](https://user-images.githubusercontent.com/3580430/143373215-d72fd02b-6645-4770-aa1c-7fd206fe3639.png)


So I make it possible to use '-' in emotion in file.
Maybe we should change the separator from '-' to other thing later.