### PR TITLE
Add dev_wasm_electron procedure

### DIFF
--- a/namui-cli/Cargo.toml
+++ b/namui-cli/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 cli_debug = []
 
 [dependencies]
-clap = "2.34.0"
+clap = { version = "3.1.6", features = ["derive"] }
 futures = "0.3.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.72"
@@ -20,3 +20,4 @@ warp = "0.3.2"
 nanoid = "0.4.0"
 webbrowser = "0.5.5"
 regex = "1.5.4"
+wsl = "0.1.0"

--- a/namui-cli/electron/.gitignore
+++ b/namui-cli/electron/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+package-lock.json
+.wsl-env

--- a/namui-cli/electron/package.json
+++ b/namui-cli/electron/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "namui-cli-electron",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron .",
+    "start:windows": "dotenv -e .wsl-env -- $WINDOWS_ELECTRON_EXE_PATH .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "dotenv-cli": "^5.0.0",
+    "electron": "^17.1.2"
+  }
+}

--- a/namui-cli/electron/package.json
+++ b/namui-cli/electron/package.json
@@ -4,10 +4,11 @@
   "main": "src/main.js",
   "scripts": {
     "start": "electron .",
-    "start:windows": "dotenv -e .wsl-env -- $WINDOWS_ELECTRON_EXE_PATH .",
+    "start:windows": "dotenv -e .wsl-env cross-var %WINDOWS_ELECTRON_EXE_PATH% .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "cross-var": "^1.1.0",
     "dotenv-cli": "^5.0.0",
     "electron": "^17.1.2"
   }

--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -1,0 +1,30 @@
+const { app, BrowserWindow } = require("electron");
+
+const port = parseInt(process.argv[2]);
+if (typeof port !== "number" || isNaN(port)) {
+    console.error("Port not served");
+    process.exit(1);
+}
+
+function createWindow() {
+    const mainWindow = new BrowserWindow({
+        width: 1280,
+        height: 720,
+    });
+    mainWindow.webContents.openDevTools();
+
+    app.getGPUInfo("complete").then((data) => console.log(data));
+    mainWindow.loadURL(`http://localhost:${port}`);
+}
+
+app.whenReady().then(() => {
+    createWindow();
+
+    app.on("activate", function () {
+        if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    });
+});
+
+app.on("window-all-closed", function () {
+    if (process.platform !== "darwin") app.quit();
+});

--- a/namui-cli/scripts/install.sh
+++ b/namui-cli/scripts/install.sh
@@ -1,39 +1,83 @@
-#!/bin/sh
+#!/bin/bash
 
-cargo --version
-if [ $? -ne 0 ]; then
-    echo "Cargo command execution failed. Is there a cargo installed?"
-    exit 4
-fi
+function main() {
+    cli_root_path=$(cd $(dirname $0) && cd .. && pwd -P)
+    cli_path="$cli_root_path/target/debug/namui-cli"
+    cargo_bin_dir_path="$HOME/.cargo/bin"
 
-wasm-pack --version
-if [ $? -ne 0 ]; then
-    echo "Wasm-pack command execution failed. Is there a wasm-pack installed?\nIf not, install it with \"cargo install wasm-pack\"."
-    exit 5
-fi
+    check_cargo_installed
+    check_wasm_pack_installed
+    check_cargo_bin_dir_exist $cargo_bin_dir_path
 
-BIN_DIR="$HOME/.cargo/bin"
-if [ ! -d $BIN_DIR ]; then
-    echo "Could not find dir \"$BIN_DIR\". Is there a cargo installed?"
-    exit 1
-fi
+    build_cli $cli_root_path
 
-ROOT_DIR=$(cd $(dirname $0) && cd .. && pwd -P)
-NAMUI_CLI_PATH="$ROOT_DIR/target/debug/namui-cli"
-if [ ! -e $NAMUI_CLI_PATH ]; then
-    echo "Could not find \"$NAMUI_CLI_PATH\". Running \"cargo build\""
-    $(cd $ROOT_DIR && cargo build)
+    make_cli_symlink $cargo_bin_dir_path $cli_path
+
+    echo "Successfully installed."
+}
+
+# Error Code
+EXIT_CARGO_NOT_FOUND=1
+EXIT_WASM_PACK_NOT_FOUND=2
+EXIT_CARGO_BIN_DIR_NOT_FOUND=3
+EXIT_CLI_BUILD_FAILED=4
+EXIT_SYMLINK_MAKE_FAILED=5
+
+function check_cargo_installed() {
+    cargo --version
+    if [ $? -ne 0 ]; then
+        echo "Cargo command execution failed. Is there a cargo installed?"
+        exit $EXIT_CARGO_NOT_FOUND
+    fi
+}
+
+function check_wasm_pack_installed() {
+    wasm-pack --version
+    if [ $? -ne 0 ]; then
+        echo "Wasm-pack command execution failed. Is there a wasm-pack installed?\nIf not, install it with \"cargo install wasm-pack\"."
+        exit $EXIT_WASM_PACK_NOT_FOUND
+    fi
+}
+
+#######################################
+# Arguments:
+#   cargo_bin_dir_path: string
+#######################################
+function check_cargo_bin_dir_exist() {
+    cargo_bin_dir_path=$1
+    if [ ! -d $cargo_bin_dir_path ]; then
+        echo "Could not find dir \"$cargo_bin_dir_path\". Is there a cargo installed?"
+        exit $EXIT_CARGO_BIN_DIR_NOT_FOUND
+    fi
+}
+
+#######################################
+# Arguments:
+#   cli_root_path: string
+#######################################
+function build_cli() {
+    cli_root_path=$1
+    echo $cli_root_path
+    $(cd $cli_root_path && cargo build)
     if [ $? -ne 0 ]; then
         echo "Build failed."
-        exit 2
+        exit $EXIT_CLI_BUILD_FAILED
     fi
-fi
+}
 
-echo "Making link."
-cd $BIN_DIR && ln -sf $NAMUI_CLI_PATH namui
-if [ $? -ne 0 ]; then
-    echo "Link failed."
-    exit 3
-fi
+#######################################
+# Arguments:
+#   cargo_bin_dir_path: string
+#   cli_path: string
+#######################################
+function make_cli_symlink() {
+    cargo_bin_dir_path=$1
+    cli_path=$2
+    cd $cargo_bin_dir_path && ln -sf $cli_path namui
+    if [ $? -ne 0 ]; then
+        echo "Link failed."
+        exit $EXIT_SYMLINK_MAKE_FAILED
+    fi
+}
 
-echo "Successfully installed."
+main

--- a/namui-cli/scripts/uninstall.sh
+++ b/namui-cli/scripts/uninstall.sh
@@ -6,11 +6,16 @@ function main() {
 
     remove_symlink $symlink_path
 
+    if [ $(is_os_wsl) -eq 1 ]; then
+        remove_electron_on_windows
+    fi
+
     echo "Successfully uninstalled."
 }
 
 # Error Code
 EXIT_SYMLINK_REMOVE_FAIL=1
+ELECTRON_ON_WINDOW_REMOVE_FAILED=2
 
 #######################################
 # Arguments:
@@ -26,6 +31,25 @@ function remove_symlink() {
         fi
     else
         echo "Could not find link \"$symlink_path\". Seems already uninstalled."
+    fi
+}
+
+function is_os_wsl() {
+    # https://github.com/microsoft/WSL/issues/423
+    if [ $(uname -r | sed -n 's/.*\( *Microsoft *\).*/\1/ip') ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+function remove_electron_on_windows() {
+    window_electron_root_path="$(wslpath $(wslvar APPDATA))/namui/electron"
+
+    rm -rf $window_electron_root_path
+    if [ $? -ne 0 ]; then
+        echo "Electron on window remove failed."
+        exit $ELECTRON_ON_WINDOW_REMOVE_FAILED
     fi
 }
 

--- a/namui-cli/scripts/uninstall.sh
+++ b/namui-cli/scripts/uninstall.sh
@@ -1,23 +1,32 @@
-#!/bin/sh
+#!/bin/bash
 
-BIN_DIR="$HOME/.cargo/bin"
-if [ ! -d $BIN_DIR ]; then
-    echo "Could not find dir \"$BIN_DIR\". Is there a cargo installed?"
-    exit 1
-fi
+function main() {
+    cargo_bin_dir_path="$HOME/.cargo/bin"
+    symlink_path="$cargo_bin_dir_path/namui"
 
-NAMUI_LINK_PATH="$BIN_DIR/namui"
+    remove_symlink $symlink_path
 
-if [ ! -e $NAMUI_LINK_PATH ]; then
-    echo "Could not find link \"$NAMUI_LINK_PATH\". Seems already uninstalled."
-    exit 0
-fi
+    echo "Successfully uninstalled."
+}
 
-echo "Deleting link."
-cd $BIN_DIR && rm -f namui
-if [ $? -ne 0 ]; then
-    echo "Delete failed."
-    exit 2
-fi
+# Error Code
+EXIT_SYMLINK_REMOVE_FAIL=1
 
-echo "Successfully uninstalled."
+#######################################
+# Arguments:
+#   symlink_path: string
+#######################################
+function remove_symlink() {
+    symlink_path=$1
+    if [ -e $symlink_path ]; then
+        rm -f $symlink_path
+        if [ $? -ne 0 ]; then
+            echo "Delete failed."
+            exit $EXIT_SYMLINK_REMOVE_FAIL
+        fi
+    else
+        echo "Could not find link \"$symlink_path\". Seems already uninstalled."
+    fi
+}
+
+main

--- a/namui-cli/src/main.rs
+++ b/namui-cli/src/main.rs
@@ -1,17 +1,35 @@
 mod procedures;
 mod services;
 mod util;
-use procedures::dev_wasm_web;
+use procedures::{dev_wasm_electron, dev_wasm_web};
 use std::env::current_dir;
 mod types;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[clap(version)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    DevWasmWeb {},
+    DevWasmElectron {},
+}
 
 #[tokio::main]
 async fn main() {
+    let cli = Cli::parse();
     let manifest_path = current_dir()
         .expect("No current dir found")
         .join("Cargo.toml");
 
-    let result = dev_wasm_web(&manifest_path);
+    let result = match &cli.command {
+        Commands::DevWasmWeb {} => dev_wasm_web(&manifest_path),
+        Commands::DevWasmElectron {} => dev_wasm_electron(&manifest_path),
+    };
 
     match result {
         Ok(_) => {}

--- a/namui-cli/src/procedures/dev_wasm_electron.rs
+++ b/namui-cli/src/procedures/dev_wasm_electron.rs
@@ -1,0 +1,79 @@
+use crate::{
+    debug_println,
+    services::{
+        electron_dev_service::start_electron_dev_service,
+        rust_build_service::{BuildOption, BuildPlatform, BuildResult, RustBuildService},
+        rust_project_watch_service::RustProjectWatchService,
+        wasm_bundle_web_server::WasmBundleWebServer,
+    },
+    util::print_build_result,
+};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+pub fn dev_wasm_electron(manifest_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    const PORT: u16 = 8080;
+    let wasm_bundle_web_server_url = format!("http://localhost:{}", PORT);
+
+    let _ = start_electron_dev_service(&PORT).unwrap();
+    println!("server is running on {}", wasm_bundle_web_server_url);
+
+    let build_dist_path = manifest_path.parent().unwrap().join("pkg");
+    let project_root_path = manifest_path.parent().unwrap().to_path_buf();
+
+    let rust_project_watch_service = Arc::new(RustProjectWatchService::new());
+    let wasm_bundle_web_server = WasmBundleWebServer::start(PORT, &build_dist_path);
+    let rust_build_service = Arc::new(RustBuildService::new());
+
+    tokio::spawn(build(
+        wasm_bundle_web_server.clone(),
+        rust_build_service.clone(),
+        build_dist_path.clone(),
+        project_root_path.clone(),
+    ));
+    rust_project_watch_service.watch(manifest_path, {
+        let wasm_bundle_web_server = wasm_bundle_web_server.clone();
+        let rust_build_service = rust_build_service.clone();
+        let build_dist_path = build_dist_path.clone();
+        let project_root_path = project_root_path.clone();
+        move || {
+            tokio::spawn(build(
+                wasm_bundle_web_server.clone(),
+                rust_build_service.clone(),
+                build_dist_path.clone(),
+                project_root_path.clone(),
+            ));
+        }
+    })?;
+
+    Ok(())
+}
+
+async fn build(
+    wasm_bundle_web_server: Arc<WasmBundleWebServer>,
+    rust_build_service: Arc<RustBuildService>,
+    build_dist_path: PathBuf,
+    project_root_path: PathBuf,
+) {
+    debug_println!("build fn run");
+    match rust_build_service.cancel_and_start_build(&BuildOption {
+        platform: BuildPlatform::WasmElectron,
+        dist_path: build_dist_path.to_path_buf(),
+        project_root_path: project_root_path.to_path_buf(),
+    }) {
+        BuildResult::Canceled => {
+            debug_println!("build canceled");
+        }
+        BuildResult::Successful(cargo_build_result) => {
+            print_build_result(&cargo_build_result.error_messages, &vec![]);
+            wasm_bundle_web_server
+                .on_build_done(&cargo_build_result)
+                .await;
+        }
+        BuildResult::Failed(err) => {
+            eprintln!("failed to build: {}", err);
+        }
+    }
+}

--- a/namui-cli/src/procedures/mod.rs
+++ b/namui-cli/src/procedures/mod.rs
@@ -1,2 +1,4 @@
 pub mod dev_wasm_web;
 pub use dev_wasm_web::*;
+pub mod dev_wasm_electron;
+pub use dev_wasm_electron::*;

--- a/namui-cli/src/services/electron_dev_service.rs
+++ b/namui-cli/src/services/electron_dev_service.rs
@@ -1,0 +1,27 @@
+use crate::util::get_cli_root_path;
+use std::{
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+};
+use wsl::is_wsl;
+
+pub fn start_electron_dev_service(port: &u16) -> Result<Child, String> {
+    Command::new("npm")
+        .current_dir(get_electron_root_path())
+        .args([
+            "run",
+            match is_wsl() {
+                true => "start:windows",
+                false => "start",
+            },
+            port.to_string().as_str(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())
+}
+
+fn get_electron_root_path() -> PathBuf {
+    get_cli_root_path().join("electron")
+}

--- a/namui-cli/src/services/mod.rs
+++ b/namui-cli/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod electron_dev_service;
 pub mod rust_build_service;
 pub mod rust_project_watch_service;
 pub mod wasm_bundle_web_server;

--- a/namui-cli/src/services/rust_build_service.rs
+++ b/namui-cli/src/services/rust_build_service.rs
@@ -32,6 +32,7 @@ pub struct BuildOption {
 #[derive(Clone)]
 pub enum BuildPlatform {
     WasmWeb,
+    WasmElectron,
 }
 
 impl RustBuildService {
@@ -172,7 +173,7 @@ impl CancelableBuilder {
         build_option: &BuildOption,
     ) -> Result<Child, Box<dyn std::error::Error>> {
         match build_option.platform {
-            BuildPlatform::WasmWeb => Ok(Command::new("wasm-pack")
+            BuildPlatform::WasmElectron | BuildPlatform::WasmWeb => Ok(Command::new("wasm-pack")
                 .args([
                     "build",
                     "--target",

--- a/namui-cli/src/services/wasm_bundle_web_server.rs
+++ b/namui-cli/src/services/wasm_bundle_web_server.rs
@@ -1,6 +1,7 @@
 use crate::{
     debug_println,
     types::{ErrorMessage, WebsocketMessage},
+    util::get_cli_root_path,
 };
 use futures::{
     channel::mpsc::{unbounded, UnboundedSender},
@@ -11,7 +12,6 @@ use futures::{
 use nanoid::nanoid;
 use std::{
     collections::HashMap,
-    env::current_exe,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -169,14 +169,6 @@ impl WasmBundleWebServer {
         }
         debug_println!("send_cached_error_messages: sended to {}", id);
     }
-}
-
-fn get_cli_root_path() -> PathBuf {
-    let mut exe_path = current_exe().expect("Current exe path not found.");
-    exe_path.pop();
-    exe_path.pop();
-    exe_path.pop();
-    exe_path
 }
 
 fn get_static_dir() -> PathBuf {

--- a/namui-cli/src/util/get_cli_root_path.rs
+++ b/namui-cli/src/util/get_cli_root_path.rs
@@ -1,0 +1,9 @@
+use std::{env::current_exe, path::PathBuf};
+
+pub fn get_cli_root_path() -> PathBuf {
+    let mut exe_path = current_exe().expect("Current exe path not found.");
+    exe_path.pop();
+    exe_path.pop();
+    exe_path.pop();
+    exe_path
+}

--- a/namui-cli/src/util/mod.rs
+++ b/namui-cli/src/util/mod.rs
@@ -3,3 +3,5 @@ mod debug_println;
 pub use debug_println::*;
 mod print_build_result;
 pub use print_build_result::*;
+mod get_cli_root_path;
+pub use get_cli_root_path::*;


### PR DESCRIPTION
# What I did
- Update install/uninstall script for setup electron
- Add electron sub project
- Add dev_wasm_electron procedure

# What dev_wasm_electron procedure do?
- Run wasm build with `dev` and `wasm-electron` flag
- Run wasm bundle dev server
- Run electron that connects to wasm bundle dev server

# Special behavior in wsl
Running the gpu app on wsl is a nuisance. So we runs `electron.exe` from windows while in wsl.
But if `electron.exe` and dlls are on wsl path, there is a problem that does not work properly.
So in wsl, install script will install electron to windows and `ElectronDevService` uses electron in windows.