### PR TITLE
Remove root from code-workspace

### DIFF
--- a/namseent.code-workspace
+++ b/namseent.code-workspace
@@ -20,9 +20,6 @@
     },
     {
       "path": "nrpc"
-    },
-    {
-      "path": "./"
     }
   ],
   "settings": {


### PR DESCRIPTION
Vscode sometimes open root directory when I open file.
For example, when i open namui/src/lib.rs, it open namseent/namui/src/lib.rs.
I think it's kind of vscode bug.

So I suggest to open root if user really need to edit something that can access from root.