### PR TITLE
Show camera clip preview on timeline

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body.rs
@@ -110,6 +110,20 @@ fn render_camera_clip_preview(
     let width_by_fixed_height = xywh.height * 16.0 / 9.0;
 
     let letter_box_half_width = (width_by_fixed_height - xywh.width) / 2.0;
+    let background = rect(RectParam {
+        x: 0.0,
+        y: 0.0,
+        width: width_by_fixed_height,
+        height: xywh.height,
+        style: RectStyle {
+            fill: Some(RectFill {
+                color: Color::WHITE,
+            }),
+
+            ..Default::default()
+        },
+        ..Default::default()
+    });
 
     translate(
         xywh.x - letter_box_half_width,
@@ -126,13 +140,16 @@ fn render_camera_clip_preview(
                 CAMERA_CLIP_ROUND_RADIUS,
             ),
             ClipOp::Intersect,
-            camera_angle.render(
-                &Wh {
-                    width: width_by_fixed_height,
-                    height: xywh.height,
-                },
-                &camera_angle_image_loader,
-            ),
+            render![
+                background,
+                camera_angle.render(
+                    &Wh {
+                        width: width_by_fixed_height,
+                        height: xywh.height,
+                    },
+                    &camera_angle_image_loader,
+                ),
+            ],
         ),
     )
 }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body.rs
@@ -29,51 +29,69 @@ impl CameraClipBody {
         };
         let is_highlight = props.context.selected_clip_ids.contains(&&props.clip.id);
 
+        let background = namui::rect(namui::RectParam {
+            x: clip_rect.x,
+            y: clip_rect.y,
+            width: clip_rect.width,
+            height: clip_rect.height,
+            style: namui::RectStyle {
+                fill: Some(namui::RectFill {
+                    color: namui::Color::from_f01(0.4, 0.4, 0.8, 1.0),
+                }),
+                round: Some(namui::RectRound {
+                    radius: CAMERA_CLIP_ROUND_RADIUS,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let border = namui::rect(namui::RectParam {
+            x: clip_rect.x,
+            y: clip_rect.y,
+            width: clip_rect.width,
+            height: clip_rect.height,
+            style: namui::RectStyle {
+                stroke: Some(if is_highlight {
+                    namui::RectStroke {
+                        color: namui::Color::RED,
+                        width: 3.0,
+                        border_position: namui::BorderPosition::Inside,
+                    }
+                } else {
+                    namui::RectStroke {
+                        color: namui::Color::BLACK,
+                        width: 1.0,
+                        border_position: namui::BorderPosition::Inside,
+                    }
+                }),
+                round: Some(namui::RectRound {
+                    radius: CAMERA_CLIP_ROUND_RADIUS,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .attach_event(move |builder| {
+            let clip_id = props.clip.id.clone();
+            builder.on_mouse_down(move |event| {
+                let event = EditorEvent::CameraClipBodyMouseDownEvent {
+                    clip_id: clip_id.clone(),
+                    click_in_time: timeline_start_at + PixelSize(event.local_xy.x) * time_per_pixel,
+                };
+                namui::event::send(event);
+            })
+        });
+
         namui::render![
+            background,
             render_camera_clip_preview(
                 &clip_rect,
                 props.track_body_wh.width,
                 &props.clip.camera_angle,
                 LudaEditorServerCameraAngleImageLoader {},
             ),
-            namui::rect(namui::RectParam {
-                x: clip_rect.x,
-                y: clip_rect.y,
-                width: clip_rect.width,
-                height: clip_rect.height,
-                style: namui::RectStyle {
-                    fill: None,
-                    stroke: Some(if is_highlight {
-                        namui::RectStroke {
-                            color: namui::Color::RED,
-                            width: 3.0,
-                            border_position: namui::BorderPosition::Inside,
-                        }
-                    } else {
-                        namui::RectStroke {
-                            color: namui::Color::BLACK,
-                            width: 1.0,
-                            border_position: namui::BorderPosition::Inside,
-                        }
-                    }),
-                    round: Some(namui::RectRound {
-                        radius: CAMERA_CLIP_ROUND_RADIUS,
-                    }),
-                    ..Default::default()
-                },
-                ..Default::default()
-            })
-            .attach_event(move |builder| {
-                let clip_id = props.clip.id.clone();
-                builder.on_mouse_down(move |event| {
-                    let event = EditorEvent::CameraClipBodyMouseDownEvent {
-                        clip_id: clip_id.clone(),
-                        click_in_time: timeline_start_at
-                            + PixelSize(event.local_xy.x) * time_per_pixel,
-                    };
-                    namui::event::send(event);
-                })
-            }),
+            border,
         ]
     }
 }

--- a/luda-editor/luda-editor-client/src/app/types/camera_angle.rs
+++ b/luda-editor/luda-editor-client/src/app/types/camera_angle.rs
@@ -73,35 +73,17 @@ impl CameraAngle {
             height: image_size.height,
         };
 
-        let background = rect(RectParam {
-            x: 0.0,
-            y: 0.0,
-            width: wh.width,
-            height: wh.height,
-            style: RectStyle {
-                fill: Some(RectFill {
-                    color: Color::WHITE,
-                }),
-
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        render![
-            background,
-            clip(
-                PathBuilder::new().add_rect(&clip_rect),
-                ClipOp::Intersect,
-                namui::image(ImageParam {
-                    source: ImageSource::Image(image),
-                    xywh: image_xywh,
-                    style: ImageStyle {
-                        fit: ImageFit::Fill,
-                        paint_builder: None,
-                    },
-                })
-            ),
-        ]
+        clip(
+            PathBuilder::new().add_rect(&clip_rect),
+            ClipOp::Intersect,
+            namui::image(ImageParam {
+                source: ImageSource::Image(image),
+                xywh: image_xywh,
+                style: ImageStyle {
+                    fit: ImageFit::Fill,
+                    paint_builder: None,
+                },
+            }),
+        )
     }
 }

--- a/luda-editor/luda-editor-client/src/app/types/camera_angle.rs
+++ b/luda-editor/luda-editor-client/src/app/types/camera_angle.rs
@@ -73,17 +73,35 @@ impl CameraAngle {
             height: image_size.height,
         };
 
-        clip(
-            PathBuilder::new().add_rect(&clip_rect),
-            ClipOp::Intersect,
-            namui::image(ImageParam {
-                source: ImageSource::Image(image),
-                xywh: image_xywh,
-                style: ImageStyle {
-                    fit: ImageFit::Fill,
-                    paint_builder: None,
-                },
-            }),
-        )
+        let background = rect(RectParam {
+            x: 0.0,
+            y: 0.0,
+            width: wh.width,
+            height: wh.height,
+            style: RectStyle {
+                fill: Some(RectFill {
+                    color: Color::WHITE,
+                }),
+
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        render![
+            background,
+            clip(
+                PathBuilder::new().add_rect(&clip_rect),
+                ClipOp::Intersect,
+                namui::image(ImageParam {
+                    source: ImageSource::Image(image),
+                    xywh: image_xywh,
+                    style: ImageStyle {
+                        fit: ImageFit::Fill,
+                        paint_builder: None,
+                    },
+                })
+            ),
+        ]
     }
 }


### PR DESCRIPTION
# What was the problem
In the timeline, it was very difficult to distinguish the camera clips. Because all the clips were the same color and the same shape.

# How did I solve it
I show camera clip preview in camera clip body, like other video editing tools.

# Design Doc
https://docs.google.com/document/d/1bs7z9n0Oy0qpS-00k946Yz69BYClqtIpL5pBrh10HLA/edit#