### PR TITLE
Fix wrong local xy calculation for aboluste

### DIFF
--- a/namui/src/namui/render/rendering_tree.rs
+++ b/namui/src/namui/render/rendering_tree.rs
@@ -291,8 +291,8 @@ impl RenderingTree {
                 }
                 SpecialRenderingNode::Absolute(absolute) => {
                     let next_local_xy = Xy {
-                        x: absolute.x,
-                        y: absolute.y,
+                        x: raw_mouse_event.xy.x - absolute.x,
+                        y: raw_mouse_event.xy.y - absolute.y,
                     };
                     absolute.rendering_tree.iter().rev().for_each(|child| {
                         child.call_mouse_event_impl(


### PR DESCRIPTION
# What Happened
I couldn't get the mouse event for the rendering tree which used `absolute()`. So I digged it and found it's because of wrong local xy calculation for `absolute` on mouse event handling.