### PR TITLE
Rollback rustfmt to default

### DIFF
--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
@@ -35,11 +35,7 @@ impl ImageBrowser {
                 height: item_size.height,
                 style: RectStyle {
                     stroke: Some(RectStroke {
-                        width: if is_selected {
-                            3.0
-                        } else {
-                            1.0
-                        },
+                        width: if is_selected { 3.0 } else { 1.0 },
                         border_position: BorderPosition::Inside,
                         color: if is_selected {
                             namui::Color::RED
@@ -47,9 +43,7 @@ impl ImageBrowser {
                             namui::Color::BLACK
                         },
                     }),
-                    round: Some(RectRound {
-                        radius: 5.0,
-                    }),
+                    round: Some(RectRound { radius: 5.0 }),
                     fill: Some(RectFill {
                         color: namui::Color::WHITE,
                     }),

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/browser_item.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/browser_item.rs
@@ -27,11 +27,7 @@ impl BrowserItem {
                 height: props.item_size.height,
                 style: RectStyle {
                     stroke: Some(RectStroke {
-                        width: if props.is_selected {
-                            3.0
-                        } else {
-                            1.0
-                        },
+                        width: if props.is_selected { 3.0 } else { 1.0 },
                         border_position: BorderPosition::Inside,
                         color: if props.is_selected {
                             namui::Color::RED
@@ -39,9 +35,7 @@ impl BrowserItem {
                             namui::Color::BLACK
                         },
                     }),
-                    round: Some(RectRound {
-                        radius: 5.0,
-                    }),
+                    round: Some(RectRound { radius: 5.0 }),
                     fill: Some(RectFill {
                         color: namui::Color::WHITE,
                     }),

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/mod.rs
@@ -77,9 +77,7 @@ impl ImageBrowser {
                 } => {
                     self.image_filename_objects = image_filename_objects.to_vec();
                 }
-                EditorEvent::ImageBrowserSelectEvent {
-                    selected_key,
-                } => {
+                EditorEvent::ImageBrowserSelectEvent { selected_key } => {
                     namui::log(format!("selected_key: {}", selected_key));
                     if selected_key == "back" {
                         let directory_splitted = self.directory_key.split("-").collect::<Vec<_>>();
@@ -273,9 +271,13 @@ impl ImageBrowser {
         let pose = pose.unwrap();
 
         let mut emotions = BTreeSet::new();
-        for filename_object in self.image_filename_objects.iter().filter(|filename_object| {
-            filename_object.character == character && filename_object.pose == pose
-        }) {
+        for filename_object in self
+            .image_filename_objects
+            .iter()
+            .filter(|filename_object| {
+                filename_object.character == character && filename_object.pose == pose
+            })
+        {
             emotions.insert(&filename_object.emotion);
         }
 

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/mod.rs
@@ -22,19 +22,18 @@ pub struct ClipEditorProps<'a> {
 
 impl ClipEditor {
     pub fn update(&mut self, event: &dyn std::any::Any) {
-        self.camera_clip_editor
-            .update(event);
+        self.camera_clip_editor.update(event);
     }
 
     pub fn render(&self, props: &ClipEditorProps) -> RenderingTree {
         match &props.selected_clip {
             Some(clip) => match clip {
-                Clip::Camera(camera_clip) => self
-                    .camera_clip_editor
-                    .render(&CameraClipEditorProps {
+                Clip::Camera(camera_clip) => {
+                    self.camera_clip_editor.render(&CameraClipEditorProps {
                         camera_clip: &camera_clip,
                         xywh: props.xywh,
-                    }),
+                    })
+                }
                 Clip::Subtitle(_) => todo!(),
             },
             None => RenderingTree::Empty,

--- a/luda-editor/luda-editor-client/src/editor/job/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/job/mod.rs
@@ -34,12 +34,7 @@ fn find_camera_track_of_clip<'a>(
 
 impl MoveCameraClipJob {
     pub fn move_camera_clip_by_job(&self, clip: &mut CameraClip, time_per_pixel: &TimePerPixel) {
-        let delta_x = self
-            .last_global_mouse_xy
-            .x
-            - self
-                .click_anchor_in_global
-                .x;
+        let delta_x = self.last_global_mouse_xy.x - self.click_anchor_in_global.x;
         let delta_time = PixelSize(delta_x) * *time_per_pixel;
         let clip_duration = clip.end_at - clip.start_at;
         let moved_start_at = clip.start_at + delta_time;
@@ -59,18 +54,10 @@ impl MoveCameraClipJob {
         let moving_clip_id = &self.clip_id;
         let moving_clip = clips
             .iter()
-            .find(|clip| {
-                clip.id
-                    .eq(moving_clip_id)
-            })
+            .find(|clip| clip.id.eq(moving_clip_id))
             .unwrap();
 
-        let delta_x = self
-            .last_global_mouse_xy
-            .x
-            - self
-                .click_anchor_in_global
-                .x;
+        let delta_x = self.last_global_mouse_xy.x - self.click_anchor_in_global.x;
         let delta_time = PixelSize(delta_x) * *time_per_pixel;
         let clip_duration = moving_clip.end_at - moving_clip.start_at;
         let moved_start_at = moving_clip.start_at + delta_time;
@@ -78,18 +65,12 @@ impl MoveCameraClipJob {
 
         let moving_clip_index = clips
             .iter()
-            .position(|clip| {
-                clip.id
-                    .eq(moving_clip_id)
-            })
+            .position(|clip| clip.id.eq(moving_clip_id))
             .unwrap();
 
         let mut next_moving_clip_index = moving_clip_index;
 
-        for (index, clip) in clips
-            .iter()
-            .enumerate()
-        {
+        for (index, clip) in clips.iter().enumerate() {
             if index == moving_clip_index {
                 continue;
             }
@@ -119,10 +100,7 @@ impl MoveCameraClipJob {
         if is_preview {
             clips
                 .iter_mut()
-                .find(|clip| {
-                    clip.id
-                        .eq(moving_clip_id)
-                })
+                .find(|clip| clip.id.eq(moving_clip_id))
                 .map(|moving_clip| {
                     moving_clip.start_at = moved_start_at;
                     moving_clip.end_at = moved_end_at;

--- a/luda-editor/luda-editor-client/src/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/mod.rs
@@ -161,7 +161,10 @@ impl Editor {
         let onmessage_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
             // Handle difference Text/Binary,...
             if let Ok(array_buffer) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
-                namui::log(format!("message event, received arraybuffer: {:?}", array_buffer));
+                namui::log(format!(
+                    "message event, received arraybuffer: {:?}",
+                    array_buffer
+                ));
                 let u8_array = js_sys::Uint8Array::new(&array_buffer);
                 let len = u8_array.byte_length() as usize;
                 let packet = u8_array.to_vec();

--- a/luda-editor/luda-editor-client/src/editor/timeline/timeline_body/track_body/camera_track_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/timeline/timeline_body/track_body/camera_track_body/mod.rs
@@ -21,41 +21,25 @@ pub struct CameraTrackBodyProps<'a> {
 
 fn move_clip_at_last(track: &mut CameraTrack, clip_id: &String) {
     let clips = &mut track.clips;
-    let moving_clip_index = clips
-        .iter()
-        .position(|clip| {
-            clip.id
-                .eq(clip_id)
-        })
-        .unwrap();
+    let moving_clip_index = clips.iter().position(|clip| clip.id.eq(clip_id)).unwrap();
     let moving_clip = clips.remove(moving_clip_index);
     clips.push(moving_clip);
 }
 
 impl CameraTrackBody {
     pub fn render(props: &CameraTrackBodyProps) -> RenderingTree {
-        let clips = match &props
-            .timeline
-            .job
-        {
+        let clips = match &props.timeline.job {
             Some(Job::MoveCameraClip(job)) => {
-                let mut track = props
-                    .track
-                    .clone();
+                let mut track = props.track.clone();
 
-                let time_per_pixel = &props
-                    .timeline
-                    .time_per_pixel;
+                let time_per_pixel = &props.timeline.time_per_pixel;
                 job.order_clips_by_moving_clip(&mut track, time_per_pixel, true);
 
                 move_clip_at_last(&mut track, &job.clip_id);
 
                 track.clips
             }
-            None => props
-                .track
-                .clips
-                .to_vec(),
+            None => props.track.clips.to_vec(),
         };
 
         render![

--- a/luda-editor/luda-editor-client/src/editor/types.rs
+++ b/luda-editor/luda-editor-client/src/editor/types.rs
@@ -15,9 +15,7 @@ pub struct Time {
 }
 impl Time {
     pub fn zero() -> Self {
-        Self {
-            milliseconds: 0,
-        }
+        Self { milliseconds: 0 }
     }
 }
 impl std::ops::Sub for Time {
@@ -39,38 +37,22 @@ impl std::ops::Add for Time {
 impl std::ops::Div<TimePerPixel> for Time {
     type Output = PixelSize;
     fn div(self, rhs: TimePerPixel) -> Self::Output {
-        let milliseconds = self.milliseconds as f64
-            / rhs
-                .time
-                .milliseconds as f64;
-        PixelSize(
-            milliseconds as f32
-                * rhs
-                    .pixel_size
-                    .0,
-        )
+        let milliseconds = self.milliseconds as f64 / rhs.time.milliseconds as f64;
+        PixelSize(milliseconds as f32 * rhs.pixel_size.0)
     }
 }
 impl std::ops::Div<i64> for Time {
     type Output = Time;
     fn div(self, rhs: i64) -> Self::Output {
         let milliseconds = self.milliseconds / rhs;
-        Time {
-            milliseconds,
-        }
+        Time { milliseconds }
     }
 }
 impl std::ops::Mul<TimePerPixel> for PixelSize {
     type Output = Time;
     fn mul(self, rhs: TimePerPixel) -> Self::Output {
         Time {
-            milliseconds: ((self.0
-                / rhs
-                    .pixel_size
-                    .0)
-                * (rhs
-                    .time
-                    .milliseconds as f32)) as i64,
+            milliseconds: ((self.0 / rhs.pixel_size.0) * (rhs.time.milliseconds as f32)) as i64,
         }
     }
 }
@@ -269,17 +251,12 @@ impl Time {
         }
     }
     pub fn ms(milliseconds: i64) -> Time {
-        Time {
-            milliseconds,
-        }
+        Time { milliseconds }
     }
 }
 impl TimePerPixel {
     pub(crate) fn new(time: Time, pixel_size: PixelSize) -> TimePerPixel {
-        TimePerPixel {
-            time,
-            pixel_size,
-        }
+        TimePerPixel { time, pixel_size }
     }
 }
 

--- a/luda-editor/luda-editor-server/src/main.rs
+++ b/luda-editor/luda-editor-server/src/main.rs
@@ -23,10 +23,15 @@ async fn main() {
         .and(warp::ws())
         .map(|ws: warp::ws::Ws| ws.on_upgrade(move |web_socket| on_connected(web_socket)));
 
-    let cors = warp::cors().allow_any_origin().allow_methods(vec!["GET", "OPTIONS"]);
+    let cors = warp::cors()
+        .allow_any_origin()
+        .allow_methods(vec!["GET", "OPTIONS"]);
     let log = warp::log("luda_editor_rpc");
 
-    let routes = resource_images_route.or(web_socket_route).with(cors).with(log);
+    let routes = resource_images_route
+        .or(web_socket_route)
+        .with(cors)
+        .with(log);
 
     warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
 }
@@ -56,8 +61,10 @@ async fn on_connected(web_socket: WebSocket) {
         }
     };
 
-    let _ =
-        join!(loop_sending, luda_editor_rpc::loop_receiving(tx2, stream, handler, response_waiter));
+    let _ = join!(
+        loop_sending,
+        luda_editor_rpc::loop_receiving(tx2, stream, handler, response_waiter)
+    );
 }
 
 #[derive(Clone)]
@@ -88,9 +95,7 @@ impl luda_editor_rpc::RpcHandle for RpcHandler {
                         }
                     }
                 }
-                Ok(luda_editor_rpc::get_camera_shot_urls::Response {
-                    camera_shot_urls,
-                })
+                Ok(luda_editor_rpc::get_camera_shot_urls::Response { camera_shot_urls })
             }
             Err(error) => {
                 let error_message = format!("get_camera_shot_urls error: {}", error);

--- a/namui/src/namui/draw/image.rs
+++ b/namui/src/namui/draw/image.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 
 pub fn draw_image(namui_context: &NamuiContext, command: &ImageDrawCommand) {
-    let image = namui::managers().image_manager.clone().try_load(command.url.clone());
+    let image = namui::managers()
+        .image_manager
+        .clone()
+        .try_load(command.url.clone());
     if image.is_none() {
         return;
     }
@@ -39,8 +42,9 @@ pub fn draw_image(namui_context: &NamuiContext, command: &ImageDrawCommand) {
         let mut default_paint = default_paint.borrow_mut();
 
         if default_paint.is_none() {
-            let paint =
-                Paint::new().set_style(PaintStyle::Fill).set_color(Color::gary_scale_f01(0.5));
+            let paint = Paint::new()
+                .set_style(PaintStyle::Fill)
+                .set_color(Color::gary_scale_f01(0.5));
             *default_paint = Some(paint);
         }
         let default_paint_reference = default_paint.as_ref().unwrap();

--- a/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
@@ -33,16 +33,18 @@ async fn get_typeface_file_urls() -> Result<TypefaceFileUrls, String> {
     Ok(typeface_file_map_file
         .iter()
         .flat_map(|(language, font_file_map)| {
-            font_file_map.iter().map(move |(font_weight, font_file_url)| {
-                (
-                    TypefaceType {
-                        serif: false,
-                        font_weight: font_weight.clone(),
-                        language: *language,
-                    },
-                    font_file_url.clone(),
-                )
-            })
+            font_file_map
+                .iter()
+                .map(move |(font_weight, font_file_url)| {
+                    (
+                        TypefaceType {
+                            serif: false,
+                            font_weight: font_weight.clone(),
+                            language: *language,
+                        },
+                        font_file_url.clone(),
+                    )
+                })
         })
         .collect())
 }
@@ -50,12 +52,13 @@ async fn get_typeface_file_urls() -> Result<TypefaceFileUrls, String> {
 async fn get_typeface_files(
     typeface_file_urls: &TypefaceFileUrls,
 ) -> HashMap<TypefaceType, Vec<u8>> {
-    let iter =
-        join_all(typeface_file_urls.into_iter().map(|(typeface_type, font_file_url)| async move {
+    let iter = join_all(typeface_file_urls.into_iter().map(
+        |(typeface_type, font_file_url)| async move {
             let bytes = fetch_get_vec_u8(font_file_url).await.unwrap();
             (*typeface_type, bytes)
-        }))
-        .await;
+        },
+    ))
+    .await;
 
     return HashMap::from_iter(iter);
 }

--- a/namui/src/namui/manager/web/image_manager.rs
+++ b/namui/src/namui/manager/web/image_manager.rs
@@ -48,7 +48,10 @@ impl ImageManager {
                         self.image_map.insert(url, Arc::new(image));
                     }
                     None => {
-                        namui::log(format!("failed to MakeImageFromEncoded: {}, {:?}", url, data));
+                        namui::log(format!(
+                            "failed to MakeImageFromEncoded: {}, {:?}",
+                            url, data
+                        ));
                     }
                 },
                 Err(error) => {

--- a/namui/src/namui/namui_common.rs
+++ b/namui/src/namui/namui_common.rs
@@ -95,10 +95,7 @@ pub struct Wh<T> {
 }
 impl<T> Wh<T> {
     pub fn new(width: T, height: T) -> Self {
-        Self {
-            width,
-            height,
-        }
+        Self { width, height }
     }
 }
 

--- a/namui/src/namui/namui_web/fetch.rs
+++ b/namui/src/namui/namui_web/fetch.rs
@@ -10,7 +10,9 @@ pub async fn fetch_get(url: &str) -> Result<Response, String> {
     let request = Request::new_with_str_and_init(url, &options).unwrap();
 
     let window = web_sys::window().unwrap();
-    let response_value = JsFuture::from(window.fetch_with_request(&request)).await.unwrap();
+    let response_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .unwrap();
     assert!(response_value.is_instance_of::<Response>());
     let response: Response = response_value.dyn_into().unwrap();
 
@@ -23,8 +25,11 @@ pub async fn fetch_get(url: &str) -> Result<Response, String> {
 pub async fn fetch_get_array_buffer(url: &str) -> Result<ArrayBuffer, String> {
     let response: Response = fetch_get(&url).await.unwrap();
 
-    let array_buffer =
-        JsFuture::from(response.array_buffer().unwrap()).await.unwrap().dyn_into().unwrap();
+    let array_buffer = JsFuture::from(response.array_buffer().unwrap())
+        .await
+        .unwrap()
+        .dyn_into()
+        .unwrap();
 
     Result::Ok(array_buffer)
 }

--- a/namui/src/namui/namui_web/mod.rs
+++ b/namui/src/namui/namui_web/mod.rs
@@ -29,7 +29,11 @@ static MANAGERS: OnceCell<Mutex<Managers>> = OnceCell::new();
 pub static CANVAS_KIT: OnceCell<Arc<CanvasKit>> = OnceCell::new();
 
 pub fn get_managers() -> std::sync::MutexGuard<'static, Managers> {
-    MANAGERS.get().expect("managers not initialized").lock().unwrap()
+    MANAGERS
+        .get()
+        .expect("managers not initialized")
+        .lock()
+        .unwrap()
 }
 
 impl NamuiImpl for Namui {
@@ -66,7 +70,9 @@ impl NamuiImpl for Namui {
     fn request_animation_frame(callback: Box<dyn FnOnce()>) {
         let closure = Closure::once(callback);
 
-        window().request_animation_frame(closure.as_ref().unchecked_ref()).unwrap();
+        window()
+            .request_animation_frame(closure.as_ref().unchecked_ref())
+            .unwrap();
         closure.forget();
     }
     fn log(format: String) {
@@ -87,7 +93,11 @@ fn make_canvas_element() -> Result<HtmlCanvasElement, Element> {
             canvas_element.set_width(1920);
             canvas_element.set_height(1080);
 
-            document.body().unwrap().append_child(&canvas_element).unwrap();
+            document
+                .body()
+                .unwrap()
+                .append_child(&canvas_element)
+                .unwrap();
 
             Result::Ok(canvas_element)
         }

--- a/namui/src/namui/render/image.rs
+++ b/namui/src/namui/render/image.rs
@@ -21,13 +21,7 @@ pub struct ImageParam {
     pub style: ImageStyle,
 }
 
-pub fn image(
-    ImageParam {
-        url,
-        xywh,
-        style,
-    }: ImageParam,
-) -> RenderingTree {
+pub fn image(ImageParam { url, xywh, style }: ImageParam) -> RenderingTree {
     let image_draw_command = ImageDrawCommand {
         url,
         xywh,

--- a/namui/src/namui/render/path.rs
+++ b/namui/src/namui/render/path.rs
@@ -3,10 +3,7 @@ use crate::namui::{self, *};
 pub fn path(path: Path, paint: Paint) -> RenderingTree {
     RenderingTree::Node(RenderingData {
         draw_calls: vec![DrawCall {
-            commands: vec![DrawCommand::Path(PathDrawCommand {
-                path,
-                paint,
-            })],
+            commands: vec![DrawCommand::Path(PathDrawCommand { path, paint })],
         }],
         ..Default::default()
     })

--- a/namui/src/namui/render/rect.rs
+++ b/namui/src/namui/render/rect.rs
@@ -98,10 +98,7 @@ pub fn rect(
 
     let mut draw_commands: Vec<DrawCommand> = vec![];
 
-    if let Some(RectFill {
-        color,
-    }) = fill
-    {
+    if let Some(RectFill { color }) = fill {
         let fill_paint = namui::Paint::new()
             .set_color(color)
             .set_style(namui::PaintStyle::Fill)

--- a/namui/src/namui/render/rendering_tree.rs
+++ b/namui/src/namui/render/rendering_tree.rs
@@ -58,13 +58,19 @@ impl RenderingTree {
             }
             RenderingTree::Special(special) => match special {
                 SpecialRenderingNode::Translate(translate) => {
-                    namui_context.surface.canvas().translate(translate.x, translate.y);
+                    namui_context
+                        .surface
+                        .canvas()
+                        .translate(translate.x, translate.y);
 
                     for child in &translate.rendering_tree {
                         child.draw(namui_context);
                     }
 
-                    namui_context.surface.canvas().translate(-translate.x, -translate.y);
+                    namui_context
+                        .surface
+                        .canvas()
+                        .translate(-translate.x, -translate.y);
                 }
                 SpecialRenderingNode::Clip(clip) => {
                     let canvas = namui_context.surface.canvas();
@@ -145,7 +151,10 @@ impl RenderingData {
     fn is_inside(&self, local_xy: &Xy<f32>) -> bool {
         self.draw_calls.iter().any(|draw_call| {
             // TODO : Handle drawCall.clip
-            draw_call.commands.iter().any(|draw_command| draw_command.is_inside(local_xy))
+            draw_call
+                .commands
+                .iter()
+                .any(|draw_command| draw_command.is_inside(local_xy))
         })
     }
 }
@@ -235,13 +244,7 @@ mod tests {
             })]),
         ]);
 
-        rendering_tree.call_mouse_event(
-            MouseEventType::Down,
-            &namui::Xy {
-                x: 75.0,
-                y: 75.0,
-            },
-        );
+        rendering_tree.call_mouse_event(MouseEventType::Down, &namui::Xy { x: 75.0, y: 75.0 });
 
         unsafe {
             assert_eq!(ON_MOUSE_DOWN_CALLED_ID_LIST, vec!["0", "1", "3", "5"]);

--- a/namui/src/namui/skia/web/typeface.rs
+++ b/namui/src/namui/skia/web/typeface.rs
@@ -21,7 +21,6 @@ impl Typeface {
 }
 impl Drop for Typeface {
     fn drop(&mut self) {
-        self.0
-            .delete();
+        self.0.delete();
     }
 }

--- a/nrpc/src/def_rpc.rs
+++ b/nrpc/src/def_rpc.rs
@@ -248,9 +248,7 @@ mod tests {
                 })
             }
         }
-        let rpc_handler = RpcHandler {
-            number: 0,
-        };
+        let rpc_handler = RpcHandler { number: 0 };
 
         let stream = UnboundedReceiverStream::new(receiver);
         let stream = stream.map(|item| Ok(item));
@@ -268,16 +266,8 @@ mod tests {
                     path: "abc".to_string(),
                 })
                 .await;
-            assert_eq!(
-                response
-                    .unwrap()
-                    .directory_entries
-                    .len(),
-                1
-            );
-            cloned_sender
-                .send(vec![])
-                .unwrap();
+            assert_eq!(response.unwrap().directory_entries.len(), 1);
+            cloned_sender.send(vec![]).unwrap();
         };
         join!(receiving, sending);
     }

--- a/nrpc/src/response_waiter.rs
+++ b/nrpc/src/response_waiter.rs
@@ -19,14 +19,11 @@ impl ResponseWaiter {
 impl ResponseWaiter {
     pub fn ready_to_wait(&self, id: u64) -> Arc<Notify> {
         let notify = Arc::new(Notify::new());
-        self.notification_map
-            .insert(id, notify.clone());
+        self.notification_map.insert(id, notify.clone());
         notify
     }
     pub async fn wait(&self, id: u64, notify: Arc<Notify>) -> Result<Vec<u8>, String> {
-        notify
-            .notified()
-            .await;
+        notify.notified().await;
 
         let (_, data) = self
             .response_data_map
@@ -36,13 +33,9 @@ impl ResponseWaiter {
         Ok(data)
     }
     pub fn on_response(&self, id: u64, response: Vec<u8>) {
-        self.response_data_map
-            .insert(id, response);
+        self.response_data_map.insert(id, response);
 
-        let (_, notify) = self
-            .notification_map
-            .remove(&id)
-            .unwrap();
+        let (_, notify) = self.notification_map.remove(&id).unwrap();
 
         notify.notify_waiters();
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-use_small_heuristics = "Off"
-# chain_width = 0


### PR DESCRIPTION
> English follows

rust-analyzer가 vscode에서 타입 힌트를 화면에 보여주는데, 만약 타입이 길 경우 코드의 너비가 화면보다 더 커서 코드의 일부가 보이지 않을 때가 있습니다.

이 문제를 해결하기 위해 저는 rustfmt의 설정으로 한 줄의 길이를 제한하려고 했습니다만, 그렇게까지 효과적이지 않았습니다.

특히, 저는 chaining의 너비를 줄이려고 했습니다. 하지만 제가 줄이고 싶었던 chaining은 builder-pattern같은 method chaining(a().b().c() 같은)인데, 그것 말고 a.b.c 같은 property chaining도 너비가 줄어들더라고요. 그건 원치 않았는데, 그것만 따로 설정하는건 없었습니다.

그래서 마땅한 아이디어가 떠오르기 전까지는 rustfmt를 default 설정으로 바꾸려고 합니다. 만약 괜찮은 rustfmt 설정값을 누구든 찾는다면 공유하고 토론해봅시다.

rust-analyzer shows type hints in vscode on the screen, but if the type is long, the width of the code is larger than the screen, so part of the code is sometimes not visible.

To solve this problem, I tried limiting the length of a single line with a setting in rustfmt, but it didn't work that far.

Specifically, I tried to reduce the width of the chaining. However, the chaining I wanted to reduce is method chaining (like a().b().c()) like builder-pattern, but property chaining like a.b.c also reduces the width. I didn't want that, but there was nothing to set it apart.

So I'm going to change rustfmt to the default configuration until I get a good idea. If anyone finds a good rustfmt configuration, please share and discuss.