### PR TITLE
Check Cargo.lock in CI

### DIFF
--- a/.github/actions/namui-test/action.yml
+++ b/.github/actions/namui-test/action.yml
@@ -20,13 +20,12 @@ runs:
       shell: bash
       run: time namui test ${{ inputs.target }} -m ${{ inputs.path }}/Cargo.toml
 
-    - name: Check up to date Cargo.lock checked
-      uses: technote-space/get-diff-action@v6
-      with:
-        FILES: |
-          Cargo.lock
-
-    - name: Confirm Cargo.lock
-      if: env.GIT_DIFF
+    - name: Did you push Cargo.lock
       shell: bash
-      run: printf "::error::File change detected. If it's Cargo.lock, you should add it into git\n" && git diff --name-only && exit 1
+      run: |
+        if [[ $(git diff --name-only) ]]; then
+            echo "::error::File change detected. If it's Cargo.lock, you should add it into git"
+            exit 1
+        else
+            echo "Good. Cargo.lock is up to date (or it ignored by gitignore)"
+        fi

--- a/.github/actions/namui-test/action.yml
+++ b/.github/actions/namui-test/action.yml
@@ -25,6 +25,7 @@ runs:
       run: |
         if [[ $(git diff --name-only) ]]; then
             echo "::error::File change detected. If it's Cargo.lock, you should add it into git"
+            echo  "::error::$(git diff --name-only)"
             exit 1
         else
             echo "Good. Cargo.lock is up to date (or it ignored by gitignore)"

--- a/.github/actions/namui-test/action.yml
+++ b/.github/actions/namui-test/action.yml
@@ -19,3 +19,14 @@ runs:
     - name: Test
       shell: bash
       run: time namui test ${{ inputs.target }} -m ${{ inputs.path }}/Cargo.toml
+
+    - name: Check up to date Cargo.lock checked
+      uses: technote-space/get-diff-action@v6
+      with:
+        FILES: |
+          Cargo.lock
+
+    - name: Confirm Cargo.lock
+      if: env.GIT_DIFF
+      shell: bash
+      run: printf "::error::File change detected. If it's Cargo.lock, you should add it into git\n" && git diff --name-only && exit 1

--- a/luda-editor/luda-editor-client/Cargo.lock
+++ b/luda-editor/luda-editor-client/Cargo.lock
@@ -685,6 +685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
I found that sometime we don't push updated Cargo.lock when we update Cargo.toml. I found how CI can catch it before merge pull requests.

context: https://github.com/rust-lang/rust-analyzer/issues/12219