### PR TITLE
Support vscode multi-root workspace

### DIFF
--- a/namseent.code-workspace
+++ b/namseent.code-workspace
@@ -1,0 +1,22 @@
+{
+    "folders": [
+        {
+            "path": "luda-editor/luda-editor-client"
+        },
+        {
+            "path": "luda-editor/luda-editor-server"
+        },
+        {
+            "path": "luda-editor/luda-editor-rpc"
+        },
+        {
+            "path": "namui"
+        },
+        {
+            "path": "nrpc"
+        },
+        {
+            "path": "./"
+        }
+    ]
+}


### PR DESCRIPTION
> English follows

우리는 rust cargo workspace를 사용하지 않기로 결정했습니다. 왜냐하면 rust에서 wasm를 사용할 때, wasm에서 빌드하지 못하는 dependency를 cargo workspace에서 체크하는 문제가 있기 때문입니다.

cargo workspace를 없애면 vscode로 root 디렉토리를 켜서 작업할 수 없습니다. cargo workspace 없이는 root 디렉토리에선 rust-analyzer가 동작하지 않기 때문입니다.

이러한 불편함을 개선하기 위해 vscode multi-root workspace를 도입합니다. 엄청나게 편하진 않을지라도, vscode를 여러개 켜야하는 것보단 더 나을 것이라 예상됩니다.

We decided not to use the rust cargo workspace. This is because when using wasm in rust, there is a problem in cargo workspace checking for dependencies that wasm cannot build.

Because of removing the cargo workspace, you won't be able to work in rust, when you open the root directory with vscode. This is because rust-analyzer will not run in the root directory without cargo workspace.

To alleviate this inconvenience, vscode multi-root workspace is introduced. It's not that much convenient, but it's expected to be better than having to have multiple vscodes turned on.