### PR TITLE
Install cli on windows

### DIFF
--- a/namui-cli/scripts/install.ps1
+++ b/namui-cli/scripts/install.ps1
@@ -1,0 +1,114 @@
+function Main {
+    $CliRootPath = Get-CliRootPath
+    $CliPath = Get-CliPath -CliRootPath $CliRootPath
+    $CargoBinDirPath = Get-CargoBinDirPath
+
+    Assert-CargoInstalled
+    Assert-WasmPackInstalled
+    Assert-CargoBinDirExist -CargoBinDirPath $CargoBinDirPath
+
+    Build-Cli -CliRootPath $CliRootPath
+
+    New-CliSymlink -CliPath $CliPath -CargoBinDirPath $CargoBinDirPath
+
+    Initialize-Config -CliPath $CliPath -CargoBinDirPath $CargoBinDirPath
+
+    Write-Output "Successfully installed."
+}
+
+# Error Code
+$EXIT_CARGO_NOT_FOUND = 1
+$EXIT_WASM_PACK_NOT_FOUND = 2
+$EXIT_CARGO_BIN_DIR_NOT_FOUND = 3
+$EXIT_CLI_BUILD_FAILED = 4
+$EXIT_SYMLINK_MAKE_FAILED = 5
+$EXIT_CONFIG_INIT_FAILED = 6
+
+function Get-CliRootPath {
+    return (Get-Item $PSScriptRoot).Parent.FullName
+}
+
+function Get-CliPath {
+    param (
+        [string] $CliRootPath
+    )
+
+    return Join-Path -Path $CliRootPath -ChildPath "\target\debug\namui-cli.exe"
+}
+
+function Get-CargoBinDirPath {
+    return "$Env:USERPROFILE\.cargo\bin"
+}
+
+function Assert-CargoInstalled {
+    cargo --version
+    if (!$?) {
+        Write-Output "Cargo command execution failed. Is there a cargo installed?"
+        Exit $EXIT_CARGO_NOT_FOUND
+    }
+}
+
+function Assert-WasmPackInstalled {
+    wasm-pack --version
+    if (!$?) {
+        Write-Output "Wasm-pack command execution failed. Is there a wasm-pack installed?`n`If not, install it with https://rustwasm.github.io/wasm-pack/installer/"
+        Exit $EXIT_WASM_PACK_NOT_FOUND
+    }
+}
+
+function Assert-CargoBinDirExist {
+    param (
+        [string] $CargoBinDirPath
+    )
+
+    Test-Path $CargoBinDirPath
+    if (!$?) {
+        Write-Output "Could not find dir `"$CargoBinDirPath`". Is there a cargo installed?"
+        Exit $EXIT_CARGO_BIN_DIR_NOT_FOUND
+    }
+}
+
+function Build-Cli {
+    param (
+        [string] $CliRootPath
+    )
+
+    Set-Location -Path $CliRootPath
+    cargo build
+    if (!$?) {
+        Write-Output "Cli build failed."
+        Exit $EXIT_CLI_BUILD_FAILED
+    }
+}
+
+function New-CliSymlink {
+    param (
+        [string] $CliPath,
+        [string] $CargoBinDirPath
+    )
+
+    $SymlinkPath = Join-Path -Path $CargoBinDirPath -ChildPath "\namui.exe"
+    New-item -ItemType SymbolicLink -Path $SymlinkPath -Target $CliPath -Force
+    if (!$?) {
+        Write-Output "Link failed."
+        Exit $EXIT_SYMLINK_MAKE_FAILED
+    }
+}
+
+function Initialize-Config {
+    param (
+        [string] $CliPath,
+        [string] $CargoBinDirPath
+    )
+
+    $ConfigJson = @{ exe_path = $CliPath } | ConvertTo-Json
+    $ConfigPath = Join-Path -Path $CargoBinDirPath -ChildPath "\namui.config.json"
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($ConfigPath, $ConfigJson, $Utf8NoBomEncoding)
+    if (!$?) {
+        Write-Output "Config init failed"
+        Exit $EXIT_CONFIG_INIT_FAILED
+    }
+}
+
+Main

--- a/namui-cli/scripts/uninstall.ps1
+++ b/namui-cli/scripts/uninstall.ps1
@@ -1,0 +1,45 @@
+function Main {
+    $CargoBinDirPath = Get-CargoBinDirPath
+
+    Remove-Symlink -CargoBinDirPath $CargoBinDirPath
+
+    Remove-Config -CargoBinDirPath $CargoBinDirPath
+
+    Write-Output "Successfully uninstalled."
+}
+
+# Error Code
+$EXIT_SYMLINK_REMOVE_FAIL = 1
+$EXIT_CONFIG_REMOVE_FAIL = 2
+
+function Get-CargoBinDirPath {
+    return "$Env:USERPROFILE\.cargo\bin"
+}
+
+function Remove-Symlink {
+    param (
+        [string] $CargoBinDirPath
+    )
+
+    $SymlinkPath = Join-Path -Path $CargoBinDirPath -ChildPath "\namui.exe"
+    Remove-Item -Path $SymlinkPath
+    if (!$?) {
+        Write-Output "Could not remove symlink"
+        Exit $EXIT_SYMLINK_REMOVE_FAIL
+    }
+}
+
+function Remove-Config {
+    param (
+        [string] $CargoBinDirPath
+    )
+
+    $ConfigPath = Join-Path -Path $CargoBinDirPath -ChildPath "\namui.config.json"
+    Remove-Item -Path $ConfigPath
+    if (!$?) {
+        Write-Output "Could not remove config"
+        Exit $EXIT_CONFIG_REMOVE_FAIL
+    }
+}
+
+Main


### PR DESCRIPTION
# What I did
## Add install and uninstall script
Add `install.ps1` and `uninstall.ps1` to `namui-cli/scripts`
Install script should be executed with administrative privileges. 
Because of next line
https://github.com/NamseEnt/namseent/pull/145/files#diff-d2d04ddfc0aeb03d7a265cb12c138b5967ac4197cf5cbf48ea4d747f0c701b83R91

Install script does
- Check cargo installed
- Check wasm-pack installed
- Build cli
- Make symlink of namui-cli.exe to cargo bin dir
- Make config file next to symlink

Uninstall script does
- Remove symlink
- Remove config file

## Resolve #144
via making config file
`namui.config.json` contains path of real exe file, not symlink's

Close #144