### PR TITLE
Detect wsl by finding explorer.exe

### DIFF
--- a/namui-cli/scripts/install.sh
+++ b/namui-cli/scripts/install.sh
@@ -118,7 +118,7 @@ function install_electron() {
 
 function is_os_wsl() {
     # https://github.com/microsoft/WSL/issues/423
-    if [ $(uname -r | sed -n 's/.*\( *Microsoft *\).*/\1/ip') ]; then
+    if [ $(which explorer.exe) ]; then
         echo 1
     else
         echo 0


### PR DESCRIPTION
`uname` uses kernel's name. In docker, it's same so if I run docker image in wsl, container also say it's wsl. So I fixed the way to get it's wsl or not by finding explorer.exe.