### PR TITLE
Keep minimum height for text background

### DIFF
--- a/namui/src/namui/render/text.rs
+++ b/namui/src/namui/render/text.rs
@@ -180,7 +180,7 @@ fn draw_background(param: &TextParam, font: &Font) -> RenderingTree {
     let glyphs_top_bottom = get_glyphs_top_bottom(font, &glyph_ids);
 
     let bottom_of_baseline = get_bottom_of_baseline(&param.baseline, &font_metrics);
-    let (height, top) = match glyphs_top_bottom {
+    let (mut height, mut top) = match glyphs_top_bottom {
         Some((top, bottom)) => {
             let height = bottom - top
                 + if let Some(drop_shadow) = param.style.drop_shadow {
@@ -196,6 +196,14 @@ fn draw_background(param: &TextParam, font: &Font) -> RenderingTree {
             param.y + bottom_of_baseline + font_metrics.ascent,
         ),
     };
+
+    let minimum_height = param.font_type.size as f32;
+
+    if height < minimum_height {
+        let delta_height = minimum_height - height;
+        top -= delta_height / 2.0;
+        height = minimum_height;
+    }
 
     let margin = background.margin.unwrap_or(LtrbRect::default());
 


### PR DESCRIPTION
# Why I changed it
Previously, If I tried to draw '...' using namui::text with background, the background's height was same with height of `...`.
Like below!
![image](https://user-images.githubusercontent.com/3580430/153191132-2687f297-ea62-4f05-b0ac-2c62c3475e6d.png)

So I edit to keep minimum height using font size.
Like below!
![image](https://user-images.githubusercontent.com/3580430/153190949-0cafc1a4-5a28-4029-bd62-fd8903ee06da.png)
