### PR TITLE
Exclude crossing clip during select clips at once

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -737,7 +737,7 @@ impl Editor {
                     .partial_cmp(&start_point_to_select),
             ];
 
-            if results.contains(&Some(ordering)) {
+            if results.iter().all(|result| result == &Some(ordering)) {
                 self.selected_clip_ids.insert(clip.get_id().to_string());
             }
         });


### PR DESCRIPTION
If I click one clip, and press Shift+End
![image](https://user-images.githubusercontent.com/3580430/153192627-64fa0bb2-99b3-4940-8d3f-76cc8a1a8255.png)

# Before
![image](https://user-images.githubusercontent.com/3580430/153192678-074fd770-b1c7-49d1-8c07-bc0f50e5c0da.png)

OH NYO~ Why it select the previous clip!?
> Because I made a code like that :(

# How to fix it
![image](https://user-images.githubusercontent.com/3580430/153192738-c2b7c84e-024b-439e-abaf-f2e82b4e8c43.png)

