### PR TITLE
Init event receiver on namui::init

### DIFF
--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -1,6 +1,7 @@
 use super::namui_state::{update_namui_state, NamuiState};
 use super::render::{RenderingData, RenderingTree};
 use super::skia::*;
+use crate::event::EventReceiver;
 use serde::{Deserialize, Serialize};
 use serde_repr::*;
 use std::time::Duration;
@@ -22,6 +23,7 @@ pub struct NamuiContext {
     pub(crate) surface: Surface,
     pub(crate) fps_info: FpsInfo,
     pub(crate) rendering_tree: RenderingTree,
+    pub(crate) event_receiver: EventReceiver,
 }
 impl NamuiContext {
     pub fn get_rendering_tree_xy(&self, id: &str) -> Option<Xy<f32>> {

--- a/namui/src/namui/event/mod.rs
+++ b/namui/src/namui/event/mod.rs
@@ -5,8 +5,9 @@ use tokio::sync::mpsc::{self, unbounded_channel};
 
 type Event = Box<dyn Any + Send + Sync>;
 static EVENT_SENDER: OnceCell<mpsc::UnboundedSender<Event>> = OnceCell::new();
+pub(crate) type EventReceiver = mpsc::UnboundedReceiver<Event>;
 
-pub fn init() -> mpsc::UnboundedReceiver<Event> {
+pub fn init() -> EventReceiver {
     let (sender, receiver) = unbounded_channel();
     EVENT_SENDER.set(sender).unwrap();
     receiver

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -59,8 +59,6 @@ pub async fn start<TProps>(
     state: &mut dyn Entity<Props = TProps>,
     props: &TProps,
 ) {
-    let mut event_receiver = event::init();
-
     init_font().await;
 
     namui_context.rendering_tree = state.render(props);
@@ -72,7 +70,7 @@ pub async fn start<TProps>(
     let mut event_count = 0;
 
     loop {
-        let event = event_receiver.recv().await.unwrap();
+        let event = namui_context.event_receiver.recv().await.unwrap();
         event_count += 1;
 
         match event.downcast_ref::<NamuiEvent>() {

--- a/namui/src/namui/namui_mock/mod.rs
+++ b/namui/src/namui/namui_mock/mod.rs
@@ -76,6 +76,7 @@ impl NamuiImpl for Namui {
                 last_60_frame_time: Namui::now(),
             },
             rendering_tree: RenderingTree::Empty,
+            event_receiver: crate::event::init(),
         }
     }
 

--- a/namui/src/namui/namui_web/mod.rs
+++ b/namui/src/namui/namui_web/mod.rs
@@ -64,6 +64,7 @@ impl NamuiImpl for Namui {
                 last_60_frame_time: Namui::now(),
             },
             rendering_tree: RenderingTree::Empty,
+            event_receiver: crate::event::init(),
         }
     }
 


### PR DESCRIPTION
# What happened?
Error occurred when using `namui::event::send()` while making `namui::Entity` for the first time.
This was because the event channel had not been created yet.

This pr makes event channel to be created in `namui::init` step.
