### PR TITLE
Resize camera clip using sash

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/events.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/events.rs
@@ -2,6 +2,7 @@ use super::clip_editor::camera_clip_editor::wysiwyg_editor::{
     cropper::CropperHandle, resizer::ResizerHandle,
 };
 use crate::app::editor::clip_editor::camera_clip_editor::image_browser::ImageBrowserItem;
+use crate::app::editor::timeline::timeline_body::track_body::camera_track_body::camera_clip_body::CameraClipBodyPart;
 use crate::app::types::*;
 use std::sync::Arc;
 
@@ -9,6 +10,7 @@ pub enum EditorEvent {
     CameraClipBodyMouseDownEvent {
         clip_id: String,
         click_in_time: Time,
+        clicked_part: CameraClipBodyPart,
     },
     SubtitleClipHeadMouseDownEvent {
         clip_id: String,

--- a/luda-editor/luda-editor-client/src/app/editor/job/add_camera_clip.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/add_camera_clip.rs
@@ -26,6 +26,7 @@ impl JobExecute for AddCameraClipJob {
 
 #[cfg(test)]
 mod tests {
+    use super::super::*;
     use super::*;
     use namui::prelude::*;
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -100,67 +101,5 @@ mod tests {
         let expected_clip_ids = ["0", "1", "2", "3", "4"];
         let result_clip_ids = extract_camera_clip_ids(&result);
         assert_eq!(result_clip_ids, expected_clip_ids);
-    }
-
-    fn extract_camera_clip_ids(sequence: &Sequence) -> Vec<String> {
-        sequence
-            .tracks
-            .iter()
-            .filter_map::<Vec<String>, _>(|track| {
-                if let Track::Camera(camera_track) = track.as_ref() {
-                    Some(
-                        camera_track
-                            .clips
-                            .iter()
-                            .map(|clip| clip.id.clone())
-                            .collect(),
-                    )
-                } else {
-                    None
-                }
-            })
-            .flatten()
-            .collect()
-    }
-
-    fn mock_sequence(camera_clip_ids: &[&str]) -> Sequence {
-        let mut clips = Vec::new();
-        camera_clip_ids.iter().enumerate().for_each(|(index, id)| {
-            let start_at = Time::from_ms(index as f32);
-            let end_at = Time::from_ms((index + 1) as f32);
-            clips.push(mock_camera_clip(id, start_at, end_at));
-        });
-        Sequence {
-            tracks: vec![Arc::new(Track::Camera(CameraTrack {
-                id: "track-1".to_string(),
-                clips: clips.into(),
-            }))]
-            .into(),
-        }
-    }
-
-    fn mock_camera_clip(clip_id: &str, start_at: Time, end_at: Time) -> Arc<CameraClip> {
-        Arc::new(CameraClip {
-            id: clip_id.to_string(),
-            start_at,
-            end_at,
-            camera_angle: CameraAngle {
-                character_pose_emotion: CharacterPoseEmotion(
-                    "c".to_string(),
-                    "p".to_string(),
-                    "e".to_string(),
-                ),
-                source_01_circumscribed: Circumscribed {
-                    center: Xy { x: 0.0, y: 0.0 },
-                    radius: 1.0,
-                },
-                crop_screen_01_rect: LtrbRect {
-                    left: 0.0,
-                    top: 0.0,
-                    right: 1.0,
-                    bottom: 1.0,
-                },
-            },
-        })
     }
 }

--- a/luda-editor/luda-editor-client/src/app/editor/job/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/mod.rs
@@ -13,6 +13,8 @@ mod change_image;
 pub use self::change_image::*;
 mod add_camera_clip;
 pub use self::add_camera_clip::*;
+mod resize_camera_clip;
+pub use self::resize_camera_clip::*;
 #[cfg(test)]
 pub mod test_utils;
 #[cfg(test)]
@@ -27,6 +29,7 @@ pub enum Job {
     WysiwygCropImage(WysiwygCropImageJob),
     ChangeImage(ChangeImageJob),
     AddCameraClip(AddCameraClipJob),
+    ResizeCameraClip(ResizeCameraClipJob),
 }
 
 impl Job {
@@ -39,6 +42,7 @@ impl Job {
             Job::WysiwygCropImage(job) => job,
             Job::ChangeImage(job) => job,
             Job::AddCameraClip(job) => job,
+            Job::ResizeCameraClip(job) => job,
         };
         job_execute.execute(sequence)
     }

--- a/luda-editor/luda-editor-client/src/app/editor/job/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/mod.rs
@@ -13,6 +13,10 @@ mod change_image;
 pub use self::change_image::*;
 mod add_camera_clip;
 pub use self::add_camera_clip::*;
+#[cfg(test)]
+pub mod test_utils;
+#[cfg(test)]
+pub use test_utils::*;
 
 #[derive(Debug, Clone)]
 pub enum Job {

--- a/luda-editor/luda-editor-client/src/app/editor/job/move_camera_clip.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/move_camera_clip.rs
@@ -35,12 +35,23 @@ impl MoveCameraClipJob {
     }
 }
 
+pub(crate) fn get_camera_track_id(sequence: &Sequence) -> String {
+    sequence
+        .tracks
+        .iter()
+        .find_map(|track| match track.as_ref() {
+            Track::Camera(track) => Some(track.id.clone()),
+            _ => None,
+        })
+        .unwrap()
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use super::super::*;
     use super::*;
     use namui::prelude::*;
+    use std::sync::Arc;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[test]
@@ -130,77 +141,4 @@ mod tests {
         let result_clip_ids = extract_camera_clip_ids(&result);
         assert_eq!(result_clip_ids, expected_clip_ids);
     }
-
-    fn extract_camera_clip_ids(sequence: &Sequence) -> Vec<String> {
-        sequence
-            .tracks
-            .iter()
-            .filter_map::<Vec<String>, _>(|track| {
-                if let Track::Camera(camera_track) = track.as_ref() {
-                    Some(
-                        camera_track
-                            .clips
-                            .iter()
-                            .map(|clip| clip.id.clone())
-                            .collect(),
-                    )
-                } else {
-                    None
-                }
-            })
-            .flatten()
-            .collect()
-    }
-
-    fn mock_sequence(camera_clip_ids: &[&str]) -> Sequence {
-        let mut clips = Vec::new();
-        camera_clip_ids.iter().enumerate().for_each(|(index, id)| {
-            let start_at = Time::from_ms(index as f32);
-            let end_at = Time::from_ms((index + 1) as f32);
-            clips.push(mock_camera_clip(id, start_at, end_at));
-        });
-        Sequence {
-            tracks: vec![Arc::new(Track::Camera(CameraTrack {
-                id: "track-1".to_string(),
-                clips: clips.into(),
-            }))]
-            .into(),
-        }
-    }
-
-    fn mock_camera_clip(clip_id: &str, start_at: Time, end_at: Time) -> Arc<CameraClip> {
-        Arc::new(CameraClip {
-            id: clip_id.to_string(),
-            start_at,
-            end_at,
-            camera_angle: CameraAngle {
-                character_pose_emotion: CharacterPoseEmotion(
-                    "c".to_string(),
-                    "p".to_string(),
-                    "e".to_string(),
-                ),
-                source_01_circumscribed: Circumscribed {
-                    center: Xy { x: 0.0, y: 0.0 },
-                    radius: 1.0,
-                },
-                crop_screen_01_rect: LtrbRect {
-                    left: 0.0,
-                    top: 0.0,
-                    right: 1.0,
-                    bottom: 1.0,
-                },
-            },
-        })
-    }
-}
-
-pub(crate) fn get_camera_track_id(sequence: &Sequence) -> String {
-    sequence
-        .tracks
-        .iter()
-        .find_map(|track| match track.as_ref() {
-            Track::Camera(track) => Some(track.id.clone()),
-            _ => None,
-        })
-        .unwrap()
 }

--- a/luda-editor/luda-editor-client/src/app/editor/job/resize_camera_clip.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/resize_camera_clip.rs
@@ -1,0 +1,153 @@
+use super::{get_camera_track_id, JobExecute};
+use crate::app::types::*;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ResizeDirection {
+    Left,
+    Right,
+}
+#[derive(Debug, Clone)]
+pub struct ResizeCameraClipJob {
+    pub clip_id: String,
+    pub click_anchor_in_time: Time,
+    pub last_mouse_position_in_time: Time,
+    pub resize_direction: ResizeDirection,
+    pub is_moved: bool,
+}
+
+impl JobExecute for ResizeCameraClipJob {
+    fn execute(&self, sequence: &Sequence) -> Result<Sequence, String> {
+        let sequence = sequence.clone();
+        let camera_track_id = get_camera_track_id(&sequence);
+        match sequence.replace_track(&camera_track_id, |track: &CameraTrack| {
+            let mut track = track.clone();
+            self.resize_clip_in_track(&mut track);
+            Ok(track)
+        }) {
+            UpdateResult::Updated(replacer) => Ok(replacer),
+            UpdateResult::NotUpdated => Err("Camera track not found".to_string()),
+            UpdateResult::Err(error) => Err(error),
+        }
+    }
+}
+
+impl ResizeCameraClipJob {
+    pub fn get_delta_time(&self) -> Time {
+        (self.last_mouse_position_in_time - self.click_anchor_in_time)
+            * match self.resize_direction {
+                ResizeDirection::Left => -1.0,
+                ResizeDirection::Right => 1.0,
+            }
+    }
+    pub fn resize_clip_in_track(&self, track: &mut CameraTrack) {
+        track.resize_clip_delta(&self.clip_id, self.get_delta_time());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn increase_by_left_direction_should_work() {
+        let sequence = mock_sequence(&["0", "1", "2"]);
+        let job = ResizeCameraClipJob {
+            clip_id: "1".to_string(),
+            click_anchor_in_time: Time::from_ms(0.0),
+            last_mouse_position_in_time: Time::from_ms(-0.5),
+            is_moved: true,
+            resize_direction: ResizeDirection::Left,
+        };
+
+        let result = job.execute(&sequence).unwrap();
+        let expected_clip_ids = ["0", "1", "2"];
+        let result_clip_ids = extract_camera_clip_ids(&result);
+        assert_eq!(result_clip_ids, expected_clip_ids);
+
+        let clips = extract_camera_clips(&result);
+        assert_eq!(clips[0].start_at, Time::from_ms(0.0));
+        assert_eq!(clips[0].end_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].start_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].end_at, Time::from_ms(2.5));
+        assert_eq!(clips[2].start_at, Time::from_ms(2.5));
+        assert_eq!(clips[2].end_at, Time::from_ms(3.5));
+    }
+    #[test]
+    #[wasm_bindgen_test]
+    fn decrease_by_left_direction_should_work() {
+        let sequence = mock_sequence(&["0", "1", "2"]);
+        let job = ResizeCameraClipJob {
+            clip_id: "1".to_string(),
+            click_anchor_in_time: Time::from_ms(0.0),
+            last_mouse_position_in_time: Time::from_ms(0.5),
+            is_moved: true,
+            resize_direction: ResizeDirection::Left,
+        };
+
+        let result = job.execute(&sequence).unwrap();
+        let expected_clip_ids = ["0", "1", "2"];
+        let result_clip_ids = extract_camera_clip_ids(&result);
+        assert_eq!(result_clip_ids, expected_clip_ids);
+
+        let clips = extract_camera_clips(&result);
+        assert_eq!(clips[0].start_at, Time::from_ms(0.0));
+        assert_eq!(clips[0].end_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].start_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].end_at, Time::from_ms(1.5));
+        assert_eq!(clips[2].start_at, Time::from_ms(1.5));
+        assert_eq!(clips[2].end_at, Time::from_ms(2.5));
+    }
+    #[test]
+    #[wasm_bindgen_test]
+    fn increase_by_right_direction_should_work() {
+        let sequence = mock_sequence(&["0", "1", "2"]);
+        let job = ResizeCameraClipJob {
+            clip_id: "1".to_string(),
+            click_anchor_in_time: Time::from_ms(0.0),
+            last_mouse_position_in_time: Time::from_ms(0.5),
+            is_moved: true,
+            resize_direction: ResizeDirection::Right,
+        };
+
+        let result = job.execute(&sequence).unwrap();
+        let expected_clip_ids = ["0", "1", "2"];
+        let result_clip_ids = extract_camera_clip_ids(&result);
+        assert_eq!(result_clip_ids, expected_clip_ids);
+
+        let clips = extract_camera_clips(&result);
+        assert_eq!(clips[0].start_at, Time::from_ms(0.0));
+        assert_eq!(clips[0].end_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].start_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].end_at, Time::from_ms(2.5));
+        assert_eq!(clips[2].start_at, Time::from_ms(2.5));
+        assert_eq!(clips[2].end_at, Time::from_ms(3.5));
+    }
+    #[test]
+    #[wasm_bindgen_test]
+    fn decrease_by_right_direction_should_work() {
+        let sequence = mock_sequence(&["0", "1", "2"]);
+        let job = ResizeCameraClipJob {
+            clip_id: "1".to_string(),
+            click_anchor_in_time: Time::from_ms(0.0),
+            last_mouse_position_in_time: Time::from_ms(-0.5),
+            is_moved: true,
+            resize_direction: ResizeDirection::Right,
+        };
+
+        let result = job.execute(&sequence).unwrap();
+        let expected_clip_ids = ["0", "1", "2"];
+        let result_clip_ids = extract_camera_clip_ids(&result);
+        assert_eq!(result_clip_ids, expected_clip_ids);
+
+        let clips = extract_camera_clips(&result);
+        assert_eq!(clips[0].start_at, Time::from_ms(0.0));
+        assert_eq!(clips[0].end_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].start_at, Time::from_ms(1.0));
+        assert_eq!(clips[1].end_at, Time::from_ms(1.5));
+        assert_eq!(clips[2].start_at, Time::from_ms(1.5));
+        assert_eq!(clips[2].end_at, Time::from_ms(2.5));
+    }
+}

--- a/luda-editor/luda-editor-client/src/app/editor/job/test_utils.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/job/test_utils.rs
@@ -1,0 +1,80 @@
+use crate::app::types::*;
+use namui::prelude::*;
+use std::sync::Arc;
+
+pub fn extract_camera_clip_ids(sequence: &Sequence) -> Vec<String> {
+    sequence
+        .tracks
+        .iter()
+        .filter_map::<Vec<String>, _>(|track| {
+            if let Track::Camera(camera_track) = track.as_ref() {
+                Some(
+                    camera_track
+                        .clips
+                        .iter()
+                        .map(|clip| clip.id.clone())
+                        .collect(),
+                )
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect()
+}
+
+pub fn extract_camera_clips(sequence: &Sequence) -> Vec<Arc<CameraClip>> {
+    sequence
+        .tracks
+        .iter()
+        .filter_map::<Vec<Arc<CameraClip>>, _>(|track| {
+            if let Track::Camera(camera_track) = track.as_ref() {
+                Some(camera_track.clips.iter().map(|clip| clip.clone()).collect())
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect()
+}
+
+pub fn mock_sequence(camera_clip_ids: &[&str]) -> Sequence {
+    let mut clips = Vec::new();
+    camera_clip_ids.iter().enumerate().for_each(|(index, id)| {
+        let start_at = Time::from_ms(index as f32);
+        let end_at = Time::from_ms((index + 1) as f32);
+        clips.push(mock_camera_clip(id, start_at, end_at));
+    });
+    Sequence {
+        tracks: vec![Arc::new(Track::Camera(CameraTrack {
+            id: "track-1".to_string(),
+            clips: clips.into(),
+        }))]
+        .into(),
+    }
+}
+
+pub fn mock_camera_clip(clip_id: &str, start_at: Time, end_at: Time) -> Arc<CameraClip> {
+    Arc::new(CameraClip {
+        id: clip_id.to_string(),
+        start_at,
+        end_at,
+        camera_angle: CameraAngle {
+            character_pose_emotion: CharacterPoseEmotion(
+                "c".to_string(),
+                "p".to_string(),
+                "e".to_string(),
+            ),
+            source_01_circumscribed: Circumscribed {
+                center: Xy { x: 0.0, y: 0.0 },
+                radius: 1.0,
+            },
+            crop_screen_01_rect: LtrbRect {
+                left: 0.0,
+                top: 0.0,
+                right: 1.0,
+                bottom: 1.0,
+            },
+        },
+    })
+}

--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -9,6 +9,7 @@ use crate::app::editor::{clip_editor::ClipEditorProps, top_bar::TopBarProps};
 use luda_editor_rpc::Socket;
 use namui::prelude::*;
 use std::{cmp::Ordering, collections::BTreeSet, sync::Arc};
+use timeline::timeline_body::track_body::camera_track_body::camera_clip_body::*;
 pub use timeline::*;
 use wasm_bindgen_futures::spawn_local;
 mod clip_editor;
@@ -53,17 +54,40 @@ impl namui::Entity for Editor {
                 EditorEvent::CameraClipBodyMouseDownEvent {
                     clip_id,
                     click_in_time,
+                    clicked_part,
                     ..
                 } => {
                     self.on_clip_mouse_down(clip_id);
 
                     if self.job.is_none() {
-                        self.job = Some(Job::MoveCameraClip(MoveCameraClipJob {
-                            clip_ids: self.selected_clip_ids.clone(),
-                            click_anchor_in_time: *click_in_time,
-                            last_mouse_position_in_time: *click_in_time,
-                            is_moved: false,
-                        }));
+                        match clicked_part {
+                            CameraClipBodyPart::Sash(sash_direction) => {
+                                if self.selected_clip_ids.len() != 1 {
+                                    namui::log!("selected_clip_ids.len() should be 1 to resize, but it's {}", self.selected_clip_ids.len());
+                                    return;
+                                }
+                                let clip_id = self.selected_clip_ids.iter().next().unwrap();
+
+                                self.job = Some(Job::ResizeCameraClip(ResizeCameraClipJob {
+                                    clip_id: clip_id.clone(),
+                                    click_anchor_in_time: *click_in_time,
+                                    last_mouse_position_in_time: *click_in_time,
+                                    is_moved: false,
+                                    resize_direction: match *sash_direction {
+                                        SashDirection::Left => ResizeDirection::Left,
+                                        SashDirection::Right => ResizeDirection::Right,
+                                    },
+                                }));
+                            }
+                            CameraClipBodyPart::Body => {
+                                self.job = Some(Job::MoveCameraClip(MoveCameraClipJob {
+                                    clip_ids: self.selected_clip_ids.clone(),
+                                    click_anchor_in_time: *click_in_time,
+                                    last_mouse_position_in_time: *click_in_time,
+                                    is_moved: false,
+                                }));
+                            }
+                        }
                     }
                 }
                 EditorEvent::SubtitleClipHeadMouseDownEvent {
@@ -183,6 +207,10 @@ impl namui::Entity for Editor {
                         job.last_mouse_position_in_time = *mouse_position_in_time;
                         job.is_moved = true;
                     }
+                    Some(Job::ResizeCameraClip(ref mut job)) => {
+                        job.last_mouse_position_in_time = *mouse_position_in_time;
+                        job.is_moved = true;
+                    }
                     _ => {}
                 },
                 EditorEvent::CameraTrackBodyRightClickEvent {
@@ -209,7 +237,8 @@ impl namui::Entity for Editor {
                 },
                 NamuiEvent::MouseUp(_) => match self.job {
                     Some(Job::MoveCameraClip(MoveCameraClipJob { is_moved, .. }))
-                    | Some(Job::MoveSubtitleClip(MoveSubtitleClipJob { is_moved, .. })) => {
+                    | Some(Job::MoveSubtitleClip(MoveSubtitleClipJob { is_moved, .. }))
+                    | Some(Job::ResizeCameraClip(ResizeCameraClipJob { is_moved, .. })) => {
                         if is_moved {
                             self.execute_job();
                         } else {

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
@@ -16,7 +16,7 @@ use playback_time_view::*;
 mod time_ruler;
 use time_ruler::*;
 mod play_head;
-mod timeline_body;
+pub mod timeline_body;
 mod timeline_header;
 mod track_header;
 

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
@@ -1,6 +1,6 @@
 use namui::prelude::*;
 use std::sync::Arc;
-mod track_body;
+pub mod track_body;
 use super::TimelineRenderContext;
 use crate::app::{
     editor::events::EditorEvent,

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
@@ -3,6 +3,8 @@ use crate::app::{
     types::*,
 };
 use namui::prelude::*;
+mod sash;
+pub use sash::*;
 
 pub struct CameraClipBody {}
 pub struct CameraClipBodyProps<'a> {
@@ -11,6 +13,12 @@ pub struct CameraClipBodyProps<'a> {
     pub context: &'a TimelineRenderContext<'a>,
 }
 const CAMERA_CLIP_ROUND_RADIUS: f32 = 5.0;
+
+#[derive(Debug, Clone, Copy)]
+pub enum CameraClipBodyPart {
+    Sash(SashDirection),
+    Body,
+}
 
 impl CameraClipBody {
     pub fn render(props: &CameraClipBodyProps) -> RenderingTree {
@@ -27,7 +35,9 @@ impl CameraClipBody {
             width: width - 2.0,
             height: props.track_body_wh.height - 2.0,
         };
-        let is_highlight = props.context.selected_clip_ids.contains(&&props.clip.id);
+        let is_selected = props.context.selected_clip_ids.contains(&&props.clip.id);
+        let is_highlight = is_selected;
+        let is_sashes_showing = is_selected && props.context.selected_clip_ids.len() == 1;
 
         let background = namui::rect(namui::RectParam {
             x: clip_rect.x,
@@ -75,13 +85,47 @@ impl CameraClipBody {
         .attach_event(move |builder| {
             let clip_id = props.clip.id.clone();
             builder.on_mouse_down(move |event| {
+                let clicked_part = if is_sashes_showing {
+                    [SashDirection::Left, SashDirection::Right]
+                        .iter()
+                        .find_map(|direction| {
+                            let sash_rect = get_sash_rect(&clip_rect, *direction);
+                            if sash_rect.is_xy_in(&event.local_xy) {
+                                Some(CameraClipBodyPart::Sash(*direction))
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_else(|| CameraClipBodyPart::Body)
+                } else {
+                    CameraClipBodyPart::Body
+                };
+
                 let event = EditorEvent::CameraClipBodyMouseDownEvent {
                     clip_id: clip_id.clone(),
                     click_in_time: timeline_start_at + PixelSize(event.local_xy.x) * time_per_pixel,
+                    clicked_part,
                 };
                 namui::event::send(event);
             })
         });
+
+        let sashes = if is_sashes_showing {
+            RenderingTree::Children(
+                [SashDirection::Right] // NOTE : No left sash yet. it's intended to be added later if it's really needed.
+                    .iter()
+                    .map(|direction| {
+                        render_sash(&SashBodyProps {
+                            context: props.context,
+                            direction: *direction,
+                            clip_rect: &clip_rect,
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            RenderingTree::Empty
+        };
 
         namui::render![
             background,
@@ -92,6 +136,7 @@ impl CameraClipBody {
                 LudaEditorServerCameraAngleImageLoader {},
             ),
             border,
+            sashes,
         ]
     }
 }

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
@@ -20,6 +20,9 @@ pub enum CameraClipBodyPart {
     Body,
 }
 
+/// NOTE : No left sash yet. it's intended to be added later if it's really needed.
+const AVAILABLE_SASH_DIRECTIONS: [sash::SashDirection; 1] = [SashDirection::Left];
+
 impl CameraClipBody {
     pub fn render(props: &CameraClipBodyProps) -> RenderingTree {
         let timeline_start_at = props.context.start_at;
@@ -86,7 +89,7 @@ impl CameraClipBody {
             let clip_id = props.clip.id.clone();
             builder.on_mouse_down(move |event| {
                 let clicked_part = if is_sashes_showing {
-                    [SashDirection::Left, SashDirection::Right]
+                    AVAILABLE_SASH_DIRECTIONS
                         .iter()
                         .find_map(|direction| {
                             let sash_rect = get_sash_rect(&clip_rect, *direction);
@@ -112,7 +115,7 @@ impl CameraClipBody {
 
         let sashes = if is_sashes_showing {
             RenderingTree::Children(
-                [SashDirection::Right] // NOTE : No left sash yet. it's intended to be added later if it's really needed.
+                AVAILABLE_SASH_DIRECTIONS
                     .iter()
                     .map(|direction| {
                         render_sash(&SashBodyProps {

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
@@ -21,7 +21,7 @@ pub enum CameraClipBodyPart {
 }
 
 /// NOTE : No left sash yet. it's intended to be added later if it's really needed.
-const AVAILABLE_SASH_DIRECTIONS: [sash::SashDirection; 1] = [SashDirection::Left];
+const AVAILABLE_SASH_DIRECTIONS: [sash::SashDirection; 1] = [SashDirection::Right];
 
 impl CameraClipBody {
     pub fn render(props: &CameraClipBodyProps) -> RenderingTree {

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/sash.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/sash.rs
@@ -1,0 +1,45 @@
+use crate::app::{
+    editor::{events::EditorEvent, TimelineRenderContext},
+    types::*,
+};
+use namui::prelude::*;
+
+const SASH_WIDTH: f32 = 15.0;
+pub(super) struct SashBodyProps<'a> {
+    pub context: &'a TimelineRenderContext<'a>,
+    pub direction: SashDirection,
+    pub clip_rect: &'a XywhRect<f32>,
+}
+#[derive(Debug, Clone, Copy)]
+pub enum SashDirection {
+    Left,
+    Right,
+}
+pub(super) fn render_sash(props: &SashBodyProps) -> RenderingTree {
+    let sash_rect = get_sash_rect(&props.clip_rect, props.direction);
+    let path = PathBuilder::new().add_rect(&sash_rect.into_ltrb());
+
+    let paint = PaintBuilder::new()
+        .set_color(Color::from_u8(255, 127, 39, 255))
+        .set_style(PaintStyle::Fill)
+        .set_anti_alias(true);
+
+    namui::path(path, paint)
+}
+
+pub(super) fn get_sash_rect(clip_rect: &XywhRect<f32>, direction: SashDirection) -> XywhRect<f32> {
+    match direction {
+        SashDirection::Left => XywhRect {
+            x: clip_rect.x,
+            y: clip_rect.y,
+            width: SASH_WIDTH,
+            height: clip_rect.height,
+        },
+        SashDirection::Right => XywhRect {
+            x: clip_rect.x + clip_rect.width - SASH_WIDTH,
+            y: clip_rect.y,
+            width: SASH_WIDTH,
+            height: clip_rect.height,
+        },
+    }
+}

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/mod.rs
@@ -5,7 +5,7 @@ use crate::app::{
 };
 use namui::prelude::*;
 use std::collections::LinkedList;
-mod camera_clip_body;
+pub mod camera_clip_body;
 
 pub struct CameraTrackBody {}
 pub struct CameraTrackBodyProps<'a> {
@@ -62,6 +62,11 @@ impl CameraTrackBody {
 
                 move_clip_at_last(&mut track, moving_clip_ids);
 
+                track.clips
+            }
+            Some(Job::ResizeCameraClip(job)) => {
+                let mut track = props.track.clone();
+                job.resize_clip_in_track(&mut track);
                 track.clips
             }
             _ => props.track.clips.clone(),

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/mod.rs
@@ -1,7 +1,7 @@
 use self::camera_track_body::{CameraTrackBody, CameraTrackBodyProps};
 use crate::app::{editor::TimelineRenderContext, types::Track};
 use namui::prelude::*;
-mod camera_track_body;
+pub mod camera_track_body;
 use self::subtitle_track_body::{SubtitleTrackBody, SubtitleTrackBodyProps};
 mod subtitle_track_body;
 

--- a/luda-editor/luda-editor-client/src/app/types/camera_track.rs
+++ b/luda-editor/luda-editor-client/src/app/types/camera_track.rs
@@ -126,6 +126,25 @@ impl CameraTrack {
         }
         chunks
     }
+
+    pub(crate) fn resize_clip_delta(&mut self, clip_id: &str, delta_time: Time) {
+        let mut clips = self.clips.to_vec();
+
+        let clip_index = clips.iter().position(|c| c.id == clip_id).unwrap();
+
+        let clip = clips.remove(clip_index);
+        let new_clip = Arc::new(CameraClip {
+            id: clip.id.clone(),
+            start_at: clip.start_at,
+            end_at: clip.end_at + delta_time,
+            camera_angle: clip.camera_angle.clone(),
+        });
+        clips.insert(clip_index, new_clip);
+
+        push_front_camera_clips(&mut clips);
+
+        self.clips = clips.into();
+    }
 }
 
 fn push_front_camera_clips(clips: &mut [Arc<CameraClip>]) {


### PR DESCRIPTION
# What I did
Did you know that there are no functionality to resize the camera clip until now!?
but, from now on, you can resize the camera clip using sash~
(Actually we already did it on typescript version~)

No left sash. Because if we resize using left sash, it should affect to timeline.start_at, but it seems not easy to do that. By priority, I think it's not necessary to support left sash right now. So I just implemented about right sash.

# Design doc
https://docs.google.com/document/d/1iD2e1NfCoR7sWDg4Z5s-j9247dn8usq2hBA5cn_A7CM/edit#