### PR TITLE
Install namui-cli in namui-test-host docker image

### DIFF
--- a/.github/workflows/namui-test-host-linux.yml
+++ b/.github/workflows/namui-test-host-linux.yml
@@ -25,6 +25,7 @@ jobs:
           filters: |
             namui-test-host:
               - .github/**
+              - namui-cli/**
               - docker-images/namui-test-host/linux.Dockerfile
             namui-cli:
               - .github/**

--- a/docker-images/namui-test-host/linux.Dockerfile
+++ b/docker-images/namui-test-host/linux.Dockerfile
@@ -15,3 +15,8 @@ RUN apk upgrade -U -a \
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 RUN rustup target add wasm32-unknown-unknown
+
+COPY namui-cli/ /namui-cli/
+
+RUN sh /namui-cli/scripts/install.sh
+


### PR DESCRIPTION
To use namui-cli in namui-cfg in test, I put namui-cli inside of namui-test-host docker image