### PR TITLE
Box namui::event internally

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
@@ -56,9 +56,9 @@ impl ImageBrowser {
             .attach_event(|builder| {
                 builder.on_mouse_down(Box::new(move |_| {
                     namui::log(format!("select browser item {}", "back"));
-                    namui::event::send(Box::new(EditorEvent::ImageBrowserSelectEvent {
+                    namui::event::send(EditorEvent::ImageBrowserSelectEvent {
                         selected_item: ImageBrowserItem::Back,
-                    }));
+                    });
                 }))
             }),
             text(TextParam {

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/browser_item.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/browser_item.rs
@@ -48,9 +48,9 @@ impl BrowserItem {
                 let item = props.item.clone();
                 builder.on_mouse_down(Box::new(move |_| {
                     namui::log(format!("select browser item {:?}", item));
-                    namui::event::send(Box::new(EditorEvent::ImageBrowserSelectEvent {
+                    namui::event::send(EditorEvent::ImageBrowserSelectEvent {
                         selected_item: item.clone(),
-                    }));
+                    });
                 }))
             }),
             text(TextParam {

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
@@ -140,9 +140,9 @@ impl Scroll {
                     (0.0_f32).max(inner_height - height),
                 );
 
-                namui::event::send(Box::new(EditorEvent::ScrolledEvent {
+                namui::event::send(EditorEvent::ScrolledEvent {
                     scroll_y: next_scroll_y,
-                }));
+                });
             }))
         });
 

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/cropper.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/cropper.rs
@@ -64,11 +64,11 @@ fn render_handles(dest_rect: &LtrbRect, container_size: &Wh<f32>) -> RenderingTr
                     let handle = handle.clone();
                     let container_size = container_size.clone();
                     builder.on_mouse_down(Box::new(move |mouse_event| {
-                        namui::event::send(Box::new(WysiwygEditorCropperHandleMouseDownEvent {
+                        namui::event::send(WysiwygEditorCropperHandleMouseDownEvent {
                             handle: handle.clone(),
                             mouse_xy: mouse_event.global_xy,
                             container_size: container_size,
-                        }))
+                        })
                     }))
                 })
             })

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/mod.rs
@@ -164,12 +164,10 @@ fn render_inner_image(
         render_source_image(image, None, &source_rect)
             .attach_event(|builder| {
                 builder.on_mouse_down(Box::new(move |event| {
-                    namui::event::send(Box::new(
-                        EditorEvent::WysiwygEditorInnerImageMouseDownEvent {
-                            mouse_xy: event.global_xy,
-                            container_size: container_size.clone(),
-                        },
-                    ))
+                    namui::event::send(EditorEvent::WysiwygEditorInnerImageMouseDownEvent {
+                        mouse_xy: event.global_xy,
+                        container_size: container_size.clone(),
+                    })
                 }))
             })
             .with_mouse_cursor(MouseCursor::Move),

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/resizer.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/resizer.rs
@@ -74,7 +74,7 @@ fn render_resize_handles(source_rect: &XywhRect<f32>, container_size: &Wh<f32>) 
                     let container_size = container_size.clone();
                     let source_rect = source_rect.clone();
                     builder.on_mouse_down(Box::new(move |mouse_event| {
-                        namui::event::send(Box::new(WysiwygEditorResizerHandleMouseDownEvent {
+                        namui::event::send(WysiwygEditorResizerHandleMouseDownEvent {
                             handle,
                             center_xy: source_rect.center(),
                             mouse_xy: mouse_event.global_xy,
@@ -83,7 +83,7 @@ fn render_resize_handles(source_rect: &XywhRect<f32>, container_size: &Wh<f32>) 
                                 width: source_rect.width,
                                 height: source_rect.height,
                             },
-                        }))
+                        })
                     }))
                 })
             })

--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -281,11 +281,9 @@ impl Editor {
                             .map(|url| ImageFilenameObject::new(url))
                             .collect();
 
-                        namui::event::send(Box::new(
-                            EditorEvent::ImageFilenameObjectsUpdatedEvent {
-                                image_filename_objects,
-                            },
-                        ))
+                        namui::event::send(EditorEvent::ImageFilenameObjectsUpdatedEvent {
+                            image_filename_objects,
+                        })
                     }
                     Err(error) => namui::log(format!("error on get_camera_shot_urls: {:?}", error)),
                 }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
@@ -79,18 +79,18 @@ impl TimelineBody {
                 if keyboard_manager
                     .any_code_press(&[namui::Code::ShiftLeft, namui::Code::ShiftRight])
                 {
-                    namui::event::send(Box::new(EditorEvent::TimelineMoveEvent {
+                    namui::event::send(EditorEvent::TimelineMoveEvent {
                         pixel: PixelSize(event.delta_xy.y),
-                    }))
+                    })
                 } else if keyboard_manager
                     .any_code_press(&[namui::Code::AltLeft, namui::Code::AltRight])
                 {
                     let anchor_x_in_timeline = PixelSize(mouse_position.x as f32 - timeline_xy.x);
 
-                    namui::event::send(Box::new(EditorEvent::TimelineZoomEvent {
+                    namui::event::send(EditorEvent::TimelineZoomEvent {
                         delta: event.delta_xy.y,
                         anchor_x_in_timeline,
-                    }))
+                    })
                 }
             }))
         });

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body.rs
@@ -63,7 +63,7 @@ impl CameraClipBody {
                     local_mouse_xy: event.local_xy,
                     global_mouse_xy: event.global_xy,
                 };
-                namui::event::send(Box::new(event));
+                namui::event::send(event);
             }))
         })]
     }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
@@ -105,11 +105,11 @@ impl SubtitleClipBody {
         .attach_event(|builder| {
             let clip_id = props.clip.id.clone();
             builder.on_mouse_down(Box::new(move |event| {
-                namui::event::send(Box::new(EditorEvent::SubtitleClipHeadMouseDownEvent {
+                namui::event::send(EditorEvent::SubtitleClipHeadMouseDownEvent {
                     clip_id: clip_id.clone(),
                     local_mouse_xy: event.local_xy,
                     global_mouse_xy: event.global_xy,
-                }));
+                });
             }))
         });
 

--- a/luda-editor/luda-editor-client/src/app/sequence_list/load_button.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/load_button.rs
@@ -10,7 +10,7 @@ impl SequenceList {
                     let path = path.clone();
                     builder.on_mouse_down(Box::new(move |_| {
                         let path = path.clone();
-                        namui::event::send(Box::new(SequenceListEvent::SequenceLoadEvent { path }));
+                        namui::event::send(SequenceListEvent::SequenceLoadEvent { path });
                     }))
                 }),
             self.render_button_text(wh, "Load".to_string())

--- a/luda-editor/luda-editor-client/src/app/sequence_list/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/mod.rs
@@ -57,20 +57,20 @@ impl Entity for SequenceList {
                 },
                 SequenceListEvent::SequenceLoadEvent { path } => {
                     let started_at = Namui::now();
-                    namui::event::send(Box::new(SequenceListEvent::SequenceLoadStateUpdateEvent {
+                    namui::event::send(SequenceListEvent::SequenceLoadStateUpdateEvent {
                         path: path.clone(),
                         state: Some(SequenceLoadState {
                             started_at,
                             detail: SequenceLoadStateDetail::Loading,
                         }),
-                    }));
+                    });
                     spawn_local({
                         let path = path.clone();
                         let socket = self.socket.clone();
                         async move {
                             fn handle_error(path: String, started_at: Duration, error: String) {
                                 namui::log(format!("error on read_file: {:?}", error));
-                                namui::event::send(Box::new(
+                                namui::event::send(
                                     SequenceListEvent::SequenceLoadStateUpdateEvent {
                                         path,
                                         state: Some(SequenceLoadState {
@@ -78,7 +78,7 @@ impl Entity for SequenceList {
                                             detail: SequenceLoadStateDetail::Failed { error },
                                         }),
                                     },
-                                ));
+                                );
                             }
                             let result = socket
                                 .read_file(luda_editor_rpc::read_file::Request {
@@ -89,7 +89,7 @@ impl Entity for SequenceList {
                                 Ok(response) => {
                                     let file = response.file;
                                     match Sequence::try_from(file) {
-                                        Ok(sequence) => namui::event::send(Box::new(
+                                        Ok(sequence) => namui::event::send(
                                             SequenceListEvent::SequenceLoadStateUpdateEvent {
                                                 path: path.clone(),
                                                 state: Some(SequenceLoadState {
@@ -99,7 +99,7 @@ impl Entity for SequenceList {
                                                     },
                                                 }),
                                             },
-                                        )),
+                                        ),
                                         Err(error) => handle_error(path.clone(), started_at, error),
                                     }
                                 }

--- a/luda-editor/luda-editor-client/src/app/sequence_list/open_button.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/open_button.rs
@@ -17,10 +17,10 @@ impl SequenceList {
                     let sequence = sequence.clone();
                     builder.on_mouse_down(Box::new(move |_| {
                         let sequence = sequence.clone();
-                        namui::event::send(Box::new(RouterEvent::PageChangeToEditorEvent(
-                            Box::new(move |context| -> Editor {
+                        namui::event::send(RouterEvent::PageChangeToEditorEvent(Box::new(
+                            move |context| -> Editor {
                                 Editor::new(context.socket.clone(), sequence.clone())
-                            }),
+                            },
                         )));
                     }))
                 }),

--- a/namui/Cargo.toml
+++ b/namui/Cargo.toml
@@ -32,6 +32,7 @@ ordered-float = "2.10"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
+tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/namui/src/namui/event/mod.rs
+++ b/namui/src/namui/event/mod.rs
@@ -24,3 +24,20 @@ pub enum NamuiEvent {
     ScreenResize(namui::Wh<i16>),
     Wheel(namui::Xy<f32>),
 }
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    async fn received_event_should_be_able_to_downcast() {
+        let mut event_receiver = super::init();
+        #[derive(Debug, PartialEq)]
+        enum Event {
+            Test,
+        }
+        super::send(Event::Test);
+        let event = event_receiver.recv().await.unwrap();
+        let downcasted = event.downcast_ref::<Event>().unwrap();
+        assert_eq!(downcasted, &Event::Test);
+    }
+}

--- a/namui/src/namui/event/mod.rs
+++ b/namui/src/namui/event/mod.rs
@@ -12,8 +12,8 @@ pub fn init() -> mpsc::UnboundedReceiver<Event> {
     receiver
 }
 
-pub fn send(event: Event) {
-    EVENT_SENDER.get().unwrap().send(event).unwrap();
+pub fn send(event: impl Any + Send + Sync) {
+    EVENT_SENDER.get().unwrap().send(Box::new(event)).unwrap();
 }
 
 pub enum NamuiEvent {

--- a/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
@@ -103,7 +103,7 @@ mod tests {
             ]),
         )]);
 
-        assert_eq!(font_file_url_map, answer,);
+        assert_eq!(font_file_url_map, answer);
 
         let serialized_font_file_url_map = serde_json::to_string(&font_file_url_map).unwrap();
         // NOTE: We don't test `serialized_font_file_url_map` because it's hashmap, order is random.

--- a/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
@@ -91,22 +91,25 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            font_file_url_map,
-            HashMap::from([(
-                Language::Ko,
-                HashMap::from([
-                    (FontWeight::_100, "ko/NotoSansKR-Thin.otf".to_string()),
-                    (FontWeight::_300, "ko/NotoSansKR-Light.otf".to_string()),
-                    (FontWeight::_400, "ko/NotoSansKR-Regular.otf".to_string()),
-                    (FontWeight::_500, "ko/NotoSansKR-Medium.otf".to_string()),
-                    (FontWeight::_700, "ko/NotoSansKR-Bold.otf".to_string()),
-                    (FontWeight::_900, "ko/NotoSansKR-Black.otf".to_string()),
-                ])
-            )])
-        );
+        let answer = HashMap::from([(
+            Language::Ko,
+            HashMap::from([
+                (FontWeight::_100, "ko/NotoSansKR-Thin.otf".to_string()),
+                (FontWeight::_300, "ko/NotoSansKR-Light.otf".to_string()),
+                (FontWeight::_400, "ko/NotoSansKR-Regular.otf".to_string()),
+                (FontWeight::_500, "ko/NotoSansKR-Medium.otf".to_string()),
+                (FontWeight::_700, "ko/NotoSansKR-Bold.otf".to_string()),
+                (FontWeight::_900, "ko/NotoSansKR-Black.otf".to_string()),
+            ]),
+        )]);
+
+        assert_eq!(font_file_url_map, answer,);
 
         let serialized_font_file_url_map = serde_json::to_string(&font_file_url_map).unwrap();
-        assert_eq!(serialized_font_file_url_map, "{\"Ko\":{\"100\":\"ko/NotoSansKR-Thin.otf\",\"300\":\"ko/NotoSansKR-Light.otf\",\"400\":\"ko/NotoSansKR-Regular.otf\",\"500\":\"ko/NotoSansKR-Medium.otf\",\"700\":\"ko/NotoSansKR-Bold.otf\",\"900\":\"ko/NotoSansKR-Black.otf\"}}");
+        // NOTE: We don't test `serialized_font_file_url_map` because it's hashmap, order is random.
+
+        let deserialized_font_file_url_map: TypefaceFileUrlsFile =
+            serde_json::from_str(&serialized_font_file_url_map).unwrap();
+        assert_eq!(deserialized_font_file_url_map, answer);
     }
 }

--- a/namui/src/namui/manager/web/mouse_manager.rs
+++ b/namui/src/namui/manager/web/mouse_manager.rs
@@ -29,10 +29,10 @@ impl MouseManager {
                 ..*namui::state()
             });
 
-            namui::event::send(Box::new(namui::NamuiEvent::MouseDown(Xy {
+            namui::event::send(namui::NamuiEvent::MouseDown(Xy {
                 x: mouse_position.x as f32,
                 y: mouse_position.y as f32,
-            })));
+            }));
         }) as Box<dyn FnMut(_)>);
 
         element
@@ -55,10 +55,10 @@ impl MouseManager {
                 ..*namui::state()
             });
 
-            namui::event::send(Box::new(namui::NamuiEvent::MouseUp(Xy {
+            namui::event::send(namui::NamuiEvent::MouseUp(Xy {
                 x: mouse_position.x as f32,
                 y: mouse_position.y as f32,
-            })));
+            }));
         }) as Box<dyn FnMut(_)>);
 
         element
@@ -78,10 +78,10 @@ impl MouseManager {
                 ..*namui::state()
             });
 
-            namui::event::send(Box::new(namui::NamuiEvent::MouseMove(Xy {
+            namui::event::send(namui::NamuiEvent::MouseMove(Xy {
                 x: mouse_position.x as f32,
                 y: mouse_position.y as f32,
-            })));
+            }));
         }) as Box<dyn FnMut(_)>);
 
         element

--- a/namui/src/namui/manager/web/screen_manager.rs
+++ b/namui/src/namui/manager/web/screen_manager.rs
@@ -28,12 +28,10 @@ impl ScreenManager {
                 window.inner_width().unwrap().as_f64().unwrap() as i16,
                 window.inner_height().unwrap().as_f64().unwrap() as i16,
             );
-            namui::event::send(Box::new(namui::event::NamuiEvent::ScreenResize(
-                namui::Wh {
-                    width: screen_size.0,
-                    height: screen_size.1,
-                },
-            )));
+            namui::event::send(namui::event::NamuiEvent::ScreenResize(namui::Wh {
+                width: screen_size.0,
+                height: screen_size.1,
+            }));
         }) as Box<dyn FnMut()>);
 
         window

--- a/namui/src/namui/manager/web/wheel_manager.rs
+++ b/namui/src/namui/manager/web/wheel_manager.rs
@@ -7,10 +7,10 @@ pub struct WheelManager {}
 impl WheelManager {
     pub fn new() -> Self {
         let wheel_closure = Closure::wrap(Box::new(move |event: web_sys::WheelEvent| {
-            namui::event::send(Box::new(namui::NamuiEvent::Wheel(Xy {
+            namui::event::send(namui::NamuiEvent::Wheel(Xy {
                 x: event.delta_x() as f32,
                 y: event.delta_y() as f32,
-            })));
+            }));
         }) as Box<dyn FnMut(_)>);
 
         let window = namui::window();

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -149,7 +149,7 @@ async fn init_font() {
 }
 
 fn on_frame() {
-    event::send(Box::new(NamuiEvent::AnimationFrame));
+    event::send(NamuiEvent::AnimationFrame);
 
     Namui::request_animation_frame(Box::new(move || {
         on_frame();

--- a/namui/src/namui/render/text_input/render/mod.rs
+++ b/namui/src/namui/render/text_input/render/mod.rs
@@ -43,10 +43,10 @@ impl namui::Entity for TextInput {
                             event.global_xy
                         ));
                         let selection = get_selection_on_mouse_down(event.local_xy.x, &text_input);
-                        namui::event::send(Box::new(namui::text_input_event::SelectionChanged {
+                        namui::event::send(namui::text_input_event::SelectionChanged {
                             id: text_input.id.clone(),
                             selection: selection.ok(),
-                        }));
+                        });
                     }))
                 }),
                 draw_texts_divided_by_selection(&self)


### PR DESCRIPTION
Previously, we have to call `namui::event::send(Box::new(Event))` to send event to namui. It's toooooo anoying to put `Box::new` everytime.

I found that we don't have to put `Box::new` everytime, just pass event as `impl Any + Send + Sync` and just box it inside of send function.