### PR TITLE
Zome and move timeline

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/events.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/events.rs
@@ -1,7 +1,7 @@
 use super::clip_editor::camera_clip_editor::wysiwyg_editor::{
     cropper::CropperHandle, resizer::ResizerHandle,
 };
-use crate::app::types::ImageFilenameObject;
+use crate::app::types::{ImageFilenameObject, PixelSize};
 
 pub enum EditorEvent {
     CameraClipBodyMouseDownEvent {
@@ -38,5 +38,12 @@ pub enum EditorEvent {
         mouse_xy: namui::Xy<f32>,
         handle: CropperHandle,
         container_size: namui::Wh<f32>,
+    },
+    TimelineMoveEvent {
+        pixel: PixelSize,
+    },
+    TimelineZoomEvent {
+        delta: f32,
+        anchor_x_in_timeline: PixelSize,
     },
 }

--- a/luda-editor/luda-editor-client/src/app/editor/job/move_camera_clip.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/move_camera_clip.rs
@@ -67,7 +67,7 @@ impl MoveCameraClipJob {
                 continue;
             }
 
-            let clip_center_at = (clip.start_at + clip.end_at) / 2;
+            let clip_center_at = (clip.start_at + clip.end_at) / 2.0;
 
             if index < moving_clip_index {
                 if moved_start_at < clip_center_at {

--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -12,7 +12,7 @@ use self::{
         WysiwygResizeImageJob,
     },
 };
-use super::types::{ImageFilenameObject, Sequence};
+use super::types::{ImageFilenameObject, Sequence, TimePerPixel};
 use crate::app::editor::clip_editor::ClipEditorProps;
 mod clip_editor;
 mod events;
@@ -111,6 +111,38 @@ impl namui::Entity for Editor {
                             container_size: *container_size,
                         }));
                     };
+                }
+                EditorEvent::TimelineMoveEvent { pixel } => {
+                    self.timeline.start_at += pixel * self.timeline.time_per_pixel;
+                }
+                EditorEvent::TimelineZoomEvent {
+                    delta,
+                    anchor_x_in_timeline,
+                } => {
+                    let zoom_by_wheel = |target: &f32, delta: &f32| -> f32 {
+                        const STEP: f32 = 400.0;
+                        const MIN: f32 = 10.0;
+                        const MAX: f32 = 1000.0;
+
+                        let wheel = STEP * (target / 10.0).log2();
+
+                        let next_wheel = wheel + delta;
+
+                        let zoomed = num::clamp(10.0 * 2.0f32.powf(next_wheel / STEP), MIN, MAX);
+                        zoomed
+                    };
+                    let time_of_mouse_position = self.timeline.start_at
+                        + anchor_x_in_timeline * self.timeline.time_per_pixel;
+
+                    let next_ms_per_pixel =
+                        zoom_by_wheel(&self.timeline.time_per_pixel.ms_per_pixel(), delta);
+                    let next_time_per_pixel = TimePerPixel::from_ms_per_pixel(&next_ms_per_pixel);
+
+                    let next_start_at =
+                        time_of_mouse_position - anchor_x_in_timeline * next_time_per_pixel;
+
+                    self.timeline.time_per_pixel = next_time_per_pixel;
+                    self.timeline.start_at = next_start_at;
                 }
                 _ => {}
             }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
@@ -20,7 +20,7 @@ pub struct Timeline {
     time_ruler_height: f32,
     pub selected_clip_id: Option<String>,
     pub sequence: Sequence,
-    start_at: Time,
+    pub start_at: Time,
     pub time_per_pixel: TimePerPixel,
     subtitle_play_duration_measurer: SubtitlePlayDurationMeasurer,
 }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
@@ -31,8 +31,8 @@ impl Timeline {
             time_ruler_height: 20.0,
             selected_clip_id: None,
             sequence,
-            time_per_pixel: TimePerPixel::new(Time::ms(50), PixelSize(1.0)),
-            start_at: Time::sec(0),
+            time_per_pixel: TimePerPixel::new(Time::from_ms(50.0), PixelSize(1.0)),
+            start_at: Time::from_sec(0.0),
             subtitle_play_duration_measurer: SubtitlePlayDurationMeasurer::new(),
         }
     }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
@@ -1,7 +1,10 @@
 use namui::prelude::*;
 mod track_body;
 use super::TimelineRenderContext;
-use crate::app::types::Track;
+use crate::app::{
+    editor::events::EditorEvent,
+    types::{PixelSize, Track},
+};
 use track_body::*;
 
 pub struct TimelineBody {}
@@ -31,26 +34,68 @@ impl TimelineBody {
                 )
             })
             .collect::<Vec<_>>();
-
-        render![
-            namui::rect(namui::RectParam {
-                x: 0.0,
-                y: 0.0,
-                width: props.width,
-                height: props.height,
-                style: namui::RectStyle {
-                    fill: Some(namui::RectFill {
-                        color: namui::Color::from_f01(0.4, 0.4, 0.4, 1.0),
-                    }),
-                    stroke: Some(namui::RectStroke {
-                        color: namui::Color::BLACK,
-                        width: 1.0,
-                        border_position: namui::BorderPosition::Inside,
-                    }),
-                    ..Default::default()
-                },
+        let border_id = "timeline_border";
+        let border = namui::rect(namui::RectParam {
+            x: 0.0,
+            y: 0.0,
+            width: props.width,
+            height: props.height,
+            style: namui::RectStyle {
+                fill: Some(namui::RectFill {
+                    color: namui::Color::from_f01(0.4, 0.4, 0.4, 1.0),
+                }),
+                stroke: Some(namui::RectStroke {
+                    color: namui::Color::BLACK,
+                    width: 1.0,
+                    border_position: namui::BorderPosition::Inside,
+                }),
                 ..Default::default()
-            }),
+            },
+            ..Default::default()
+        })
+        .with_id(border_id)
+        .attach_event(move |builder| {
+            let width = props.width;
+            let height = props.height;
+            builder.on_wheel(Box::new(move |event| {
+                let managers = namui::managers();
+
+                let mouse_manager = &managers.mouse_manager;
+                let mouse_position = mouse_manager.mouse_position();
+                let timeline_xy = event
+                    .namui_context
+                    .get_rendering_tree_xy(border_id)
+                    .unwrap();
+
+                let is_mouse_in_timeline = mouse_position.x as f32 >= timeline_xy.x
+                    && mouse_position.x as f32 <= timeline_xy.x + width
+                    && mouse_position.y as f32 >= timeline_xy.y
+                    && mouse_position.y as f32 <= timeline_xy.y + height;
+                if !is_mouse_in_timeline {
+                    return;
+                }
+
+                let keyboard_manager = &managers.keyboard_manager;
+                if keyboard_manager
+                    .any_code_press(&[namui::Code::ShiftLeft, namui::Code::ShiftRight])
+                {
+                    namui::event::send(Box::new(EditorEvent::TimelineMoveEvent {
+                        pixel: PixelSize(event.delta_xy.y),
+                    }))
+                } else if keyboard_manager
+                    .any_code_press(&[namui::Code::AltLeft, namui::Code::AltRight])
+                {
+                    let anchor_x_in_timeline = PixelSize(mouse_position.x as f32 - timeline_xy.x);
+
+                    namui::event::send(Box::new(EditorEvent::TimelineZoomEvent {
+                        delta: event.delta_xy.y,
+                        anchor_x_in_timeline,
+                    }))
+                }
+            }))
+        });
+        render![
+            border,
             namui::clip(
                 namui::PathBuilder::new().add_rect(
                     &namui::XywhRect {
@@ -63,9 +108,7 @@ impl TimelineBody {
                 ),
                 namui::ClipOp::Intersect,
                 render![track_bodies],
-            ),
-            // TODO : setWheelZoomHandler(state.timelineState),
-            // TODO : setWheelMoveHandler(state.timelineState),
+            )
         ]
     }
 }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
@@ -31,7 +31,7 @@ impl SubtitleClipBody {
             .map_or(false, |id| id.eq(&props.clip.id));
 
         let border_width = if is_highlight { 3 } else { 1 } * 2;
-        let component_width = (Time::from_ms(200) / context.time_per_pixel).into_f32();
+        let component_width = (Time::from_ms(200.0) / context.time_per_pixel).into_f32();
         let component_height = props.track_body_wh.height / 3.0;
 
         let head_position = namui::Xy { x: 0.0, y: 0.0 };

--- a/luda-editor/luda-editor-client/src/app/editor/types/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/types/mod.rs
@@ -10,11 +10,8 @@ impl SubtitlePlayDurationMeasurer {
     pub fn get_play_duration(&self, subtitle: &Subtitle, language: &Language) -> Time {
         let minimum_play_duration = self.minimum_play_durations.get(language).unwrap();
         let play_duration_per_character = self.play_duration_per_character.get(language).unwrap();
-        let play_duration = Time::from_ms(
-            (subtitle.language_text_map.get(language).unwrap().len() as f64
-                * play_duration_per_character.milliseconds as f64)
-                .ceil() as i64,
-        );
+        let play_duration =
+            subtitle.language_text_map.get(language).unwrap().len() * play_duration_per_character;
         if play_duration < *minimum_play_duration {
             *minimum_play_duration
         } else {
@@ -27,11 +24,11 @@ impl SubtitlePlayDurationMeasurer {
             // TODO: Check minimum play duration
             minimum_play_durations: HashMap::<_, _>::from_iter(IntoIter::new([(
                 Language::Ko,
-                Time::from_ms(1000),
+                Time::from_ms(1000.0),
             )])),
             play_duration_per_character: HashMap::<_, _>::from_iter(IntoIter::new([(
                 Language::Ko,
-                Time::from_ms(100),
+                Time::from_ms(100.0),
             )])),
         }
     }

--- a/luda-editor/luda-editor-client/src/app/types/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/types/mod.rs
@@ -10,6 +10,10 @@ pub use pixel_size::*;
 pub use router_context::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+mod time;
+pub use time::*;
+mod time_per_pixel;
+pub use time_per_pixel::*;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum Track {
@@ -23,63 +27,6 @@ pub struct CameraTrack {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubtitleTrack {
     pub clips: Vec<SubtitleClip>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Time {
-    pub milliseconds: i64,
-}
-impl Time {
-    pub fn zero() -> Self {
-        Self { milliseconds: 0 }
-    }
-    pub fn from_ms(milliseconds: i64) -> Self {
-        Self { milliseconds }
-    }
-}
-impl std::ops::Sub for Time {
-    type Output = Time;
-    fn sub(self, rhs: Time) -> Self::Output {
-        Time {
-            milliseconds: self.milliseconds - rhs.milliseconds,
-        }
-    }
-}
-impl std::ops::Add for Time {
-    type Output = Time;
-    fn add(self, rhs: Time) -> Self::Output {
-        Time {
-            milliseconds: self.milliseconds + rhs.milliseconds,
-        }
-    }
-}
-impl std::ops::Div<TimePerPixel> for Time {
-    type Output = PixelSize;
-    fn div(self, rhs: TimePerPixel) -> Self::Output {
-        let milliseconds = self.milliseconds as f64 / rhs.time.milliseconds as f64;
-        PixelSize(milliseconds as f32 * rhs.pixel_size.0)
-    }
-}
-impl std::ops::Div<i64> for Time {
-    type Output = Time;
-    fn div(self, rhs: i64) -> Self::Output {
-        let milliseconds = self.milliseconds / rhs;
-        Time { milliseconds }
-    }
-}
-impl std::ops::Mul<TimePerPixel> for PixelSize {
-    type Output = Time;
-    fn mul(self, rhs: TimePerPixel) -> Self::Output {
-        Time {
-            milliseconds: ((self.0 / rhs.pixel_size.0) * (rhs.time.milliseconds as f32)) as i64,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct TimePerPixel {
-    time: Time,
-    pixel_size: PixelSize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,22 +127,6 @@ impl TryFrom<Vec<u8>> for Sequence {
 pub struct Circumscribed {
     pub center: Xy<f32>,
     pub radius: f32,
-}
-
-impl Time {
-    pub fn sec(seconds: i64) -> Time {
-        Time {
-            milliseconds: seconds * 1000,
-        }
-    }
-    pub fn ms(milliseconds: i64) -> Time {
-        Time { milliseconds }
-    }
-}
-impl TimePerPixel {
-    pub(crate) fn new(time: Time, pixel_size: PixelSize) -> TimePerPixel {
-        TimePerPixel { time, pixel_size }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/luda-editor/luda-editor-client/src/app/types/time.rs
+++ b/luda-editor/luda-editor-client/src/app/types/time.rs
@@ -1,0 +1,79 @@
+use super::{Deserialize, PixelSize, Serialize, TimePerPixel};
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct Time {
+    pub(super) milliseconds: f32,
+}
+impl Time {
+    pub fn zero() -> Self {
+        Self { milliseconds: 0.0 }
+    }
+    pub fn from_ms(milliseconds: f32) -> Self {
+        Self { milliseconds }
+    }
+    pub fn from_sec(seconds: f32) -> Time {
+        Time {
+            milliseconds: seconds * 1000.0,
+        }
+    }
+}
+impl std::ops::Sub for Time {
+    type Output = Time;
+    fn sub(self, rhs: Time) -> Self::Output {
+        Time {
+            milliseconds: self.milliseconds - rhs.milliseconds,
+        }
+    }
+}
+impl std::ops::Add for Time {
+    type Output = Time;
+    fn add(self, rhs: Time) -> Self::Output {
+        Time {
+            milliseconds: self.milliseconds + rhs.milliseconds,
+        }
+    }
+}
+impl std::ops::Div<TimePerPixel> for Time {
+    type Output = PixelSize;
+    fn div(self, rhs: TimePerPixel) -> Self::Output {
+        let milliseconds = self.milliseconds / rhs.time.milliseconds;
+        PixelSize(milliseconds * rhs.pixel_size.0)
+    }
+}
+impl std::ops::Div<f32> for Time {
+    type Output = Time;
+    fn div(self, rhs: f32) -> Self::Output {
+        let milliseconds = self.milliseconds / rhs;
+        Time { milliseconds }
+    }
+}
+impl std::ops::Mul<&Time> for usize {
+    type Output = Time;
+
+    fn mul(self, rhs: &Time) -> Self::Output {
+        Time {
+            milliseconds: self as f32 * rhs.milliseconds,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Time {
+    fn add_assign(&mut self, rhs: Time) {
+        self.milliseconds.add_assign(rhs.milliseconds);
+    }
+}
+impl std::ops::SubAssign for Time {
+    fn sub_assign(&mut self, rhs: Time) {
+        self.milliseconds.sub_assign(rhs.milliseconds);
+    }
+}
+impl std::ops::MulAssign for Time {
+    fn mul_assign(&mut self, rhs: Time) {
+        self.milliseconds.mul_assign(rhs.milliseconds);
+    }
+}
+impl std::ops::DivAssign for Time {
+    fn div_assign(&mut self, rhs: Time) {
+        self.milliseconds.div_assign(rhs.milliseconds);
+    }
+}

--- a/luda-editor/luda-editor-client/src/app/types/time_per_pixel.rs
+++ b/luda-editor/luda-editor-client/src/app/types/time_per_pixel.rs
@@ -1,0 +1,56 @@
+use super::{PixelSize, Time};
+
+#[derive(Debug, Clone, Copy)]
+pub struct TimePerPixel {
+    pub(super) time: Time,
+    pub(super) pixel_size: PixelSize,
+}
+impl TimePerPixel {
+    pub(crate) fn new(time: Time, pixel_size: PixelSize) -> TimePerPixel {
+        TimePerPixel { time, pixel_size }
+    }
+    pub(crate) fn ms_per_pixel(&self) -> f32 {
+        self.time.milliseconds / self.pixel_size.0
+    }
+    pub(crate) fn from_ms_per_pixel(ms_per_pixel: &f32) -> Self {
+        TimePerPixel {
+            time: Time {
+                milliseconds: *ms_per_pixel,
+            },
+            pixel_size: PixelSize(1.0),
+        }
+    }
+}
+
+impl std::ops::Mul<TimePerPixel> for PixelSize {
+    type Output = Time;
+    fn mul(self, rhs: TimePerPixel) -> Self::Output {
+        Time {
+            milliseconds: (self.0 / rhs.pixel_size.0) * rhs.time.milliseconds,
+        }
+    }
+}
+impl<'a> std::ops::Mul<TimePerPixel> for &'a PixelSize {
+    type Output = Time;
+    fn mul(self, rhs: TimePerPixel) -> Self::Output {
+        Time {
+            milliseconds: (self.0 / rhs.pixel_size.0) * rhs.time.milliseconds,
+        }
+    }
+}
+impl<'b> std::ops::Mul<&'b TimePerPixel> for PixelSize {
+    type Output = Time;
+    fn mul(self, rhs: &'b TimePerPixel) -> Self::Output {
+        Time {
+            milliseconds: (self.0 / rhs.pixel_size.0) * rhs.time.milliseconds,
+        }
+    }
+}
+impl<'a, 'b> std::ops::Mul<&'b TimePerPixel> for &'a PixelSize {
+    type Output = Time;
+    fn mul(self, rhs: &'b TimePerPixel) -> Self::Output {
+        Time {
+            milliseconds: (self.0 / rhs.pixel_size.0) * rhs.time.milliseconds,
+        }
+    }
+}

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -17,6 +17,12 @@ pub struct FpsInfo {
 pub struct NamuiContext {
     pub(crate) surface: Surface,
     pub(crate) fps_info: FpsInfo,
+    pub(crate) rendering_tree: RenderingTree,
+}
+impl NamuiContext {
+    pub fn get_rendering_tree_xy(&self, id: &str) -> Option<Xy<f32>> {
+        self.rendering_tree.get_xy(id)
+    }
 }
 
 pub trait NamuiImpl {

--- a/namui/src/namui/manager/web/keyboard_manager/mod.rs
+++ b/namui/src/namui/manager/web/keyboard_manager/mod.rs
@@ -32,6 +32,7 @@ impl KeyboardManager {
             let code_string = event.code();
             let code = Code::from_str(&code_string).unwrap();
             pressing_code_set_key_down.write().unwrap().insert(code);
+            event.prevent_default();
             namui::log(format!("key down: {}", code_string));
         }) as Box<dyn FnMut(_)>);
 

--- a/namui/src/namui/manager/web/keyboard_manager/mod.rs
+++ b/namui/src/namui/manager/web/keyboard_manager/mod.rs
@@ -4,18 +4,18 @@ use std::{
     sync::{Arc, RwLock},
 };
 use wasm_bindgen::{prelude::Closure, JsCast};
-use web_sys::{window, HtmlElement};
+use web_sys::window;
 mod codes;
 pub use codes::*;
 
 use crate::namui;
 
 pub struct KeyboardManager {
-    pub pressing_code_set: Arc<RwLock<HashSet<Code>>>,
+    pressing_code_set: Arc<RwLock<HashSet<Code>>>,
 }
 
 impl KeyboardManager {
-    pub fn any_code_press(&self, codes: Vec<Code>) -> bool {
+    pub fn any_code_press(&self, codes: &[Code]) -> bool {
         let pressing_code_set = self.pressing_code_set.read().unwrap();
         for code in codes {
             if pressing_code_set.contains(&code) {

--- a/namui/src/namui/manager/web/keyboard_manager/mod.rs
+++ b/namui/src/namui/manager/web/keyboard_manager/mod.rs
@@ -32,7 +32,9 @@ impl KeyboardManager {
             let code_string = event.code();
             let code = Code::from_str(&code_string).unwrap();
             pressing_code_set_key_down.write().unwrap().insert(code);
-            event.prevent_default();
+            if event.key() == "Alt" {
+                event.prevent_default();
+            }
             namui::log(format!("key down: {}", code_string));
         }) as Box<dyn FnMut(_)>);
 

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -21,7 +21,8 @@ pub(crate) use skia::{ColorFilter, Paint, Path};
 pub mod event;
 pub use event::NamuiEvent;
 mod render;
-use self::manager::{Code, Managers};
+pub use self::manager::Code;
+use self::manager::Managers;
 use self::{
     font::*,
     namui_state::{get_namui_state, NamuiState},

--- a/namui/src/namui/namui_web/mod.rs
+++ b/namui/src/namui/namui_web/mod.rs
@@ -2,6 +2,7 @@ use super::common::{FpsInfo, NamuiContext, NamuiImpl};
 use super::manager::*;
 use super::skia::{canvas_kit, CanvasKit, Surface};
 use super::Namui;
+use crate::RenderingTree;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -65,6 +66,7 @@ impl NamuiImpl for Namui {
                 frame_count: 0,
                 last_60_frame_time: Namui::now(),
             },
+            rendering_tree: RenderingTree::Empty,
         }
     }
 

--- a/namui/src/namui/render/mod.rs
+++ b/namui/src/namui/render/mod.rs
@@ -20,3 +20,5 @@ pub mod attach_event;
 pub use attach_event::*;
 pub mod mouse_cursor;
 pub use mouse_cursor::*;
+pub mod with_id;
+pub use with_id::*;

--- a/namui/src/namui/render/rect.rs
+++ b/namui/src/namui/render/rect.rs
@@ -126,18 +126,6 @@ pub fn rect(
         }));
     };
 
-    // TODO
-    //   if (onAfterDraw) {
-    //     if (!id) {
-    //       id = nanoid();
-    //     }
-    //     renderingTree.push(
-    //       AfterDraw((param) => {
-    //         onAfterDraw(id!);
-    //       }),
-    //     );
-    //   }
-
     rendering_tree.push(RenderingTree::Node(RenderingData {
         draw_calls: vec![DrawCall {
             commands: draw_commands,

--- a/namui/src/namui/render/text_input/render/get_selection_on_mouse_down.rs
+++ b/namui/src/namui/render/text_input/render/get_selection_on_mouse_down.rs
@@ -19,7 +19,7 @@ pub(crate) fn get_selection_on_mouse_down(
     //     ]);
     let is_shift_key_pressed = managers
         .keyboard_manager
-        .any_code_press([namui::Code::ShiftLeft, namui::Code::ShiftRight].to_vec());
+        .any_code_press(&[namui::Code::ShiftLeft, namui::Code::ShiftRight]);
 
     // const continouslyFastClickCount: number;
 

--- a/namui/src/namui/render/with_id.rs
+++ b/namui/src/namui/render/with_id.rs
@@ -1,0 +1,17 @@
+use super::{RenderingTree, SpecialRenderingNode};
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+pub struct WithIdNode {
+    pub(crate) rendering_tree: Vec<RenderingTree>,
+    pub(crate) id: String,
+}
+
+impl RenderingTree {
+    pub fn with_id(self, id: &str) -> RenderingTree {
+        RenderingTree::Special(SpecialRenderingNode::WithId(WithIdNode {
+            rendering_tree: vec![self],
+            id: id.to_string(),
+        }))
+    }
+}

--- a/namui/src/namui/skia/base/paint_builder.rs
+++ b/namui/src/namui/skia/base/paint_builder.rs
@@ -77,7 +77,6 @@ impl PaintBuilder {
 
     fn create_paint(&self) -> Arc<Paint> {
         let mut paint = Paint::new();
-        crate::log!("{:?}", self);
 
         if let Some(color) = self.color {
             paint = paint.set_color(color);

--- a/namui/src/namui/skia/base/path_builder.rs
+++ b/namui/src/namui/skia/base/path_builder.rs
@@ -101,7 +101,6 @@ impl PathBuilder {
 
     fn create_path(&self) -> Arc<Path> {
         let mut path = Path::new();
-        crate::log!("{:?}", self);
         for command in &self.commands {
             path = match command {
                 PathCommand::AddRect(ltrb_rect) => path.add_rect(&ltrb_rect),


### PR DESCRIPTION
# What I did
I ported timeline body zooming and moving.

## Luda editor changes
- Move and zoom timeline with wheel : 792b793d75d7459f51ad9ed1d5a7b3b85c43fb4e
- Retype time as f32 : 51bcbaee96081b33e69cdb0b4cf2107e4ea149d0

## namui changes
- Remove log : bd9531863c53c03ae40184ed088dca90139e8c9b 
- Prevent key down default for alt key only : 69e5c18279449dab38304e8d37524802c523e787
  - This is for alt-tab enabling.
- Get rendering tree xy using id : d49bef1946a785385ef235bacf4faaa140dddcb5
- Prevent key down default to keep focus on alt key : 55a62464cf197ae06a072d02c55532bea826471a
- Expose Code from namui : eae628830f705e418574b3f56fa848cd4ba5beaa

There are many namui changes, so please merge using **rebase**.