### PR TITLE
Set luda-editor-client dev profile opt-level = 2

### DIFF
--- a/luda-editor/luda-editor-client/Cargo.toml
+++ b/luda-editor/luda-editor-client/Cargo.toml
@@ -40,6 +40,10 @@ wasm-bindgen-test = "0.3.13"
 lto = true
 opt-level = 3
 
+[profile.dev]
+lto = true
+opt-level = 2
+
 [dependencies.web-sys]
 version = "0.3"
 features = [


### PR DESCRIPTION
I found that default profile in wasm-unknown-unknown is toooooo slow to draw about 20~30 rectangle. I think putting opt-level 2 is not a bad idea because we use incremental building so building is not slow as much as I expected.