### PR TITLE
Fallback emoji font

### DIFF
--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -6,6 +6,7 @@ use crate::Code;
 use serde::{Deserialize, Serialize};
 use serde_repr::*;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use strum_macros::EnumIter;
 mod xy;
@@ -26,6 +27,7 @@ pub struct NamuiContext {
     pub(crate) fps_info: FpsInfo,
     pub(crate) rendering_tree: RenderingTree,
     pub(crate) event_receiver: EventReceiver,
+    pub(crate) fallback_font_typefaces: Vec<Arc<Typeface>>,
 }
 impl NamuiContext {
     pub fn get_rendering_tree_xy(&self, id: &str) -> Option<Xy<f32>> {

--- a/namui/src/namui/draw/text.rs
+++ b/namui/src/namui/draw/text.rs
@@ -1,36 +1,135 @@
-use std::borrow::Borrow;
-
-use crate::namui::{self, skia::*, NamuiContext};
-
 use super::{TextAlign, TextBaseline, TextDrawCommand};
+use crate::namui::{skia::*, NamuiContext};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 pub fn draw_text(namui_context: &NamuiContext, command: &TextDrawCommand) {
     if command.text.len() == 0 {
         return;
     }
 
-    let font = &command.font;
-
-    let glyph_ids = font.get_glyph_ids(&command.text);
-
     let paint = command.paint_builder.build();
 
-    let widths = font.get_glyph_widths(&glyph_ids, Option::Some(&paint));
+    let fonts = std::iter::once(command.font.clone()).chain(
+        std::iter::once_with(|| get_fallback_fonts(namui_context, command.font.size)).flatten(),
+    );
 
-    let width = widths.iter().fold(0.0, |prev, curr| prev + curr);
+    let glyph_groups = get_glyph_groups(&command.text, fonts, &paint);
 
-    let metrics = font.get_metrics();
+    let total_width = glyph_groups.iter().map(|group| group.width).sum();
 
-    let bottom = command.y as f32 + get_bottom_of_baseline(&command.baseline, &metrics);
+    let left = get_left_in_align(command.x as f32, command.align, total_width);
 
-    let left = get_left_in_align(command.x as f32, command.align, width);
+    let mut bottom_of_fonts: HashMap<String, f32> = HashMap::new();
 
-    let text_blob = TextBlob::from_text(&command.text, font.borrow());
+    let mut x = left;
 
-    namui_context
-        .surface
-        .canvas()
-        .draw_text_blob(&text_blob, left, bottom, &paint);
+    for GlyphGroup {
+        glyph_ids,
+        width,
+        end_index: _,
+        font,
+    } in glyph_groups
+    {
+        let bottom = bottom_of_fonts
+            .get(&font.id)
+            .map(|bottom| bottom + font.size as f32)
+            .unwrap_or_else(|| {
+                let metrics = font.get_metrics();
+                let bottom = command.y as f32 + get_bottom_of_baseline(&command.baseline, &metrics);
+                bottom_of_fonts.insert(font.id.clone(), bottom);
+                bottom
+            });
+
+        let text_blob = TextBlob::from_glyph_ids(&glyph_ids, &font);
+
+        namui_context
+            .surface
+            .canvas()
+            .draw_text_blob(&text_blob, x, bottom, &paint);
+
+        x += width;
+    }
+}
+
+#[derive(Debug)]
+struct GlyphGroup {
+    glyph_ids: Vec<u16>,
+    end_index: usize,
+    width: f32,
+    font: Arc<Font>,
+}
+fn get_glyph_groups(
+    text: &str,
+    fonts: impl Iterator<Item = Arc<Font>>,
+    paint: &Arc<Paint>,
+) -> Vec<GlyphGroup> {
+    let mut groups: Vec<GlyphGroup> = vec![];
+    let mut non_calculated_char_and_indexes: Vec<(char, usize)> = text
+        .chars()
+        .enumerate()
+        .map(|(index, char)| (char, index))
+        .collect();
+    let mut fonts = fonts.peekable();
+
+    while !non_calculated_char_and_indexes.is_empty() && fonts.peek().is_some() {
+        let font = fonts.next().unwrap();
+
+        let text = non_calculated_char_and_indexes
+            .iter()
+            .map(|(char, _)| char)
+            .collect::<String>();
+
+        let glyph_ids = font.get_glyph_ids(&text);
+
+        let mut available_glyph_id_and_indexes = vec![];
+        for (index, glyph_id) in glyph_ids.iter().enumerate() {
+            if *glyph_id != 0 {
+                available_glyph_id_and_indexes.push((*glyph_id, index));
+                non_calculated_char_and_indexes.retain(|(_, index2)| index != *index2);
+            }
+        }
+
+        if available_glyph_id_and_indexes.is_empty() {
+            continue;
+        }
+
+        let available_glyph_id_and_index_and_width: Vec<(u16, usize, f32)> = {
+            let available_glyph_ids: Vec<_> = available_glyph_id_and_indexes
+                .iter()
+                .map(|(glyph_id, _)| *glyph_id)
+                .collect();
+
+            let widths = font.get_glyph_widths(&available_glyph_ids, Option::Some(paint));
+
+            widths
+                .into_iter()
+                .zip(available_glyph_id_and_indexes.into_iter())
+                .map(|(width, (glyph_id, index))| (glyph_id, index, width))
+                .collect()
+        };
+
+        for (glyph_id, index, width) in available_glyph_id_and_index_and_width {
+            if let Some(last_group) = groups.last_mut() {
+                if last_group.end_index + 1 == index {
+                    last_group.glyph_ids.push(glyph_id);
+                    last_group.width += width;
+                    last_group.end_index = index;
+                    continue;
+                }
+            }
+            groups.push(GlyphGroup {
+                glyph_ids: vec![glyph_id],
+                end_index: index,
+                width,
+                font: font.clone(),
+            });
+        }
+    }
+    groups.sort_by(|a, b| a.end_index.cmp(&b.end_index));
+    groups
 }
 pub fn get_left_in_align(x: f32, align: TextAlign, width: f32) -> f32 {
     match align {
@@ -45,6 +144,18 @@ pub fn get_bottom_of_baseline(baseline: &TextBaseline, font_metrics: &FontMetric
         TextBaseline::Bottom => -font_metrics.descent,
         TextBaseline::Middle => (-font_metrics.ascent - font_metrics.descent) / 2.0,
     }
+}
+fn get_fallback_fonts(namui_context: &NamuiContext, font_size: i16) -> VecDeque<Arc<Font>> {
+    let mut managers = crate::managers();
+    namui_context
+        .fallback_font_typefaces
+        .iter()
+        .map(|typeface| {
+            managers
+                .font_manager
+                .get_font_of_typeface(typeface.clone(), font_size)
+        })
+        .collect()
 }
 impl TextDrawCommand {
     pub fn get_bounding_box(&self) -> Option<LtrbRect> {

--- a/namui/src/namui/manager/common/font_manager.rs
+++ b/namui/src/namui/manager/common/font_manager.rs
@@ -1,34 +1,50 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::namui::{manager::TypefaceManager, skia::Font, FontType, TypefaceType};
+use crate::{
+    namui::{manager::TypefaceManager, skia::Font, FontType, TypefaceType},
+    Typeface,
+};
 
 pub struct FontManager {
-    fonts: HashMap<FontType, Arc<Font>>,
+    font_type_fonts: HashMap<FontType, Arc<Font>>,
+    typeface_fonts: HashMap<String, Arc<Font>>,
     pub typeface_manager: TypefaceManager,
 }
 
 impl FontManager {
     pub fn new() -> Self {
         Self {
-            fonts: HashMap::new(),
+            font_type_fonts: HashMap::new(),
+            typeface_fonts: HashMap::new(),
             typeface_manager: TypefaceManager::new(),
         }
     }
     pub fn get_font(&mut self, font_type: &FontType) -> Option<Arc<Font>> {
-        let font = self.fonts.get(font_type);
+        let font = self.font_type_fonts.get(font_type);
         match font {
             Some(font) => Some(font.clone()),
-            None => match self.create_font(font_type) {
+            None => match self.create_font_from_font_type(font_type) {
                 Ok(font) => {
-                    let font = Arc::new(font);
-                    self.fonts.insert(font_type.clone(), font.clone());
+                    self.font_type_fonts.insert(font_type.clone(), font.clone());
                     Some(font)
                 }
                 Err(_) => None,
             },
         }
     }
-    fn create_font(&self, font_type: &FontType) -> Result<Font, String> {
+    pub fn get_font_of_typeface(&mut self, typeface: Arc<Typeface>, font_size: i16) -> Arc<Font> {
+        let key = Font::generate_id(&typeface, font_size);
+        let font = self.typeface_fonts.get(&key);
+        match font {
+            Some(font) => font.clone(),
+            None => {
+                let font = Self::crate_font(&typeface, font_size);
+                self.typeface_fonts.insert(key, font.clone());
+                font
+            }
+        }
+    }
+    fn create_font_from_font_type(&self, font_type: &FontType) -> Result<Arc<Font>, String> {
         let typeface_type = TypefaceType {
             font_weight: font_type.font_weight,
             language: font_type.language,
@@ -36,11 +52,11 @@ impl FontManager {
         };
         let typeface = self.typeface_manager.get_typeface(&typeface_type);
         match typeface {
-            Some(typeface) => {
-                let font = Font::new(&typeface, &font_type.size);
-                Ok(font)
-            }
+            Some(typeface) => Ok(Self::crate_font(&typeface, font_type.size)),
             None => Err(format!("Could not find typeface for {:?}", font_type)),
         }
+    }
+    fn crate_font(typeface: &Typeface, font_size: i16) -> Arc<Font> {
+        Arc::new(Font::new(typeface, font_size))
     }
 }

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -61,7 +61,7 @@ pub async fn start<TProps>(
     state: &mut dyn Entity<Props = TProps>,
     props: &TProps,
 ) {
-    init_font().await;
+    init_font(&mut namui_context).await;
 
     namui_context.rendering_tree = state.render(props);
 
@@ -149,11 +149,11 @@ fn set_mouse_cursor(rendering_tree: &RenderingTree) {
     mouse_manager.set_mouse_cursor(cursor);
 }
 
-async fn init_font() {
+async fn init_font(namui_context: &mut NamuiContext) {
     let font_manager = &mut *managers().font_manager;
     let typeface_manager = &mut font_manager.typeface_manager;
 
-    match load_sans_typeface_of_all_languages(typeface_manager).await {
+    match load_all_fonts(namui_context, typeface_manager).await {
         Ok(()) => {
             log("Font loaded".to_string());
         }

--- a/namui/src/namui/namui_mock/mod.rs
+++ b/namui/src/namui/namui_mock/mod.rs
@@ -77,6 +77,7 @@ impl NamuiImpl for Namui {
             },
             rendering_tree: RenderingTree::Empty,
             event_receiver: crate::event::init(),
+            fallback_font_typefaces: Vec::new(),
         }
     }
 

--- a/namui/src/namui/namui_web/mod.rs
+++ b/namui/src/namui/namui_web/mod.rs
@@ -66,6 +66,7 @@ impl NamuiImpl for Namui {
             },
             rendering_tree: RenderingTree::Empty,
             event_receiver: crate::event::init(),
+            fallback_font_typefaces: Vec::new(),
         }
     }
 

--- a/namui/src/namui/skia/web/canvas.rs
+++ b/namui/src/namui/skia/web/canvas.rs
@@ -97,7 +97,8 @@ impl Canvas {
     }
 
     pub(crate) fn draw_text(&self, string: &str, x: f32, y: f32, paint: &Paint, font: &Font) {
-        self.0.drawText(string, x, y, &paint.0, &font.0);
+        self.0
+            .drawText(string, x, y, &paint.0, &font.canvas_kit_font);
     }
     pub(crate) fn rotate(&self, radian: f32) {
         self.0

--- a/namui/src/namui/skia/web/canvas_kit/text_blob_factory.rs
+++ b/namui/src/namui/skia/web/canvas_kit/text_blob_factory.rs
@@ -1,19 +1,24 @@
 use super::*;
+use crate::namui::skia::GlyphIds;
 
 #[wasm_bindgen]
 extern "C" {
     pub type TextBlobFactory;
-    // ///
-    // /// Return a TextBlob with a single run of text.
-    // ///
-    // /// It does not perform typeface fallback for characters not found in the Typeface.
-    // /// It does not perform kerning or other complex shaping; glyphs are positioned based on their
-    // /// default advances.
-    // /// @param glyphs - if using Malloc'd array, be sure to use CanvasKit.MallocGlyphIDs().
-    // /// @param font
-    // ///
-    // #[wasm_bindgen(structural, method)]
-    // pub fn MakeFromGlyphs(this: &TextBlobFactory, glyphs: InputGlyphIDArray, font: Font) -> CanvasKitTextBlob;
+    ///
+    /// Return a TextBlob with a single run of text.
+    ///
+    /// It does not perform typeface fallback for characters not found in the Typeface.
+    /// It does not perform kerning or other complex shaping; glyphs are positioned based on their
+    /// default advances.
+    /// @param glyphs - if using Malloc'd array, be sure to use CanvasKit.MallocGlyphIDs().
+    /// @param font
+    ///
+    #[wasm_bindgen(structural, method)]
+    pub fn MakeFromGlyphs(
+        this: &TextBlobFactory,
+        glyphs: &GlyphIds,
+        font: &CanvasKitFont,
+    ) -> CanvasKitTextBlob;
 
     // ///
     // /// Returns a TextBlob built from a single run of text with rotation, scale, and translations.

--- a/namui/src/namui/skia/web/font.rs
+++ b/namui/src/namui/skia/web/font.rs
@@ -1,32 +1,37 @@
-use std::str::FromStr;
-
-use serde::{Deserialize, Serialize};
-
-use crate::namui;
-
 pub use super::base::*;
 use super::*;
 
 unsafe impl Sync for CanvasKitFont {}
 unsafe impl Send for CanvasKitFont {}
-pub struct Font(pub Box<CanvasKitFont>);
+pub struct Font {
+    pub(crate) id: String,
+    pub(crate) canvas_kit_font: CanvasKitFont,
+    pub(crate) size: i16,
+}
 
 impl Font {
-    pub fn new(typeface: &Typeface, size: &i16) -> Self {
-        Font(Box::new(CanvasKitFont::new(&typeface.0, size.clone())))
+    pub fn generate_id(typeface: &Typeface, size: i16) -> String {
+        format!("{}-{}", typeface.id, size)
+    }
+    pub fn new(typeface: &Typeface, size: i16) -> Self {
+        Font {
+            id: Self::generate_id(typeface, size),
+            canvas_kit_font: CanvasKitFont::new(&typeface.canvas_kit_typeface, size),
+            size,
+        }
     }
     pub fn get_glyph_ids(&self, text: &str) -> Box<GlyphIds> {
-        let canvas_kit_font = &self.0;
+        let canvas_kit_font = &self.canvas_kit_font;
         canvas_kit_font.getGlyphIDs(text)
     }
     pub(crate) fn get_glyph_widths(&self, glyph_ids: &GlyphIds, paint: Option<&Paint>) -> Vec<f32> {
-        let canvas_kit_font = &self.0;
+        let canvas_kit_font = &self.canvas_kit_font;
         let widths = canvas_kit_font.getGlyphWidths(glyph_ids, paint.map(|p| &p.0));
         widths.to_vec()
     }
 
     pub fn get_metrics(&self) -> FontMetrics {
-        let canvas_kit_font = &self.0;
+        let canvas_kit_font = &self.canvas_kit_font;
         let canvas_kit_font_metrics = &canvas_kit_font.getMetrics();
         let bounds = canvas_kit_font_metrics.bounds().map(|numbers| LtrbRect {
             left: numbers[0],
@@ -47,7 +52,7 @@ impl Font {
         glyph_ids: &GlyphIds,
         paint: Option<&Paint>,
     ) -> Vec<LtrbRect> {
-        let canvas_kit_font = &self.0;
+        let canvas_kit_font = &self.canvas_kit_font;
         let bound_items = canvas_kit_font
             .getGlyphBounds(glyph_ids, paint.map(|p| &p.0))
             .to_vec();
@@ -70,7 +75,7 @@ impl Font {
 
 impl Drop for Font {
     fn drop(&mut self) {
-        self.0.delete();
+        self.canvas_kit_font.delete();
     }
 }
 

--- a/namui/src/namui/skia/web/text_blob.rs
+++ b/namui/src/namui/skia/web/text_blob.rs
@@ -1,5 +1,3 @@
-use crate::namui;
-
 use super::*;
 
 unsafe impl Sync for CanvasKitTextBlob {}
@@ -7,7 +5,18 @@ unsafe impl Send for CanvasKitTextBlob {}
 pub struct TextBlob(pub CanvasKitTextBlob);
 impl TextBlob {
     pub fn from_text(string: &str, font: &Font) -> Self {
-        TextBlob(canvas_kit().TextBlob().MakeFromText(string, &font.0))
+        TextBlob(
+            canvas_kit()
+                .TextBlob()
+                .MakeFromText(string, &font.canvas_kit_font),
+        )
+    }
+    pub fn from_glyph_ids(glyph_ids: &GlyphIds, font: &Font) -> Self {
+        TextBlob(
+            canvas_kit()
+                .TextBlob()
+                .MakeFromGlyphs(glyph_ids, &font.canvas_kit_font),
+        )
     }
 }
 impl Drop for TextBlob {


### PR DESCRIPTION
Yes, namui support emoji using [NotoColorEmoji](https://github.com/googlefonts/noto-emoji)!

![image](https://user-images.githubusercontent.com/3580430/169149811-e65273ff-ec7a-4d26-8531-f65d5f122211.png)

# How it works
1. namui try to draw text with font that user set when they call namui::text.
2. If namui fail to draw text with font, it use 'fallback font'.
3. Ah, Yas, I make namui load noto emoji as fallback font.