### PR TITLE
Optimize path by PathBuilder

### DIFF
--- a/luda-editor/luda-editor-client/Cargo.toml
+++ b/luda-editor/luda-editor-client/Cargo.toml
@@ -25,6 +25,7 @@ js-sys = "0.3.55"
 tokio-stream = { version = "0.1.8", default-features = false }
 luda-editor-rpc = { path = "../luda-editor-rpc" }
 num = "0.4.0"
+once_cell = "1.8.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -36,8 +37,8 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 wasm-bindgen-test = "0.3.13"
 
 [profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
+lto = true
+opt-level = 3
 
 [dependencies.web-sys]
 version = "0.3"

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
@@ -8,7 +8,7 @@ impl ImageBrowser {
         item_size: Wh<f32>,
         thumbnail_rect: XywhRect<f32>,
     ) -> RenderingTree {
-        let arrow_path = namui::Path::new()
+        let arrow_path = namui::PathBuilder::new()
             .move_to(0.0, 0.5)
             .line_to(0.5, 0.0)
             .line_to(0.5, 0.25)

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
@@ -45,7 +45,7 @@ impl Scroll {
         let scroll_y = num::clamp(self.scroll_y, 0.0, (0.0_f32).max(inner_height - height));
 
         let inner = namui::clip(
-            namui::Path::new().add_rect(&namui::LtrbRect {
+            namui::PathBuilder::new().add_rect(&namui::LtrbRect {
                 left: 0.0,
                 top: 0.0,
                 right: inner_width,

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/mod.rs
@@ -76,7 +76,7 @@ impl CameraClipEditor {
             props.xywh.x,
             props.xywh.y,
             namui::clip(
-                namui::Path::new().add_rect(&namui::LtrbRect {
+                namui::PathBuilder::new().add_rect(&namui::LtrbRect {
                     left: 0.0,
                     top: 0.0,
                     right: props.xywh.width,
@@ -108,7 +108,7 @@ impl CameraClipEditor {
                         image_filename_objects: props.image_filename_objects,
                     }),
                     clip(
-                        Path::new().add_rect(&preview_rect.into_ltrb()),
+                        PathBuilder::new().add_rect(&preview_rect.into_ltrb()),
                         ClipOp::Difference,
                         self.wysiwyg_editor.render(&WysiwygEditorProps {
                             xywh: XywhRect {

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/wysiwyg_editor/cropper.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/wysiwyg_editor/cropper.rs
@@ -45,7 +45,7 @@ fn render_handles(dest_rect: &LtrbRect, container_size: &Wh<f32>) -> RenderingTr
         get_handles(&dest_rect)
             .iter()
             .map(|handle| {
-                let path = Path::new().add_poly(&handle.polygon_xy, true);
+                let path = PathBuilder::new().add_poly(&handle.polygon_xy, true);
 
                 let stroke_paint = Paint::new()
                     .set_style(PaintStyle::Stroke)

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/wysiwyg_editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/wysiwyg_editor/mod.rs
@@ -140,7 +140,7 @@ fn render_outer_image(
         ));
 
     namui::clip(
-        namui::Path::new().add_rect(dest_rect),
+        namui::PathBuilder::new().add_rect(dest_rect),
         namui::ClipOp::Difference,
         namui::render![render_source_image(
             image,
@@ -159,7 +159,7 @@ fn render_inner_image(
     let container_size = container_size.clone();
 
     namui::clip(
-        namui::Path::new().add_rect(dest_rect),
+        namui::PathBuilder::new().add_rect(dest_rect),
         namui::ClipOp::Intersect,
         render_source_image(image, None, &source_rect)
             .attach_event(|builder| {

--- a/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/wysiwyg_editor/resizer.rs
+++ b/luda-editor/luda-editor-client/src/editor/clip_editor/camera_clip_editor/wysiwyg_editor/resizer.rs
@@ -47,7 +47,7 @@ fn render_resize_handles(source_rect: &XywhRect<f32>, container_size: &Wh<f32>) 
         get_handles(&source_rect)
             .iter()
             .map(|handle| {
-                let path = namui::Path::new().add_oval(&LtrbRect {
+                let path = namui::PathBuilder::new().add_oval(&LtrbRect {
                     left: handle.xy.x - HANDLE_RADIUS,
                     top: handle.xy.y - HANDLE_RADIUS,
                     right: handle.xy.x + HANDLE_RADIUS,

--- a/luda-editor/luda-editor-client/src/editor/timeline/time_ruler/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/timeline/time_ruler/mod.rs
@@ -22,7 +22,7 @@ impl Entity for TimeRuler {
             props.xywh.x,
             props.xywh.y,
             render![clip(
-                Path::new().add_rect(
+                PathBuilder::new().add_rect(
                     &XywhRect {
                         x: 0.0,
                         y: 0.0,

--- a/luda-editor/luda-editor-client/src/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/editor/timeline/timeline_body/mod.rs
@@ -52,7 +52,7 @@ impl TimelineBody {
                 ..Default::default()
             }),
             namui::clip(
-                namui::Path::new().add_rect(
+                namui::PathBuilder::new().add_rect(
                     &namui::XywhRect {
                         x: 0.0,
                         y: 0.0,

--- a/luda-editor/luda-editor-client/src/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
@@ -41,21 +41,21 @@ impl SubtitleClipBody {
         let color = Color::from_string_for_random_color(clip.id.as_str(), false);
         let brighter_color = color.brighter(0.2);
 
-        let stroke_path = namui::Path::new()
+        let stroke_path = namui::PathBuilder::new()
             .move_to(
                 head_position.x + component_width / 2.0,
                 head_position.y + component_height,
             )
             .line_to(tail_position.x + component_width / 2.0, tail_position.y);
 
-        let head_path = namui::Path::new()
+        let head_path = namui::PathBuilder::new()
             .move_to(0.0, 0.0)
             .line_to(0.0, component_height)
             .line_to(component_width, component_height)
             .line_to(component_width, component_height / 3.0)
             .close();
 
-        let tail_path = namui::Path::new()
+        let tail_path = namui::PathBuilder::new()
             .move_to(0.0, 0.0)
             .line_to(0.0, (component_height * 2.0) / 3.0)
             .line_to(component_width, component_height)

--- a/luda-editor/luda-editor-client/src/editor/types/camera_angle.rs
+++ b/luda-editor/luda-editor-client/src/editor/types/camera_angle.rs
@@ -60,7 +60,7 @@ impl CameraAngle {
         };
 
         clip(
-            Path::new().add_rect(&clip_rect),
+            PathBuilder::new().add_rect(&clip_rect),
             ClipOp::Intersect,
             namui::image(ImageParam {
                 source: ImageSource::Image(image),

--- a/namui/Cargo.toml
+++ b/namui/Cargo.toml
@@ -26,6 +26,8 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 console_error_panic_hook = { version = "0.1.6", optional = true }
 dashmap = "4"
 num = "0.4.0"
+bincode = "1.3"
+lru = "0.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -15,8 +15,8 @@ pub struct FpsInfo {
 }
 
 pub struct NamuiContext {
-    pub surface: Surface,
-    pub fps_info: FpsInfo,
+    pub(crate) surface: Surface,
+    pub(crate) fps_info: FpsInfo,
 }
 
 pub trait NamuiImpl {
@@ -84,7 +84,7 @@ pub use render;
 
 pub type Rendering = RenderingTree;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub struct Wh<T> {
     pub width: T,
     pub height: T,

--- a/namui/src/namui/common/xy.rs
+++ b/namui/src/namui/common/xy.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, Copy)]
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone, Copy)]
 pub struct Xy<T> {
     pub x: T,
     pub y: T,

--- a/namui/src/namui/draw/path.rs
+++ b/namui/src/namui/draw/path.rs
@@ -2,8 +2,9 @@ use super::PathDrawCommand;
 use crate::namui::{self, NamuiContext};
 
 pub fn draw_path(namui_context: &NamuiContext, command: &PathDrawCommand) {
+    let path = command.path_builder.build();
     namui_context
         .surface
         .canvas()
-        .draw_path(&command.path, &command.paint);
+        .draw_path(&path, &command.paint);
 }

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -13,9 +13,10 @@ pub use render::{
     MouseCursor, MouseEvent, MouseEventCallback, MouseEventType, RenderingData, RenderingTree,
     TextInput, WheelEventCallback,
 };
+pub(crate) use skia::Path;
 pub use skia::{
     types::{ClipOp, Color, PaintStyle},
-    BlendMode, ColorFilter, Font, Image, LtrbRect, Paint, Path, StrokeCap, Typeface,
+    BlendMode, ColorFilter, Font, Image, LtrbRect, Paint, PathBuilder, StrokeCap, Typeface,
 };
 pub mod event;
 pub use event::NamuiEvent;

--- a/namui/src/namui/render/attach_event.rs
+++ b/namui/src/namui/render/attach_event.rs
@@ -24,6 +24,12 @@ pub struct AttachEventNode {
     pub on_wheel: Option<WheelEventCallback>,
 }
 
+impl std::fmt::Debug for AttachEventNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rendering_tree: {:?}, on_mouse_move_in: {:?}, on_mouse_move_out: {:?}, on_mouse_down: {:?}, on_mouse_up: {:?}, on_wheel: {:?}", self.rendering_tree, self.on_mouse_move_in.is_some(), self.on_mouse_move_out.is_some(), self.on_mouse_down.is_some(), self.on_mouse_up.is_some(), self.on_wheel.is_some())
+    }
+}
+
 #[derive(Default)]
 pub struct AttachEventBuilder {
     pub(crate) on_mouse_move_in: Option<MouseEventCallback>,

--- a/namui/src/namui/render/clip.rs
+++ b/namui/src/namui/render/clip.rs
@@ -1,17 +1,21 @@
 use super::{RenderingTree, SpecialRenderingNode};
-use crate::namui::{ClipOp, Path};
+use crate::{namui::ClipOp, PathBuilder};
 use serde::Serialize;
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ClipNode {
-    pub(crate) path: Path,
+    pub(crate) path_builder: PathBuilder,
     pub(crate) clip_op: ClipOp,
     pub(crate) rendering_tree: Vec<RenderingTree>,
 }
 
-pub fn clip(path: Path, clip_op: ClipOp, rendering_tree: RenderingTree) -> RenderingTree {
+pub fn clip(
+    path_builder: PathBuilder,
+    clip_op: ClipOp,
+    rendering_tree: RenderingTree,
+) -> RenderingTree {
     RenderingTree::Special(SpecialRenderingNode::Clip(ClipNode {
-        path,
+        path_builder,
         clip_op,
         rendering_tree: vec![rendering_tree],
     }))

--- a/namui/src/namui/render/mouse_cursor.rs
+++ b/namui/src/namui/render/mouse_cursor.rs
@@ -13,7 +13,7 @@ pub enum MouseCursor {
     Move,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct MouseCursorNode {
     pub(crate) rendering_tree: Vec<RenderingTree>,
     pub cursor: MouseCursor,

--- a/namui/src/namui/render/path.rs
+++ b/namui/src/namui/render/path.rs
@@ -1,9 +1,12 @@
 use crate::namui::{self, *};
 
-pub fn path(path: Path, paint: Paint) -> RenderingTree {
+pub fn path(path_builder: PathBuilder, paint: Paint) -> RenderingTree {
     RenderingTree::Node(RenderingData {
         draw_calls: vec![DrawCall {
-            commands: vec![DrawCommand::Path(PathDrawCommand { path, paint })],
+            commands: vec![DrawCommand::Path(PathDrawCommand {
+                path_builder,
+                paint,
+            })],
         }],
         ..Default::default()
     })

--- a/namui/src/namui/render/rect.rs
+++ b/namui/src/namui/render/rect.rs
@@ -47,37 +47,49 @@ pub fn rect(
     }: RectParam,
 ) -> RenderingTree {
     let mut rendering_tree: Vec<RenderingTree> = vec![];
-    let rect: namui::XywhRect<f32> = match stroke {
+    let (x, y, rect) = match stroke {
         None
         | Some(RectStroke {
             border_position: BorderPosition::Outside,
             ..
-        }) => XywhRect {
+        }) => (
             x,
             y,
-            width,
-            height,
-        },
+            XywhRect {
+                x: 0.0,
+                y: 0.0,
+                width,
+                height,
+            },
+        ),
         Some(RectStroke {
             border_position: BorderPosition::Middle,
             width: stroke_width,
             ..
-        }) => XywhRect {
-            x: x + stroke_width,
-            y: y + stroke_width,
-            width: width - 2.0 * stroke_width,
-            height: height - 2.0 * stroke_width,
-        },
+        }) => (
+            x + stroke_width,
+            y + stroke_width,
+            XywhRect {
+                x: 0.0,
+                y: 0.0,
+                width: width - 2.0 * stroke_width,
+                height: height - 2.0 * stroke_width,
+            },
+        ),
         Some(RectStroke {
             border_position: BorderPosition::Inside,
             width: stroke_width,
             ..
-        }) => XywhRect {
-            x: x + stroke_width / 2.0,
-            y: y + stroke_width / 2.0,
-            width: width - stroke_width,
-            height: height - stroke_width,
-        },
+        }) => (
+            x + stroke_width / 2.0,
+            y + stroke_width / 2.0,
+            XywhRect {
+                x: 0.0,
+                y: 0.0,
+                width: width - stroke_width,
+                height: height - stroke_width,
+            },
+        ),
     };
 
     let rect_path = get_rect_path(rect, round);
@@ -91,7 +103,7 @@ pub fn rect(
             .set_anti_alias(true);
 
         draw_commands.push(DrawCommand::Path(PathDrawCommand {
-            path: rect_path.clone(),
+            path_builder: rect_path.clone(),
             paint: fill_paint,
         }));
     };
@@ -109,7 +121,7 @@ pub fn rect(
             .set_anti_alias(true);
 
         draw_commands.push(DrawCommand::Path(PathDrawCommand {
-            path: rect_path.clone(),
+            path_builder: rect_path.clone(),
             paint: stroke_paint,
         }));
     };
@@ -132,13 +144,15 @@ pub fn rect(
         }],
     }));
 
-    RenderingTree::Children(rendering_tree)
+    translate(x, y, RenderingTree::Children(rendering_tree))
 }
 
 //   function getRectPath(rect: InputRect) {
-fn get_rect_path(rect: XywhRect<f32>, round: Option<RectRound>) -> namui::Path {
+fn get_rect_path(rect: XywhRect<f32>, round: Option<RectRound>) -> namui::PathBuilder {
     match round {
-        Some(round) => namui::Path::new().add_rrect(rect.into_ltrb(), round.radius, round.radius),
-        None => namui::Path::new().add_rect(&rect.into_ltrb()),
+        Some(round) => {
+            namui::PathBuilder::new().add_rrect(&rect.into_ltrb(), round.radius, round.radius)
+        }
+        None => namui::PathBuilder::new().add_rect(&rect.into_ltrb()),
     }
 }

--- a/namui/src/namui/render/translate.rs
+++ b/namui/src/namui/render/translate.rs
@@ -1,7 +1,7 @@
 use super::{RenderingTree, SpecialRenderingNode};
 use serde::Serialize;
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct TranslateNode {
     pub(crate) x: f32,
     pub(crate) y: f32,

--- a/namui/src/namui/render/types.rs
+++ b/namui/src/namui/render/types.rs
@@ -1,7 +1,8 @@
 use crate::{namui::skia::LtrbRect, Wh, Xy};
 use serde::{Deserialize, Serialize};
+use std::hash::Hash;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct XywhRect<T> {
     pub x: T,
     pub y: T,

--- a/namui/src/namui/skia/base/mod.rs
+++ b/namui/src/namui/skia/base/mod.rs
@@ -1,2 +1,4 @@
 mod skia;
 pub use skia::*;
+pub mod path_builder;
+pub use path_builder::*;

--- a/namui/src/namui/skia/base/path_builder.rs
+++ b/namui/src/namui/skia/base/path_builder.rs
@@ -1,0 +1,140 @@
+use crate::{namui::skia::StrokeOptions, LtrbRect, Path, Xy};
+use once_cell::sync::OnceCell;
+use serde::Serialize;
+use std::{
+    hash::Hash,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug, Serialize, Clone)]
+enum PathCommand {
+    AddRect(LtrbRect),
+    AddRrect(LtrbRect, Xy<f32>),
+    Stroke(StrokeOptions),
+    MoveTo(Xy<f32>),
+    LineTo(Xy<f32>),
+    Scale(Xy<f32>),
+    Translate(Xy<f32>),
+    Transform([f32; 9]),
+    AddOval(LtrbRect),
+    AddPoly(Vec<Xy<f32>>, bool),
+    Close,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct PathBuilder {
+    commands: Vec<PathCommand>,
+}
+
+static PATH_CACHE: OnceCell<Mutex<lru::LruCache<PathBuilder, Arc<Path>>>> = OnceCell::new();
+
+impl PathBuilder {
+    pub(crate) fn build(&self) -> Arc<Path> {
+        self.get_or_create_path()
+    }
+    pub fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+        }
+    }
+    pub fn add_rect(mut self, ltrb_rect: &LtrbRect) -> Self {
+        self.commands.push(PathCommand::AddRect(*ltrb_rect));
+        self
+    }
+    pub fn add_rrect(mut self, rect: &LtrbRect, rx: f32, ry: f32) -> Self {
+        self.commands
+            .push(PathCommand::AddRrect(*rect, Xy { x: rx, y: ry }));
+        self
+    }
+    pub fn stroke(&mut self, options: StrokeOptions) -> Result<(), ()> {
+        self.commands.push(PathCommand::Stroke(options));
+        Ok(())
+    }
+    pub fn move_to(mut self, x: f32, y: f32) -> Self {
+        self.commands.push(PathCommand::MoveTo(Xy { x, y }));
+        self
+    }
+    pub fn line_to(mut self, x: f32, y: f32) -> Self {
+        self.commands.push(PathCommand::LineTo(Xy { x, y }));
+        self
+    }
+    pub fn scale(mut self, x: f32, y: f32) -> Self {
+        self.commands.push(PathCommand::Scale(Xy { x, y }));
+        self
+    }
+    pub fn translate(mut self, x: f32, y: f32) -> Self {
+        self.commands.push(PathCommand::Translate(Xy { x, y }));
+        self
+    }
+    pub fn transform(mut self, matrix_3x3: &[f32; 9]) -> Self {
+        self.commands.push(PathCommand::Transform(*matrix_3x3));
+        self
+    }
+    pub fn add_oval(mut self, ltrb_rect: &LtrbRect) -> Self {
+        self.commands.push(PathCommand::AddOval(*ltrb_rect));
+        self
+    }
+    pub fn add_poly(mut self, xy_array: &[Xy<f32>], close: bool) -> Self {
+        self.commands
+            .push(PathCommand::AddPoly(xy_array.to_vec(), close));
+        self
+    }
+    pub fn close(mut self) -> Self {
+        self.commands.push(PathCommand::Close);
+        self
+    }
+
+    fn get_or_create_path(&self) -> Arc<Path> {
+        let mut cache = PATH_CACHE
+            .get_or_init(|| Mutex::new(lru::LruCache::new(1024)))
+            .lock()
+            .unwrap();
+        match cache.get(self) {
+            Some(path) => path.clone(),
+            None => {
+                let path = self.create_path();
+                cache.put(self.clone(), path.clone());
+                path
+            }
+        }
+    }
+
+    fn create_path(&self) -> Arc<Path> {
+        let mut path = Path::new();
+        crate::log!("{:?}", self);
+        for command in &self.commands {
+            path = match command {
+                PathCommand::AddRect(ltrb_rect) => path.add_rect(&ltrb_rect),
+                PathCommand::AddRrect(ltrb_rect, rx_ry) => {
+                    path.add_rrect(&ltrb_rect, rx_ry.x, rx_ry.y)
+                }
+                PathCommand::Stroke(options) => {
+                    path.stroke(options).unwrap();
+                    path
+                }
+                PathCommand::MoveTo(xy) => path.move_to(xy.x, xy.y),
+                PathCommand::LineTo(xy) => path.line_to(xy.x, xy.y),
+                PathCommand::Scale(xy) => path.scale(xy.x, xy.y),
+                PathCommand::Translate(xy) => path.translate(xy.x, xy.y),
+                PathCommand::Transform(matrix_3x3) => path.transform(&matrix_3x3),
+                PathCommand::AddOval(ltrb_rect) => path.add_oval(&ltrb_rect),
+                PathCommand::AddPoly(xy_array, close) => path.add_poly(&xy_array, *close),
+                PathCommand::Close => path.close(),
+            }
+        }
+        Arc::new(path)
+    }
+}
+
+impl Hash for PathBuilder {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        bincode::serialize(self).unwrap().hash(state);
+    }
+}
+
+impl PartialEq for PathBuilder {
+    fn eq(&self, other: &Self) -> bool {
+        bincode::serialize(self).unwrap() == bincode::serialize(other).unwrap()
+    }
+}
+impl std::cmp::Eq for PathBuilder {}

--- a/namui/src/namui/skia/base/skia.rs
+++ b/namui/src/namui/skia/base/skia.rs
@@ -2,7 +2,7 @@ use super::super::types::{Color, FontMetrics, GlyphIds};
 use super::super::{Canvas, Font, Paint, Surface, TextBlob};
 use std::rc::Rc;
 
-pub struct Skia {
+pub(crate) struct Skia {
     pub surface: Surface,
 }
 

--- a/namui/src/namui/skia/types.rs
+++ b/namui/src/namui/skia/types.rs
@@ -205,17 +205,20 @@ pub enum PaintStyle {
     Stroke,
 }
 
+#[derive(Debug, Serialize, Clone)]
 pub enum StrokeCap {
     Butt,
     Round,
     Square,
 }
 
+#[derive(Debug, Serialize, Clone)]
 pub enum StrokeJoin {
     Bevel,
     Miter,
     Round,
 }
+#[derive(Debug, Serialize, Clone)]
 pub struct StrokeOptions {
     pub width: Option<f32>,
     pub miter_limit: Option<f32>,
@@ -224,7 +227,7 @@ pub struct StrokeOptions {
     pub cap: Option<StrokeCap>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub enum ClipOp {
     Intersect,
     Difference,

--- a/namui/src/namui/skia/web/canvas.rs
+++ b/namui/src/namui/skia/web/canvas.rs
@@ -2,7 +2,7 @@ use crate::{namui, XywhRect};
 
 use super::*;
 
-pub struct Canvas(pub CanvasKitCanvas);
+pub(crate) struct Canvas(pub CanvasKitCanvas);
 impl Canvas {
     pub fn draw_text_blob(&self, text_blob: &TextBlob, x: f32, y: f32, paint: &Paint) {
         self.0.drawTextBlob(&text_blob.0, x, y, &paint.0);

--- a/namui/src/namui/skia/web/color_filter.rs
+++ b/namui/src/namui/skia/web/color_filter.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::namui;
 pub use base::*;
 
+unsafe impl Sync for CanvasKitColorFilter {}
+unsafe impl Send for CanvasKitColorFilter {}
 pub struct ColorFilter(pub(crate) CanvasKitColorFilter);
 impl ColorFilter {
     pub fn from(canvas_kit_color_filter: CanvasKitColorFilter) -> Self {

--- a/namui/src/namui/skia/web/font.rs
+++ b/namui/src/namui/skia/web/font.rs
@@ -69,3 +69,9 @@ impl Drop for Font {
         self.0.delete();
     }
 }
+
+impl std::fmt::Debug for Font {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "")
+    }
+}

--- a/namui/src/namui/skia/web/paint.rs
+++ b/namui/src/namui/skia/web/paint.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::namui;
 pub use base::*;
 
+unsafe impl Sync for CanvasKitPaint {}
+unsafe impl Send for CanvasKitPaint {}
 pub struct Paint(pub(crate) CanvasKitPaint);
 impl Paint {
     pub fn new() -> Self {

--- a/namui/src/namui/skia/web/surface.rs
+++ b/namui/src/namui/skia/web/surface.rs
@@ -2,7 +2,7 @@ use crate::namui;
 
 use super::*;
 
-pub struct Surface {
+pub(crate) struct Surface {
     canvas_kit_surface: CanvasKitSurface,
     canvas: Canvas,
 }

--- a/namui/src/namui/skia/web/text_blob.rs
+++ b/namui/src/namui/skia/web/text_blob.rs
@@ -2,6 +2,8 @@ use crate::namui;
 
 use super::*;
 
+unsafe impl Sync for CanvasKitTextBlob {}
+unsafe impl Send for CanvasKitTextBlob {}
 pub struct TextBlob(pub CanvasKitTextBlob);
 impl TextBlob {
     pub fn from_text(string: &str, font: &Font) -> Self {


### PR DESCRIPTION
# What happened?
It's very expensive job to make a canvaskit path. I found it's very nature in skia (https://stackoverflow.com/questions/15039829/drawing-paths-and-hardware-acceleration)
I faced very low fps situation when I create 10\~20 rectangle. what? 10\~20 rectangle makes luda-editor slow...!

# What I did
I replace Path::new() with PathBuilder::new() in luda-editor. PathBuilder is new struct which contains the command how you want to make a path.
PathBuilder only changes into path when namui draw it in AnimationFrame.
And also, PathBuilder has LRU Cache, it reuse path which it made before if the command is the same.

# How much it optimized namui?
Before I optimize it, the fps was about 5\~10 with 10\~20 rectangle in release, debug mode both.
After I optimize, in release mode, it was 58~60fps. It's pretty enough and good.
I got a low fps in debug mode but I think it's because of other element of canvaskit like paint or text, image, I drew it together. I will optimize it at next of this PR.