### PR TITLE
Recover from fetch fail error

### DIFF
--- a/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/font/load_sans_typeface_of_all_languages.rs
@@ -24,7 +24,9 @@ pub async fn load_sans_typeface_of_all_languages(
 
 async fn load_typeface_file_urls_file() -> Result<TypefaceFileUrlsFile, String> {
     let url = "resources/font/map.json";
-    fetch_get_json(url).await
+    fetch_get_json(url)
+        .await
+        .map_err(|error| format!("{}", error))
 }
 
 async fn get_typeface_file_urls() -> Result<TypefaceFileUrls, String> {

--- a/namui/src/namui/namui_web/fetch.rs
+++ b/namui/src/namui/namui_web/fetch.rs
@@ -1,52 +1,69 @@
+use core::fmt;
+
 use js_sys::{ArrayBuffer, Uint8Array};
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, Response};
 
-pub async fn fetch_get(url: &str) -> Result<Response, String> {
+pub async fn fetch_get(url: &str) -> Result<Response, FetchError> {
     let mut options = RequestInit::new();
     options.method("GET");
 
-    let request = Request::new_with_str_and_init(url, &options).unwrap();
+    let request = Request::new_with_str_and_init(url, &options)?;
 
     let window = web_sys::window().unwrap();
-    match JsFuture::from(window.fetch_with_request(&request)).await {
-        Ok(response_value) => {
-            assert!(response_value.is_instance_of::<Response>());
-            let response: Response = response_value.dyn_into().unwrap();
+    let response_value = JsFuture::from(window.fetch_with_request(&request)).await?;
 
-            if !response.ok() {
-                return Err(response.status_text());
-            }
-            Result::Ok(response)
-        }
-        Err(error) => return Err(format!("fail to fetch {} - {:?}", url, error)),
+    let response: Response = response_value.dyn_into()?;
+
+    if !response.ok() {
+        return Err(FetchError {
+            message: response.status_text(),
+        });
     }
+    Result::Ok(response)
 }
 
-pub async fn fetch_get_array_buffer(url: &str) -> Result<ArrayBuffer, String> {
+pub async fn fetch_get_array_buffer(url: &str) -> Result<ArrayBuffer, FetchError> {
     let response: Response = fetch_get(&url).await?;
 
-    let array_buffer = JsFuture::from(response.array_buffer().unwrap())
-        .await
-        .unwrap()
-        .dyn_into()
-        .unwrap();
+    let array_buffer = JsFuture::from(response.array_buffer()?).await?.dyn_into()?;
 
     Result::Ok(array_buffer)
 }
 
-pub async fn fetch_get_json<T: for<'a> serde::Deserialize<'a>>(url: &str) -> Result<T, String> {
+pub async fn fetch_get_json<T: for<'a> serde::Deserialize<'a>>(url: &str) -> Result<T, FetchError> {
     let response: Response = fetch_get(&url).await?;
 
-    let json = JsFuture::from(response.json().unwrap()).await.unwrap();
+    let json = JsFuture::from(response.json()?).await?;
 
-    json.into_serde().map_err(|e| e.to_string())
+    json.into_serde().map_err(|e| FetchError {
+        message: format!("fail to deserialize for {} - {}", url, e),
+    })
 }
 
-pub async fn fetch_get_vec_u8(url: &str) -> Result<Vec<u8>, String> {
+pub async fn fetch_get_vec_u8(url: &str) -> Result<Vec<u8>, FetchError> {
     let array_buffer = fetch_get_array_buffer(url).await?;
     let array_buffer_view = Uint8Array::new(&array_buffer);
     let bytes = array_buffer_view.to_vec();
     Result::Ok(bytes)
+}
+
+#[derive(Debug)]
+pub struct FetchError {
+    message: String,
+}
+
+impl From<JsValue> for FetchError {
+    fn from(js_value: JsValue) -> Self {
+        Self {
+            message: format!("{:?}", js_value),
+        }
+    }
+}
+
+impl fmt::Display for FetchError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
 }

--- a/namui/src/namui/namui_web/fetch.rs
+++ b/namui/src/namui/namui_web/fetch.rs
@@ -10,20 +10,22 @@ pub async fn fetch_get(url: &str) -> Result<Response, String> {
     let request = Request::new_with_str_and_init(url, &options).unwrap();
 
     let window = web_sys::window().unwrap();
-    let response_value = JsFuture::from(window.fetch_with_request(&request))
-        .await
-        .unwrap();
-    assert!(response_value.is_instance_of::<Response>());
-    let response: Response = response_value.dyn_into().unwrap();
+    match JsFuture::from(window.fetch_with_request(&request)).await {
+        Ok(response_value) => {
+            assert!(response_value.is_instance_of::<Response>());
+            let response: Response = response_value.dyn_into().unwrap();
 
-    if !response.ok() {
-        return Err(response.status_text());
+            if !response.ok() {
+                return Err(response.status_text());
+            }
+            Result::Ok(response)
+        }
+        Err(error) => return Err(format!("fail to fetch {} - {:?}", url, error)),
     }
-    Result::Ok(response)
 }
 
 pub async fn fetch_get_array_buffer(url: &str) -> Result<ArrayBuffer, String> {
-    let response: Response = fetch_get(&url).await.unwrap();
+    let response: Response = fetch_get(&url).await?;
 
     let array_buffer = JsFuture::from(response.array_buffer().unwrap())
         .await
@@ -35,7 +37,7 @@ pub async fn fetch_get_array_buffer(url: &str) -> Result<ArrayBuffer, String> {
 }
 
 pub async fn fetch_get_json<T: for<'a> serde::Deserialize<'a>>(url: &str) -> Result<T, String> {
-    let response: Response = fetch_get(&url).await.unwrap();
+    let response: Response = fetch_get(&url).await?;
 
     let json = JsFuture::from(response.json().unwrap()).await.unwrap();
 
@@ -43,7 +45,7 @@ pub async fn fetch_get_json<T: for<'a> serde::Deserialize<'a>>(url: &str) -> Res
 }
 
 pub async fn fetch_get_vec_u8(url: &str) -> Result<Vec<u8>, String> {
-    let array_buffer = fetch_get_array_buffer(url).await.unwrap();
+    let array_buffer = fetch_get_array_buffer(url).await?;
     let array_buffer_view = Uint8Array::new(&array_buffer);
     let bytes = array_buffer_view.to_vec();
     Result::Ok(bytes)


### PR DESCRIPTION
# What happened
I thought our ImageManager can recover from error of fetching image. But it doesn't, it become panic.
I found that fetch logic used unwrap, so it was not recovered even it's return type was Result.

# What I did
I changed unwrap-ing code into question mark operator, which return Err instead of panic.