### PR TITLE
Fix way to get cargo bin path

### DIFF
--- a/namui-cli/scripts/install.sh
+++ b/namui-cli/scripts/install.sh
@@ -3,7 +3,7 @@
 function main() {
     cli_root_path=$(cd $(dirname $0) && cd .. && pwd -P)
     cli_path="$cli_root_path/target/debug/namui-cli"
-    cargo_bin_dir_path="$HOME/.cargo/bin"
+    cargo_bin_dir_path=$(dirname $(which cargo))
     electron_root_path="$cli_root_path/electron"
 
     check_cargo_installed

--- a/namui-cli/scripts/uninstall.sh
+++ b/namui-cli/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function main() {
-    cargo_bin_dir_path="$HOME/.cargo/bin"
+    cargo_bin_dir_path=$(dirname $(which cargo))
     symlink_path="$cargo_bin_dir_path/namui"
 
     remove_symlink $symlink_path


### PR DESCRIPTION
I found cargo bin doesn't always exist at `$Home/.cargo/bin`. For example, on rust alpine docker, cargo was in `/usr/local/cargo/bin/cargo`.