### PR TITLE
Overload Time, PixelSize ops in macro

### DIFF
--- a/luda-editor/luda-editor-client/Cargo.toml
+++ b/luda-editor/luda-editor-client/Cargo.toml
@@ -24,6 +24,7 @@ tokio-stream = { version = "0.1.8", default-features = false }
 luda-editor-rpc = { path = "../luda-editor-rpc" }
 num = "0.4.0"
 once_cell = "1.8.0"
+auto_ops = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
@@ -13,11 +13,11 @@ pub struct SubtitleClipBodyProps<'a> {
 impl SubtitleClipBody {
     pub fn render(props: &SubtitleClipBodyProps) -> RenderingTree {
         let SubtitleClipBodyProps { clip, context, .. } = props;
-        let x = ((clip.start_at - context.start_at) / context.time_per_pixel).into_f32();
+        let x = ((clip.start_at - context.start_at) / context.time_per_pixel).into();
         let duration = context
             .subtitle_play_duration_measurer
             .get_play_duration(&clip.subtitle, &context.language);
-        let width = (duration / context.time_per_pixel).into_f32();
+        let width: f32 = (duration / context.time_per_pixel).into();
 
         let is_out_of_bounds = x + width < 0.0 || x > props.track_body_wh.width;
         if is_out_of_bounds {
@@ -31,7 +31,7 @@ impl SubtitleClipBody {
             .map_or(false, |id| id.eq(&props.clip.id));
 
         let border_width = if is_highlight { 3 } else { 1 } * 2;
-        let component_width = (Time::from_ms(200.0) / context.time_per_pixel).into_f32();
+        let component_width = (Time::from_ms(200.0) / context.time_per_pixel).into();
         let component_height = props.track_body_wh.height / 3.0;
 
         let head_position = namui::Xy { x: 0.0, y: 0.0 };

--- a/luda-editor/luda-editor-client/src/app/types/pixel_size.rs
+++ b/luda-editor/luda-editor-client/src/app/types/pixel_size.rs
@@ -1,42 +1,92 @@
+use auto_ops::impl_op;
+
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct PixelSize(pub f32);
-impl PixelSize {
-    pub fn into_f32(&self) -> f32 {
-        self.0
+
+impl From<f32> for PixelSize {
+    fn from(f: f32) -> Self {
+        PixelSize(f)
     }
 }
 
-#[macro_use]
-macro_rules! overload_single_tuple_operator {
-    ($type: tt, $ops_trait: tt, $fn_name: ident) => {
-        use std::ops::*;
-        impl $ops_trait for $type {
-            type Output = $type;
-            fn $fn_name(self, other: $type) -> $type {
-                $type(self.0.$fn_name(other.0))
-            }
-        }
-        impl<'a> $ops_trait<$type> for &'a $type {
-            type Output = $type;
-            fn $fn_name(self, other: $type) -> $type {
-                $type(self.0.$fn_name(other.0))
-            }
-        }
-        impl<'b> $ops_trait<&'b $type> for $type {
-            type Output = $type;
-            fn $fn_name(self, other: &'b $type) -> $type {
-                $type(self.0.$fn_name(other.0))
-            }
-        }
-        impl<'a, 'b> $ops_trait<&'b $type> for &'a $type {
-            type Output = $type;
-            fn $fn_name(self, other: &'b $type) -> $type {
-                $type(self.0.$fn_name(other.0))
-            }
-        }
+impl From<PixelSize> for f32 {
+    fn from(val: PixelSize) -> Self {
+        val.0
+    }
+}
+impl From<&PixelSize> for f32 {
+    fn from(val: &PixelSize) -> Self {
+        val.0
+    }
+}
+
+macro_rules! overload_pixel_size_binary_operator_with_numeric {
+    ($ops: tt, $numeric_type: tt) => {
+        impl_op!($ops|lhs: PixelSize, rhs: $numeric_type| -> PixelSize { PixelSize(lhs.0 $ops rhs as f32) });
+        impl_op!($ops|lhs: PixelSize, rhs: &$numeric_type| -> PixelSize { PixelSize(lhs.0 $ops *rhs as f32) });
+        impl_op!($ops|lhs: &PixelSize, rhs: $numeric_type| -> PixelSize { PixelSize(lhs.0 $ops rhs as f32) });
+        impl_op!($ops|lhs: &PixelSize, rhs: &$numeric_type| -> PixelSize { PixelSize(lhs.0 $ops *rhs as f32) });
+
+        impl_op!($ops|lhs: $numeric_type, rhs: PixelSize| -> PixelSize { rhs $ops lhs as f32 });
+        impl_op!($ops|lhs: $numeric_type, rhs: &PixelSize| -> PixelSize { rhs $ops lhs as f32 });
+        impl_op!($ops|lhs: &$numeric_type, rhs: PixelSize| -> PixelSize { rhs $ops *lhs as f32 });
+        impl_op!($ops|lhs: &$numeric_type, rhs: &PixelSize| -> PixelSize { rhs $ops *lhs as f32 });
     };
 }
-overload_single_tuple_operator!(PixelSize, Add, add);
-overload_single_tuple_operator!(PixelSize, Sub, sub);
-overload_single_tuple_operator!(PixelSize, Mul, mul);
-overload_single_tuple_operator!(PixelSize, Div, div);
+
+macro_rules! overload_pixel_size_arithmetic_operator_with_numeric {
+    ($numeric_type: tt) => {
+        overload_pixel_size_binary_operator_with_numeric!(+, $numeric_type);
+        overload_pixel_size_binary_operator_with_numeric!(-, $numeric_type);
+        overload_pixel_size_binary_operator_with_numeric!(*, $numeric_type);
+        overload_pixel_size_binary_operator_with_numeric!(/, $numeric_type);
+        overload_pixel_size_binary_operator_with_numeric!(%, $numeric_type);
+    };
+}
+
+macro_rules! overload_pixel_size_binary_operator_with_self {
+    ($ops: tt) => {
+        impl_op!($ops|lhs: PixelSize, rhs: PixelSize| -> PixelSize { PixelSize(lhs.0 $ops rhs.0) });
+        impl_op!($ops|lhs: PixelSize, rhs: &PixelSize| -> PixelSize { PixelSize(lhs.0 $ops rhs.0) });
+        impl_op!($ops|lhs: &PixelSize, rhs: PixelSize| -> PixelSize { PixelSize(lhs.0 $ops rhs.0) });
+        impl_op!($ops|lhs: &PixelSize, rhs: &PixelSize| -> PixelSize { PixelSize(lhs.0 $ops rhs.0) });
+    };
+}
+
+macro_rules! overload_pixel_size_assignment_operator_with_self {
+    ($ops: tt) => {
+        impl_op!($ops|lhs: &mut PixelSize, rhs: PixelSize| { lhs.0 $ops rhs.0 });
+        impl_op!($ops|lhs: &mut PixelSize, rhs: &PixelSize| { lhs.0 $ops rhs.0 });
+    };
+}
+
+// PixelSize and PixelSize
+overload_pixel_size_binary_operator_with_self!(+);
+overload_pixel_size_binary_operator_with_self!(-);
+overload_pixel_size_binary_operator_with_self!(*);
+overload_pixel_size_binary_operator_with_self!(/);
+overload_pixel_size_binary_operator_with_self!(%);
+
+overload_pixel_size_assignment_operator_with_self!(+=);
+overload_pixel_size_assignment_operator_with_self!(-=);
+overload_pixel_size_assignment_operator_with_self!(*=);
+overload_pixel_size_assignment_operator_with_self!(/=);
+overload_pixel_size_assignment_operator_with_self!(%=);
+// END: PixelSize and PixelSize
+
+// numerics arithmetic binary operators overloading
+overload_pixel_size_arithmetic_operator_with_numeric!(u8);
+overload_pixel_size_arithmetic_operator_with_numeric!(u16);
+overload_pixel_size_arithmetic_operator_with_numeric!(u32);
+overload_pixel_size_arithmetic_operator_with_numeric!(u64);
+overload_pixel_size_arithmetic_operator_with_numeric!(u128);
+overload_pixel_size_arithmetic_operator_with_numeric!(usize);
+overload_pixel_size_arithmetic_operator_with_numeric!(i8);
+overload_pixel_size_arithmetic_operator_with_numeric!(i16);
+overload_pixel_size_arithmetic_operator_with_numeric!(i32);
+overload_pixel_size_arithmetic_operator_with_numeric!(i64);
+overload_pixel_size_arithmetic_operator_with_numeric!(i128);
+overload_pixel_size_arithmetic_operator_with_numeric!(isize);
+overload_pixel_size_arithmetic_operator_with_numeric!(f32);
+overload_pixel_size_arithmetic_operator_with_numeric!(f64);
+// END: numerics arithmetic binary operators overloading


### PR DESCRIPTION
I overloaded Time and PixelSize's arithmetic operator's using [impl_op macro](https://docs.rs/auto_ops/latest/auto_ops/). 