### PR TITLE
Remove luda-editor-client cargo checking action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,7 @@
 name: cargo-check
 on:
   push:
-    paths:
-      - "luda-editor/luda-editor-client/**"
+    paths: # Please put packages which has no other test action only.
       - "luda-editor/luda-editor-server/**"
       - "luda-editor/luda-editor-rpc/**"
       - "namui-cli/**"
@@ -22,9 +21,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - run: pushd luda-editor/luda-editor-client; cargo check; popd;
       - run: pushd luda-editor/luda-editor-server; cargo check; popd;
       - run: pushd luda-editor/luda-editor-rpc; cargo check; popd;
       - run: pushd namui-cli; cargo check; popd;
-      - run: pushd namui; cargo check; popd;
       - run: pushd nrpc; cargo check; popd;

--- a/luda-editor/luda-editor-client/.gitignore
+++ b/luda-editor/luda-editor-client/.gitignore
@@ -4,4 +4,3 @@ Cargo.lock
 bin/
 pkg/
 wasm-pack.log
-123123

--- a/luda-editor/luda-editor-client/.gitignore
+++ b/luda-editor/luda-editor-client/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 bin/
 pkg/
 wasm-pack.log
+123123


### PR DESCRIPTION
# What I did!?
I remove luda-editor-client from cargo check action because that packages will be checked by test-luda-editor-client action.