### PR TITLE
Support click track empty body 

### DIFF
--- a/luda-editor/luda-editor-client/Cargo.toml
+++ b/luda-editor/luda-editor-client/Cargo.toml
@@ -29,6 +29,7 @@ ordered-float = "2.10"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
+mockall = "0.11"
 
 [profile.release]
 lto = true

--- a/luda-editor/luda-editor-client/src/app/editor/events.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/events.rs
@@ -8,11 +8,13 @@ use std::sync::Arc;
 
 pub enum EditorEvent {
     CameraClipBodyMouseDownEvent {
+        mouse_event_id: String,
         clip_id: String,
         click_in_time: Time,
         clicked_part: CameraClipBodyPart,
     },
     SubtitleClipHeadMouseDownEvent {
+        mouse_event_id: String,
         clip_id: String,
         click_in_time: Time,
     },
@@ -52,6 +54,10 @@ pub enum EditorEvent {
         click_position_in_time: Time,
     },
     TimelineBodyMouseMoveEvent {
+        mouse_position_in_time: Time,
+    },
+    TimelineBodyLeftClickEvent {
+        is_mouse_on_clip: bool,
         mouse_position_in_time: Time,
     },
     SequenceUpdateEvent {

--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -64,7 +64,7 @@ impl namui::Entity for Editor {
                     clicked_part,
                     ..
                 } => {
-                    self.on_clip_mouse_down(clip_id);
+                    self.on_clip_mouse_down(clip_id, click_in_time);
 
                     if self.job.is_none() {
                         match clicked_part {
@@ -102,7 +102,7 @@ impl namui::Entity for Editor {
                     click_in_time,
                     ..
                 } => {
-                    self.on_clip_mouse_down(clip_id);
+                    self.on_clip_mouse_down(clip_id, click_in_time);
 
                     if self.job.is_none() {
                         self.job = Some(Job::MoveSubtitleClip(MoveSubtitleClipJob {
@@ -565,7 +565,7 @@ impl Editor {
             }
         }
     }
-    fn on_clip_mouse_down(&mut self, clip_id: &str) {
+    fn on_clip_mouse_down(&mut self, clip_id: &str, click_in_time: &Time) {
         self.clip_id_to_check_as_click = None;
 
         let keyboard_manager = &namui::managers().keyboard_manager;
@@ -579,9 +579,7 @@ impl Editor {
         } else if keyboard_manager.any_code_press(&[namui::Code::ShiftLeft])
             && self.is_clip_in_same_track_with_selected_clips(clip_id)
         {
-            let mut selected_clip_ids = self.get_selected_clip_ids().clone();
-            selected_clip_ids.insert(clip_id.to_string());
-            self.select_all_between_clips(&selected_clip_ids.into_iter().collect::<Vec<_>>());
+            self.select_all_to_time(click_in_time);
         } else if !self.selected_clip_ids.contains(clip_id) {
             self.select_only_this_clip(clip_id);
         } else {

--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -16,7 +16,7 @@ mod clip_editor;
 mod events;
 mod job;
 mod sequence_player;
-pub use sequence_player::{SequencePlayer, SequencePlayerProps};
+pub use sequence_player::{SequencePlay, SequencePlayer, SequencePlayerProps};
 mod history;
 use history::History;
 mod top_bar;
@@ -41,7 +41,7 @@ pub struct Editor {
     clip_editor: Option<ClipEditor>,
     image_filename_objects: Vec<ImageFilenameObject>,
     selected_clip_ids: Arc<BTreeSet<String>>,
-    sequence_player: SequencePlayer,
+    sequence_player: Box<dyn SequencePlay>,
     subtitle_play_duration_measurer: SubtitlePlayDurationMeasurer,
     history: History<Arc<Sequence>>,
     top_bar: TopBar,
@@ -462,10 +462,10 @@ impl Editor {
             job: None,
             clip_editor: None,
             selected_clip_ids: Arc::new(BTreeSet::new()),
-            sequence_player: SequencePlayer::new(
+            sequence_player: Box::new(SequencePlayer::new(
                 sequence.clone(),
                 Box::new(LudaEditorServerCameraAngleImageLoader {}),
-            ),
+            )),
             subtitle_play_duration_measurer: SubtitlePlayDurationMeasurer::new(),
             history: History::new(sequence.clone()),
             top_bar: TopBar::new(),

--- a/luda-editor/luda-editor-client/src/app/editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/mod.rs
@@ -220,6 +220,22 @@ impl namui::Entity for Editor {
                     }
                     _ => {}
                 },
+                EditorEvent::TimelineBodyLeftClickEvent {
+                    is_mouse_on_clip,
+                    mouse_position_in_time,
+                } => {
+                    self.sequence_player.seek(*mouse_position_in_time);
+                    if !is_mouse_on_clip {
+                        let keyboard_manager = &namui::managers().keyboard_manager;
+                        if keyboard_manager.any_code_press(&[namui::Code::ControlLeft]) {
+                            // do nothing please
+                        } else if keyboard_manager.any_code_press(&[namui::Code::ShiftLeft]) {
+                            self.select_all_to_time(mouse_position_in_time);
+                        } else {
+                            self.deselect_all_clips();
+                        }
+                    }
+                }
                 EditorEvent::CameraTrackBodyRightClickEvent {
                     mouse_global_xy,
                     mouse_position_in_time,

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/mod.rs
@@ -25,6 +25,7 @@ pub struct Timeline {
     time_ruler_height: f32,
     pub start_at: Time,
     pub time_per_pixel: TimePerPixel,
+    timeline_body: TimelineBody,
 }
 impl Timeline {
     pub fn new() -> Self {
@@ -33,6 +34,7 @@ impl Timeline {
             time_ruler_height: 20.0,
             time_per_pixel: TimePerPixel::new(Time::from_ms(50.0), PixelSize(1.0)),
             start_at: Time::from_sec(0.0),
+            timeline_body: TimelineBody::new(),
         }
     }
 }
@@ -91,6 +93,8 @@ impl Timeline {
                 _ => {}
             }
         }
+
+        self.timeline_body.update(event);
     }
 
     pub fn render(&self, props: &TimelineProps) -> namui::RenderingTree {

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/camera_clip_body/mod.rs
@@ -108,12 +108,12 @@ impl CameraClipBody {
                     CameraClipBodyPart::Body
                 };
 
-                let event = EditorEvent::CameraClipBodyMouseDownEvent {
+                namui::event::send(EditorEvent::CameraClipBodyMouseDownEvent {
+                    mouse_event_id: event.id.clone(),
                     clip_id: clip_id.clone(),
                     click_in_time: timeline_start_at + PixelSize(event.local_xy.x) * time_per_pixel,
                     clicked_part,
-                };
-                namui::event::send(event);
+                });
             })
         });
 

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
@@ -136,6 +136,7 @@ impl SubtitleClipBody {
                         let clip_id = props.clip.id.clone();
                         builder.on_mouse_down(move |event| {
                             namui::event::send(EditorEvent::SubtitleClipHeadMouseDownEvent {
+                                mouse_event_id: event.id.clone(),
                                 clip_id: clip_id.clone(),
                                 click_in_time: timeline_start_at
                                     + PixelSize(event.local_xy.x + x) * time_per_pixel,

--- a/luda-editor/luda-editor-client/src/app/sequence_list/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/mod.rs
@@ -15,16 +15,12 @@ use super::{
     },
 };
 use crate::app::{
-    editor::SequencePlayerProps,
+    editor::{SequencePlay, SequencePlayerProps},
     sequence_list::{list::render_list, sync_sequences_button::render_sync_sequences_button},
 };
 use luda_editor_rpc::Socket;
 use namui::{render, Entity, Wh, XywhRect};
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 const LIST_WIDTH: f32 = 800.0;
 const BUTTON_HEIGHT: f32 = 36.0;

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -184,6 +184,7 @@ pub enum MouseButton {
 }
 
 pub struct RawMouseEvent {
+    pub id: String,
     pub xy: Xy<f32>,
     pub pressing_buttons: HashSet<MouseButton>,
     pub button: Option<MouseButton>,

--- a/namui/src/namui/manager/web/mouse_manager.rs
+++ b/namui/src/namui/manager/web/mouse_manager.rs
@@ -29,13 +29,20 @@ impl MouseManager {
                 mouse_position: mouse_position.clone(),
                 ..*namui::state()
             });
+            let button = get_button(&event);
             namui::event::send(namui::NamuiEvent::MouseDown(crate::RawMouseEvent {
+                id: format!(
+                    "mousedown-{:?}-{:?}-{}",
+                    button,
+                    crate::now(),
+                    crate::nanoid()
+                ),
                 xy: Xy {
                     x: mouse_position.x as f32,
                     y: mouse_position.y as f32,
                 },
                 pressing_buttons: get_pressing_buttons(&event),
-                button: Some(get_button(&event)),
+                button: Some(button),
             }));
         }) as Box<dyn FnMut(_)>);
 
@@ -58,13 +65,20 @@ impl MouseManager {
                 mouse_position: mouse_position.clone(),
                 ..*namui::state()
             });
+            let button = get_button(&event);
             namui::event::send(namui::NamuiEvent::MouseUp(crate::RawMouseEvent {
+                id: format!(
+                    "mouseup-{:?}-{:?}-{}",
+                    button,
+                    crate::now(),
+                    crate::nanoid()
+                ),
                 xy: Xy {
                     x: mouse_position.x as f32,
                     y: mouse_position.y as f32,
                 },
                 pressing_buttons: get_pressing_buttons(&event),
-                button: Some(get_button(&event)),
+                button: Some(button),
             }));
         }) as Box<dyn FnMut(_)>);
 
@@ -85,6 +99,7 @@ impl MouseManager {
                 ..*namui::state()
             });
             namui::event::send(namui::NamuiEvent::MouseMove(crate::RawMouseEvent {
+                id: format!("mousemove-{:?}-{}", crate::now(), crate::nanoid()),
                 xy: Xy {
                     x: mouse_position.x as f32,
                     y: mouse_position.y as f32,

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -113,6 +113,7 @@ pub async fn start<TProps>(
             }
             Some(NamuiEvent::Wheel(xy)) => {
                 namui_context.rendering_tree.call_wheel_event(&WheelEvent {
+                    id: format!("wheel-{:?}-{}", now(), nanoid()),
                     delta_xy: xy,
                     namui_context: &namui_context,
                 });

--- a/namui/src/namui/render/rendering_tree.rs
+++ b/namui/src/namui/render/rendering_tree.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 #[derive(Clone, Debug)]
 pub struct MouseEvent {
+    pub id: String,
     pub local_xy: Xy<f32>,
     pub global_xy: Xy<f32>,
     pub pressing_buttons: HashSet<MouseButton>,
@@ -16,6 +17,7 @@ pub enum MouseEventType {
     Move,
 }
 pub struct WheelEvent<'a> {
+    pub id: String,
     pub delta_xy: &'a Xy<f32>,
     pub namui_context: &'a NamuiContext,
 }
@@ -331,6 +333,7 @@ impl RenderingTree {
                             .any(|child| child.is_point_in(&xy, matrix))
                         {
                             func(&MouseEvent {
+                                id: raw_mouse_event.id.clone(),
                                 global_xy: raw_mouse_event.xy,
                                 local_xy: matrix.transform_xy(&xy),
                                 pressing_buttons: raw_mouse_event.pressing_buttons.clone(),


### PR DESCRIPTION
There are 4 commits.
- Support id in event (80f7cc6e7f20fd47e83373619c9f2c5e6a79593d)
  - it's to find out if an empty track body is clicked.
- Mock SequncePlayer (47c8ee5c44d38adc7af803797444328218a178b0)
  - To make a mocked editor in test code.
- Handle shift+click with time (d753e17802c01f74d919a4bbf2f611af0607e2d2)
  - Previously we calculated shift+click using clip ids but it wasn't good idea because there are swallowed clips (example : 1.start--2.start---2.end--1.start).
  - I put test codes together.
- Support click track empty body (14a07a1906102978c79c03e62e7854d1db8d2072)
  - Design doc for this commit : https://docs.google.com/document/d/1TwxQNqeW7EIuoxfoUpfA8fPmDXaXAvONKKIHBJQrX6A/edit#