### PR TITLE
Get bounding box of rendering tree

### DIFF
--- a/namui/src/namui/draw/text.rs
+++ b/namui/src/namui/draw/text.rs
@@ -46,3 +46,38 @@ pub fn get_bottom_of_baseline(baseline: &TextBaseline, font_metrics: &FontMetric
         TextBaseline::Middle => (-font_metrics.ascent - font_metrics.descent) / 2.0,
     }
 }
+impl TextDrawCommand {
+    pub fn get_bounding_box(&self) -> Option<LtrbRect> {
+        if self.text.len() == 0 {
+            return None;
+        }
+
+        let font = &self.font;
+
+        let glyph_ids = font.get_glyph_ids(&self.text);
+
+        let paint = self.paint_builder.build();
+        let glyph_bounds = font.get_glyph_bounds(&glyph_ids, Some(&paint));
+
+        glyph_bounds
+            .iter()
+            .map(|bound| (bound.top, bound.bottom))
+            .reduce(|acc, (top, bottom)| (acc.0.min(top), acc.1.max(bottom)))
+            .and_then(|(top, bottom)| {
+                let widths = font.get_glyph_widths(&glyph_ids, Option::Some(&paint));
+                let width = widths.iter().fold(0.0, |prev, curr| prev + curr);
+                let x_axis_anchor = get_left_in_align(self.x as f32, self.align, width);
+
+                let metrics = font.get_metrics();
+                let y_axis_anchor =
+                    self.y as f32 + get_bottom_of_baseline(&self.baseline, &metrics);
+
+                Some(LtrbRect {
+                    left: x_axis_anchor,
+                    top: top + y_axis_anchor,
+                    right: x_axis_anchor + width,
+                    bottom: bottom + y_axis_anchor,
+                })
+            })
+    }
+}

--- a/namui/src/namui/render/matrix.rs
+++ b/namui/src/namui/render/matrix.rs
@@ -77,6 +77,19 @@ impl Matrix3x3 {
             y: self.values[1][0] * xy.x + self.values[1][1] * xy.y + self.values[1][2],
         }
     }
+
+    pub(crate) fn transform_rect(&self, rect: &crate::LtrbRect) -> crate::LtrbRect {
+        crate::LtrbRect {
+            left: self.values[0][0] * rect.left + self.values[0][1] * rect.top + self.values[0][2],
+            top: self.values[1][0] * rect.left + self.values[1][1] * rect.top + self.values[1][2],
+            right: self.values[0][0] * rect.right
+                + self.values[0][1] * rect.bottom
+                + self.values[0][2],
+            bottom: self.values[1][0] * rect.right
+                + self.values[1][1] * rect.bottom
+                + self.values[1][2],
+        }
+    }
 }
 
 impl std::ops::Mul for Matrix3x3 {

--- a/namui/src/namui/render/rendering_tree.rs
+++ b/namui/src/namui/render/rendering_tree.rs
@@ -379,6 +379,7 @@ impl RenderingTree {
         }
     }
 
+    // NOTE: matrix is reversed to keep xy in same.
     fn is_point_in(&self, xy: &Xy<f32>, matrix: &Matrix3x3) -> bool {
         match self {
             RenderingTree::Children(ref children) => {
@@ -551,8 +552,8 @@ impl RenderingTree {
                 RenderingTree::Special(special) => match special {
                     SpecialRenderingNode::Translate(translate) => {
                         let translation_matrix = Matrix3x3::from_slice(&[
-                            [1.0, 0.0, -translate.x],
-                            [0.0, 1.0, -translate.y],
+                            [1.0, 0.0, translate.x],
+                            [0.0, 1.0, translate.y],
                             [0.0, 0.0, 1.0],
                         ]);
                         let matrix = translation_matrix * matrix;
@@ -629,8 +630,8 @@ impl RenderingTree {
                     }
                     SpecialRenderingNode::Absolute(absolute) => {
                         let matrix = Matrix3x3::from_slice(&[
-                            [1.0, 0.0, -absolute.x],
-                            [0.0, 1.0, -absolute.y],
+                            [1.0, 0.0, absolute.x],
+                            [0.0, 1.0, absolute.y],
                             [0.0, 0.0, 1.0],
                         ]);
                         get_bounding_box_with_matrix_of_rendering_trees(
@@ -639,7 +640,7 @@ impl RenderingTree {
                         )
                     }
                     SpecialRenderingNode::Rotate(rotate) => {
-                        let matrix = matrix * rotate.get_counter_wise_matrix();
+                        let matrix = matrix * rotate.get_matrix();
 
                         get_bounding_box_with_matrix_of_rendering_trees(
                             rotate.rendering_tree.iter(),

--- a/namui/src/namui/render/rendering_tree.rs
+++ b/namui/src/namui/render/rendering_tree.rs
@@ -524,17 +524,166 @@ impl RenderingTree {
         }
         get_xy_with_exit_button(self, id).map(|result| result.xy)
     }
+    pub fn get_bounding_box(&self) -> Option<XywhRect<f32>> {
+        fn get_bounding_box_with_matrix(
+            rendering_tree: &RenderingTree,
+            matrix: &Matrix3x3,
+        ) -> Option<LtrbRect> {
+            fn get_bounding_box_with_matrix_of_rendering_trees<'a>(
+                rendering_trees: impl Iterator<Item = &'a RenderingTree>,
+                matrix: &Matrix3x3,
+            ) -> Option<LtrbRect> {
+                rendering_trees
+                    .map(|child| get_bounding_box_with_matrix(&child, &matrix))
+                    .filter_map(|bounding_box| bounding_box)
+                    .reduce(|acc, bounding_box| {
+                        LtrbRect::get_minimum_rectangle_containing(&acc, &bounding_box)
+                    })
+            }
+
+            match rendering_tree {
+                RenderingTree::Children(ref children) => {
+                    get_bounding_box_with_matrix_of_rendering_trees(children.iter(), matrix)
+                }
+                RenderingTree::Node(rendering_data) => rendering_data
+                    .get_bounding_box()
+                    .map(|bounding_box| matrix.transform_rect(&bounding_box)),
+                RenderingTree::Special(special) => match special {
+                    SpecialRenderingNode::Translate(translate) => {
+                        let translation_matrix = Matrix3x3::from_slice(&[
+                            [1.0, 0.0, -translate.x],
+                            [0.0, 1.0, -translate.y],
+                            [0.0, 0.0, 1.0],
+                        ]);
+                        let matrix = translation_matrix * matrix;
+                        get_bounding_box_with_matrix_of_rendering_trees(
+                            translate.rendering_tree.iter(),
+                            &matrix,
+                        )
+                    }
+                    SpecialRenderingNode::Clip(clip) => {
+                        get_bounding_box_with_matrix_of_rendering_trees(
+                            clip.rendering_tree.iter(),
+                            &matrix,
+                        )
+                        .and_then(|bounding_box| {
+                            let path = clip.path_builder.build();
+
+                            let clip_bounding_box = path.get_bounding_box();
+
+                            match clip.clip_op {
+                                ClipOp::Intersect => {
+                                    clip_bounding_box.and_then(|clip_bounding_box| {
+                                        bounding_box.intersect(&clip_bounding_box)
+                                    })
+                                }
+                                ClipOp::Difference => match clip_bounding_box {
+                                    Some(clip_bounding_box) => {
+                                        if bounding_box == clip_bounding_box {
+                                            return None;
+                                        }
+
+                                        let xs = [
+                                            bounding_box.left,
+                                            bounding_box.right,
+                                            clip_bounding_box.left,
+                                            clip_bounding_box.right,
+                                        ];
+                                        let ys = [
+                                            bounding_box.top,
+                                            bounding_box.bottom,
+                                            clip_bounding_box.top,
+                                            clip_bounding_box.bottom,
+                                        ];
+
+                                        let sixteen_xys = xs
+                                            .iter()
+                                            .zip(ys.iter())
+                                            .map(|(x, y)| Xy { x: *x, y: *y });
+
+                                        let difference_area_xys = sixteen_xys.filter(|xy| {
+                                            (clip_bounding_box.is_xy_outside(&xy)
+                                                || clip_bounding_box.is_xy_on_border(&xy))
+                                                && !bounding_box.is_xy_outside(&xy)
+                                        });
+
+                                        difference_area_xys.fold(None, |acc, xy| match acc {
+                                            Some(rect) => Some(LtrbRect {
+                                                left: rect.left.min(xy.x),
+                                                top: rect.top.min(xy.y),
+                                                right: rect.right.max(xy.x),
+                                                bottom: rect.bottom.max(xy.y),
+                                            }),
+                                            None => Some(LtrbRect {
+                                                left: xy.x,
+                                                top: xy.y,
+                                                right: xy.x,
+                                                bottom: xy.y,
+                                            }),
+                                        })
+                                    }
+                                    None => Some(bounding_box),
+                                },
+                            }
+                        })
+                    }
+                    SpecialRenderingNode::Absolute(absolute) => {
+                        let matrix = Matrix3x3::from_slice(&[
+                            [1.0, 0.0, -absolute.x],
+                            [0.0, 1.0, -absolute.y],
+                            [0.0, 0.0, 1.0],
+                        ]);
+                        get_bounding_box_with_matrix_of_rendering_trees(
+                            absolute.rendering_tree.iter(),
+                            &matrix,
+                        )
+                    }
+                    SpecialRenderingNode::Rotate(rotate) => {
+                        let matrix = matrix * rotate.get_counter_wise_matrix();
+
+                        get_bounding_box_with_matrix_of_rendering_trees(
+                            rotate.rendering_tree.iter(),
+                            &matrix,
+                        )
+                    }
+                    _ => get_bounding_box_with_matrix_of_rendering_trees(
+                        special.get_children().iter(),
+                        &matrix,
+                    ),
+                },
+                RenderingTree::Empty => None,
+            }
+        }
+
+        get_bounding_box_with_matrix(&self, &Matrix3x3::identity()).and_then(|bounding_box| {
+            Some(XywhRect {
+                x: bounding_box.left,
+                y: bounding_box.top,
+                width: bounding_box.right - bounding_box.left,
+                height: bounding_box.bottom - bounding_box.top,
+            })
+        })
+    }
 }
 
 impl RenderingData {
     fn is_inside(&self, local_xy: &Xy<f32>) -> bool {
         self.draw_calls.iter().any(|draw_call| {
-            // TODO : Handle drawCall.clip
             draw_call
                 .commands
                 .iter()
                 .any(|draw_command| draw_command.is_inside(local_xy))
         })
+    }
+
+    fn get_bounding_box(&self) -> Option<LtrbRect> {
+        self.draw_calls
+            .iter()
+            .map(|draw_call| draw_call.get_bounding_box())
+            .filter_map(|bounding_box| bounding_box)
+            .reduce(|acc, bounding_box| {
+                LtrbRect::get_minimum_rectangle_containing(&acc, &bounding_box)
+            })
     }
 }
 

--- a/namui/src/namui/skia/base/path_builder.rs
+++ b/namui/src/namui/skia/base/path_builder.rs
@@ -50,7 +50,7 @@ impl PathBuilder {
     }
     pub fn stroke(&mut self, options: StrokeOptions) -> Result<(), ()> {
         self.commands.push(PathCommand::Stroke(options));
-        Ok(())
+        Ok(()) // TODO: This is false Ok. Make it sure with stroke execution.
     }
     pub fn move_to(mut self, x: f32, y: f32) -> Self {
         self.commands.push(PathCommand::MoveTo(Xy { x, y }));

--- a/namui/src/namui/skia/types.rs
+++ b/namui/src/namui/skia/types.rs
@@ -23,6 +23,43 @@ impl LtrbRect {
             y: (self.top + self.bottom) / 2.0,
         }
     }
+
+    pub fn intersect(&self, other: &LtrbRect) -> Option<LtrbRect> {
+        let is_intersect = self.left <= other.right
+            && self.right >= other.left
+            && self.top >= other.bottom
+            && self.bottom <= other.top;
+
+        is_intersect.then(|| LtrbRect {
+            left: self.left.max(other.left),
+            top: self.top.max(other.top),
+            right: self.right.min(other.right),
+            bottom: self.bottom.min(other.bottom),
+        })
+    }
+
+    pub fn is_xy_outside(&self, xy: &Xy<f32>) -> bool {
+        xy.x < self.left || xy.x > self.right || xy.y < self.top || xy.y > self.bottom
+    }
+
+    pub fn is_xy_on_border(&self, xy: &Xy<f32>) -> bool {
+        ((xy.x == self.left || xy.x == self.right) && (self.top <= xy.y && xy.y <= self.bottom))
+            || ((xy.y == self.top || xy.y == self.bottom)
+                && (self.left <= xy.x && xy.x <= self.right))
+    }
+
+    pub fn is_xy_inside(&self, xy: &Xy<f32>) -> bool {
+        self.left <= xy.x && xy.x <= self.right && self.top <= xy.y && xy.y <= self.bottom
+    }
+
+    pub fn get_minimum_rectangle_containing(a: &LtrbRect, b: &LtrbRect) -> LtrbRect {
+        LtrbRect {
+            left: a.left.min(b.left),
+            top: a.top.min(b.top),
+            right: a.right.max(b.right),
+            bottom: a.bottom.max(b.bottom),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/namui/src/namui/skia/web/canvas_kit/path.rs
+++ b/namui/src/namui/skia/web/canvas_kit/path.rs
@@ -264,15 +264,15 @@ extern "C" {
     // #[wasm_bindgen(method)]
     // pub fn equals(this: &CanvasKitPath, other: Path) -> bool;
 
-    // ///
-    // /// Returns minimum and maximum axes values of Point array.
-    // /// Returns (0, 0, 0, 0) if Path contains no points. Returned bounds width and height may
-    // /// be larger or smaller than area affected when Path is drawn.
-    // /// @param outputArray - if provided, the bounding box will be copied into this array instead of
-    // ///                      allocating a new one.
-    // ///
-    // #[wasm_bindgen(method)]
-    // pub fn getBounds(this: &CanvasKitPath, outputArray: Option<Rect) -> Rect;
+    ///
+    /// Returns minimum and maximum axes values of Point array.
+    /// Returns (0, 0, 0, 0) if Path contains no points. Returned bounds width and height may
+    /// be larger or smaller than area affected when Path is drawn.
+    /// @param outputArray - if provided, the bounding box will be copied into this array instead of
+    ///                      allocating a new one.
+    ///
+    #[wasm_bindgen(method)]
+    pub fn getBounds(this: &CanvasKitPath) -> Box<[f32]>;
 
     // ///
     // /// Return the FillType for this path.

--- a/namui/src/namui/skia/web/font.rs
+++ b/namui/src/namui/skia/web/font.rs
@@ -48,11 +48,11 @@ impl Font {
         paint: Option<&Paint>,
     ) -> Vec<LtrbRect> {
         let canvas_kit_font = &self.0;
-        let boundItems = canvas_kit_font
+        let bound_items = canvas_kit_font
             .getGlyphBounds(glyph_ids, paint.map(|p| &p.0))
             .to_vec();
 
-        let mut iter = boundItems.iter().peekable();
+        let mut iter = bound_items.iter().peekable();
         let mut bounds = Vec::new();
 
         while iter.peek().is_some() {

--- a/namui/src/namui/skia/web/path.rs
+++ b/namui/src/namui/skia/web/path.rs
@@ -34,6 +34,19 @@ impl Path {
     pub fn contains(&self, xy: &Xy<f32>) -> bool {
         self.canvas_kit_path.contains(xy.x, xy.y)
     }
+    pub fn get_bounding_box(&self) -> Option<LtrbRect> {
+        let bounds = self.canvas_kit_path.getBounds();
+        if bounds[0] == 0.0 && bounds[1] == 0.0 && bounds[2] == 0.0 && bounds[3] == 0.0 {
+            None
+        } else {
+            Some(LtrbRect {
+                left: bounds[0],
+                top: bounds[1],
+                right: bounds[2],
+                bottom: bounds[3],
+            })
+        }
+    }
 
     pub(crate) fn add_rect(self, ltrb_rect: &LtrbRect) -> Self {
         self.canvas_kit_path.addRect(


### PR DESCRIPTION
# Demo
## Text bounding box
![image](https://user-images.githubusercontent.com/3580430/167788922-5e2f9f2b-4358-425d-b8ae-1667314a0134.png)
![image](https://user-images.githubusercontent.com/3580430/167788983-7d97a474-81a4-4924-8e2a-88f2c58bd0f3.png)
![Image from iOS](https://user-images.githubusercontent.com/3580430/167789057-21554445-a6e6-4109-8a8f-9542a1c8eaa7.jpg)

## Rendering Tree test
![image](https://user-images.githubusercontent.com/3580430/167790842-d061db70-869a-4153-8441-5c533560957e.png)
![image](https://user-images.githubusercontent.com/3580430/167790878-bc8681b1-64ee-46c8-91be-33a80b8017b9.png)


# What I did
- Implement getting bounding box of rendering tree, rendering data, draw command!
- Use bounding box to check mouse is in text or not.