### PR TITLE
Request animation frame from namui user

### DIFF
--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -9,6 +9,8 @@ mod xy;
 pub use xy::*;
 mod set_timeout;
 pub use set_timeout::*;
+mod request_animation_frame;
+pub use request_animation_frame::*;
 
 pub struct FpsInfo {
     pub fps: u16,

--- a/namui/src/namui/common/request_animation_frame.rs
+++ b/namui/src/namui/common/request_animation_frame.rs
@@ -1,0 +1,71 @@
+use once_cell::sync::OnceCell;
+use std::sync::Mutex;
+
+type Callback = Box<dyn FnOnce()>;
+pub struct CallbackContainer(Callback);
+unsafe impl Send for CallbackContainer {}
+type CallbackQueue = Vec<CallbackContainer>;
+
+static CALLBACK_QUEUE: OnceCell<Mutex<CallbackQueue>> = OnceCell::new();
+
+fn get_queue() -> std::sync::MutexGuard<'static, CallbackQueue> {
+    CALLBACK_QUEUE
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap()
+}
+
+pub fn request_animation_frame(callback: impl FnOnce() + 'static) {
+    get_queue().push(CallbackContainer(Box::new(callback)))
+}
+
+pub(crate) fn invoke_and_flush_all_animation_frame_callbacks() {
+    let mut queue = get_queue();
+    let queue = std::mem::replace(&mut *queue, Vec::new());
+    for callback in queue {
+        callback.0();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicBool, AtomicI32},
+        Arc,
+    };
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn request_animation_frame_should_work() {
+        request_animation_frame(|| {});
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn invoke_and_flush_all_animation_frame_callbacks_should_invoke() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+        request_animation_frame(move || {
+            called_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+        });
+        invoke_and_flush_all_animation_frame_callbacks();
+        assert!(called.load(std::sync::atomic::Ordering::Relaxed));
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn invoke_and_flush_all_animation_frame_callbacks_should_flush() {
+        let call_count = Arc::new(AtomicI32::new(0));
+        let call_count_clone = call_count.clone();
+        request_animation_frame(move || {
+            call_count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        });
+        assert_eq!(call_count.load(std::sync::atomic::Ordering::Relaxed), 0);
+        invoke_and_flush_all_animation_frame_callbacks();
+        assert_eq!(call_count.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+        invoke_and_flush_all_animation_frame_callbacks();
+        assert_eq!(call_count.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+}

--- a/namui/src/namui/common/set_timeout.rs
+++ b/namui/src/namui/common/set_timeout.rs
@@ -1,8 +1,6 @@
 use once_cell::sync::OnceCell;
 use std::{cmp::Reverse, collections::BinaryHeap, sync::Mutex, time::Duration};
 
-use crate::NamuiImpl;
-
 type Callback = Box<dyn FnOnce()>;
 unsafe impl Send for TimeoutCallback {}
 struct TimeoutCallback {

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -77,6 +77,8 @@ pub async fn start<TProps>(
 
         match event.downcast_ref::<NamuiEvent>() {
             Some(NamuiEvent::AnimationFrame) => {
+                invoke_and_flush_all_animation_frame_callbacks();
+
                 update_fps_info(&mut namui_context.fps_info);
 
                 namui_context.rendering_tree.draw(&namui_context);


### PR DESCRIPTION
I made `request_animation_frame` api for user, not inside of namui.

# Known issue
- With current implementation, user cannot draw what they want to draw right that frame using `request_animation_frame`.
  - Let's assume that `SequencePlayer` uses `request_animation_frame` to render on every frame.
    - Without `request_animation_frame`, it's not possible to render on right frame because namui only `render` after update by event, just `draw` in namui's internal AnimationFrame.
  - `SequencePlayer` want to render when it call `request_animation_frame`, so it call `namui::event::send` in `request_animation_frame` like below
```rust
impl SequencePlayer {
  fn update() {
    if event == SequencePlayerEvent::AnimationFrame {
      request_animation_frame(|| {
        namui::event::send(SequencePlayerEvent::AnimationFrame)
      }
    }
  }
}
```
  - the event `SequencePlayerEvent::AnimationFrame` will be called after `draw`. Because that event will be enqueued in event system, dequeued by loop in namui.
  - That means, **1 frame will be delayed.**

# How I will fix known issue at next time
- Event System
  - Synchronous Flushing & Asynchronous Waiting
    - For now, namui's event system only can wait next event. It cannot flush current queued events.
    - If event system can flush queued events, namui will flush all events right before AnimationFrame, including user-requested animation frame callbacks. Then user can draw in right frame using `request_animation_frame`.
  - It will be tracked in issue https://github.com/NamseEnt/namseent/issues/86.