### PR TITLE
Calculate subtitle duration with specific text token

### DIFF
--- a/luda-editor/luda-editor-client/Cargo.toml
+++ b/luda-editor/luda-editor-client/Cargo.toml
@@ -26,6 +26,7 @@ num = "0.4.0"
 once_cell = "1.8.0"
 auto_ops = "0.3"
 ordered-float = "2.10"
+linked-hash-map = { version = "0.5.4", features = ["serde_impl"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/luda-editor/luda-editor-client/src/app/editor/clip_select.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_select.rs
@@ -209,6 +209,7 @@ mod tests {
 
     use super::super::*;
     use super::*;
+    use linked_hash_map::LinkedHashMap;
     use luda_editor_rpc::response_waiter::ResponseWaiter;
     use namui::prelude::*;
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -393,6 +394,9 @@ mod tests {
                     ),
                     subtitle_language_play_duration_per_character_map: HashMap::<_, _>::from_iter(
                         IntoIter::new([(Language::Ko, Time::from_ms(100.0))]),
+                    ),
+                    subtitle_specific_text_token_play_duration_map: LinkedHashMap::from_iter(
+                        IntoIter::new([(format!("..."), Time::from_ms(100.0))]),
                     ),
                     subtitle_character_color_map: HashMap::<_, _>::from_iter(IntoIter::new([(
                         "하연".to_string(),

--- a/luda-editor/luda-editor-client/src/app/types/meta.rs
+++ b/luda-editor/luda-editor-client/src/app/types/meta.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use super::*;
 use async_trait::async_trait;
+use linked_hash_map::LinkedHashMap;
 use luda_editor_rpc::Socket;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen_futures::spawn_local;
@@ -10,6 +11,7 @@ use wasm_bindgen_futures::spawn_local;
 pub struct Meta {
     pub subtitle_language_minimum_play_duration_map: HashMap<Language, Time>,
     pub subtitle_language_play_duration_per_character_map: HashMap<Language, Time>,
+    pub subtitle_specific_text_token_play_duration_map: LinkedHashMap<String, Time>,
     pub subtitle_character_color_map: HashMap<String, Color>,
 }
 

--- a/luda-editor/luda-editor-client/src/app/types/subtitle_play_duration_measure.rs
+++ b/luda-editor/luda-editor-client/src/app/types/subtitle_play_duration_measure.rs
@@ -1,16 +1,30 @@
 use super::meta::Meta;
 use crate::app::types::{Subtitle, Time};
+use linked_hash_map::LinkedHashMap;
 use namui::prelude::*;
 
 const IGNORED_CHARACTERS: &[char] = &[' ', '?', '.', ','];
 pub trait SubtitlePlayDurationMeasure {
     fn get_minimum_play_duration(&self, language: &Language) -> Time;
     fn get_play_duration_per_character(&self, language: &Language) -> Time;
+    fn get_specific_text_token_play_duration_map(&self) -> LinkedHashMap<String, Time>;
     fn get_play_duration(&self, subtitle: &Subtitle, language: &Language) -> Time {
         let minimum_play_duration = self.get_minimum_play_duration(language);
         let play_duration_per_character = self.get_play_duration_per_character(language);
+        let specific_text_token_play_duration_map =
+            self.get_specific_text_token_play_duration_map();
         let text = subtitle.language_text_map.get(language).unwrap();
-        let play_duration = text
+
+        let mut play_duration: Time = Time::from_ms(0.0);
+        let text_without_token: String = specific_text_token_play_duration_map.iter().fold(
+            text.clone(),
+            |text_without_token, (token, duration)| {
+                play_duration += count_token_in_text(&text_without_token, token) * duration;
+                remove_token_from_text(&text_without_token, token)
+            },
+        );
+
+        play_duration += text_without_token
             .chars()
             .filter(|char| !IGNORED_CHARACTERS.contains(char))
             .count()
@@ -21,6 +35,14 @@ pub trait SubtitlePlayDurationMeasure {
             play_duration
         }
     }
+}
+
+fn count_token_in_text(text: &String, token: &String) -> usize {
+    text.matches(token).count()
+}
+
+fn remove_token_from_text(text: &String, token: &String) -> String {
+    text.replace(token, "")
 }
 
 impl SubtitlePlayDurationMeasure for Meta {
@@ -36,5 +58,68 @@ impl SubtitlePlayDurationMeasure for Meta {
             .get(language)
             .unwrap()
             .clone()
+    }
+
+    fn get_specific_text_token_play_duration_map(&self) -> LinkedHashMap<String, Time> {
+        self.subtitle_specific_text_token_play_duration_map.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::types::subtitle_play_duration_measure::{
+        count_token_in_text, remove_token_from_text,
+    };
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn count_no_token() {
+        let text = format!("Now testing");
+        let token = format!("..");
+        assert_eq!(count_token_in_text(&text, &token), 0);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn count_consecutive_tokens() {
+        let text = format!("Now.... testing");
+        let token = format!("..");
+        assert_eq!(count_token_in_text(&text, &token), 2);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn count_end_token() {
+        let text = format!("Now.. testing..");
+        let token = format!("..");
+        assert_eq!(count_token_in_text(&text, &token), 2);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn remove_no_token() {
+        let text = format!("Now testing");
+        let token = format!("..");
+        let expected = format!("Now testing");
+        assert_eq!(remove_token_from_text(&text, &token), expected);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn remove_consecutive_tokens() {
+        let text = format!("Now.... testing");
+        let token = format!("..");
+        let expected = format!("Now testing");
+        assert_eq!(remove_token_from_text(&text, &token), expected);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn remove_end_token() {
+        let text = format!("Now testing");
+        let token = format!("..");
+        let expected = format!("Now testing");
+        assert_eq!(remove_token_from_text(&text, &token), expected);
     }
 }

--- a/luda-editor/resources/meta.json
+++ b/luda-editor/resources/meta.json
@@ -9,6 +9,7 @@
             "milliseconds": 200.0
         }
     },
+    "subtitle_specific_text_token_play_duration_map": {},
     "subtitle_character_color_map": {
         "하연": {
             "r": 255,


### PR DESCRIPTION
# What Happened
https://github.com/NamseEnt/namseent/issues/140#issue-1167625617
> When the subtitle contains `...` or `,`, it should make subtitle duration longer. It should has different duration between `...` and `,`.
> 
> So I got a needs to calculate subtitle duration in different way when it comes to with specific text token.

# What I Did
Add `subtitle_specific_text_token_play_duration_map` to `meta.json`.
You can add token like this
```json
{
    "subtitle_language_minimum_play_duration_map": {..},
    "subtitle_language_play_duration_per_character_map": {..},
    "subtitle_specific_text_token_play_duration_map": {
      "...": {
        "milliseconds": 200.0
      }
    },
    "subtitle_character_color_map": {..}
}
```

Now `subtitle_play_duration_measure` calculates duration like following
1. Iter tokens in `meta.subtitle_specific_text_token_play_duration_map`
  a. Find token in subtitle
  b. Add (token count * token duration) to subtitle duration
  c. Remove token from subtitle
2. Add (remaining subtitle * duration per character) to subtitle duration


Close #140
