### PR TITLE
Add go-back button in editor page

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -2,9 +2,7 @@ mod timeline;
 use self::{
     clip_editor::{camera_clip_editor::image_browser::ImageBrowserItem, ClipEditor},
     events::*,
-    history::History,
     job::*,
-    top_bar::TopBar,
 };
 use super::types::*;
 use crate::app::editor::{
@@ -21,7 +19,9 @@ mod job;
 mod sequence_player;
 use sequence_player::SequencePlayer;
 mod history;
+use history::History;
 mod top_bar;
+use top_bar::TopBar;
 
 pub struct EditorProps {
     pub screen_wh: namui::Wh<f32>,

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/events.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/events.rs
@@ -1,0 +1,3 @@
+pub enum TopBarEvent {
+    GoBackButtonClicked,
+}

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/go_back_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/go_back_button.rs
@@ -1,9 +1,8 @@
+use crate::app::editor::top_bar::events::TopBarEvent;
 use namui::{
     render, Color, FontType, FontWeight, Language, RectFill, RectParam, RectRound, RectStyle,
     RenderingTree, TextAlign, TextBaseline, TextStyle, Wh,
 };
-
-use crate::app::editor::top_bar::events::TopBarEvent;
 
 pub fn render_go_back_button(wh: Wh<f32>) -> RenderingTree {
     render![

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/go_back_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/go_back_button.rs
@@ -1,0 +1,45 @@
+use namui::{
+    render, Color, FontType, FontWeight, Language, RectFill, RectParam, RectRound, RectStyle,
+    RenderingTree, TextAlign, TextBaseline, TextStyle, Wh,
+};
+
+use crate::app::editor::top_bar::events::TopBarEvent;
+
+pub fn render_go_back_button(wh: Wh<f32>) -> RenderingTree {
+    render![
+        namui::rect(RectParam {
+            x: 0.0,
+            y: 0.0,
+            width: wh.width,
+            height: wh.height,
+            style: RectStyle {
+                stroke: None,
+                fill: Some(RectFill {
+                    color: Color::from_u8(107, 185, 240, 255),
+                }),
+                round: Some(RectRound { radius: 4.0 }),
+            },
+        })
+        .with_mouse_cursor(namui::MouseCursor::Pointer)
+        .attach_event(move |builder| {
+            builder.on_mouse_down(move |_| namui::event::send(TopBarEvent::GoBackButtonClicked))
+        }),
+        namui::text(namui::TextParam {
+            text: "Go back".to_string(),
+            x: wh.width / 2.0,
+            y: wh.height / 2.0,
+            align: TextAlign::Center,
+            baseline: TextBaseline::Middle,
+            font_type: FontType {
+                serif: false,
+                size: (wh.height / 3.0 * 2.0) as i16,
+                language: Language::Ko,
+                font_weight: FontWeight::REGULAR,
+            },
+            style: TextStyle {
+                color: Color::from_u8(255, 255, 255, 255),
+                ..Default::default()
+            },
+        })
+    ]
+}

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/mod.rs
@@ -1,0 +1,66 @@
+mod events;
+mod go_back_button;
+use namui::{render, Color, RenderingTree, Wh, XywhRect};
+
+use crate::app::{events::RouterEvent, sequence_list::SequenceList};
+
+use self::{events::TopBarEvent, go_back_button::render_go_back_button};
+
+const MARGIN: f32 = 4.0;
+
+pub struct TopBarProps {
+    pub xywh: XywhRect<f32>,
+}
+
+pub struct TopBar {}
+
+impl TopBar {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn update(&mut self, event: &dyn std::any::Any) {
+        if let Some(event) = event.downcast_ref::<TopBarEvent>() {
+            match event {
+                TopBarEvent::GoBackButtonClicked => change_page_to_sequence_list(),
+            }
+        }
+    }
+
+    pub fn render(&self, props: &TopBarProps) -> RenderingTree {
+        let go_back_button_wh = Wh {
+            width: 64.0,
+            height: props.xywh.height - 2.0 * MARGIN,
+        };
+
+        let border = namui::rect(namui::RectParam {
+            x: 0.0,
+            y: 0.0,
+            width: props.xywh.width,
+            height: props.xywh.height,
+            style: namui::RectStyle {
+                stroke: Some(namui::RectStroke {
+                    color: Color::BLACK,
+                    border_position: namui::BorderPosition::Inside,
+                    width: 1.0,
+                }),
+                ..Default::default()
+            },
+        });
+
+        namui::translate(
+            props.xywh.x,
+            props.xywh.y,
+            render![
+                border,
+                namui::translate(MARGIN, MARGIN, render_go_back_button(go_back_button_wh)),
+            ],
+        )
+    }
+}
+
+fn change_page_to_sequence_list() {
+    namui::event::send(RouterEvent::PageChangeToSequenceListEvent(Box::new(
+        move |app_context| SequenceList::new(app_context.socket.clone()),
+    )))
+}

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/mod.rs
@@ -1,10 +1,8 @@
 mod events;
 mod go_back_button;
-use namui::{render, Color, RenderingTree, Wh, XywhRect};
-
-use crate::app::{events::RouterEvent, sequence_list::SequenceList};
-
 use self::{events::TopBarEvent, go_back_button::render_go_back_button};
+use crate::app::{events::RouterEvent, sequence_list::SequenceList};
+use namui::{render, Color, RenderingTree, Wh, XywhRect};
 
 const MARGIN: f32 = 4.0;
 

--- a/luda-editor/luda-editor-client/src/app/events.rs
+++ b/luda-editor/luda-editor-client/src/app/events.rs
@@ -4,7 +4,5 @@ type PageInitializer<T> = Box<dyn Fn(&AppContext) -> T + Send + Sync>;
 
 pub enum RouterEvent {
     PageChangeToEditorEvent(PageInitializer<Editor>),
-    // TODO: this gonna be used to make back button in editor
-    #[allow(dead_code)]
     PageChangeToSequenceListEvent(PageInitializer<SequenceList>),
 }


### PR DESCRIPTION
It's just a button to go back.
If you press the button inside the editor page, you will go to the sequence list page.
![image](https://user-images.githubusercontent.com/38313680/151017349-3a760a19-ad88-480e-bf52-f1e4b7d931b5.png)
