### PR TITLE
Wrap typeface with arc

### DIFF
--- a/namui/src/namui/manager/common/typeface_manager.rs
+++ b/namui/src/namui/manager/common/typeface_manager.rs
@@ -1,9 +1,9 @@
-use dashmap::DashMap;
-
 use crate::namui::{self, Typeface, TypefaceType};
+use dashmap::DashMap;
+use std::sync::Arc;
 
 pub struct TypefaceManager {
-    typefaces: DashMap<TypefaceType, Typeface>,
+    typefaces: DashMap<TypefaceType, Arc<Typeface>>,
 }
 
 impl TypefaceManager {
@@ -12,14 +12,14 @@ impl TypefaceManager {
             typefaces: DashMap::new(),
         }
     }
-    pub fn get_typeface<'a>(&'a self, option: &'a TypefaceType) -> Option<Typeface> {
+    pub fn get_typeface<'a>(&'a self, option: &'a TypefaceType) -> Option<Arc<Typeface>> {
         namui::log(format!("typefaces: {:?}", self.typefaces.len()));
-        self.typefaces.get(option).map(|x| x.clone())
+        self.typefaces.get(option).map(|typeface| typeface.clone())
     }
     pub fn load_typeface(&self, option: &TypefaceType, bytes: &Vec<u8>) {
         let typeface = Typeface::new(bytes);
         namui::log(format!("Loaded typeface: {:?}", option));
 
-        self.typefaces.insert(*option, typeface);
+        self.typefaces.insert(*option, Arc::new(typeface));
     }
 }


### PR DESCRIPTION
I got a error message that dropped typeface reused in canvaskit. To avoid that problem, I wrap typeface with arc. I think I reverted it in previous PR. --> https://github.com/NamseEnt/namseent/commit/d02165d95be9d566cab84551af3c04638ffa57f0#diff-9a9aca6cc9da3533e1a18cef81db49c3306ac59f6808885dd33f05a2c8aae4f8R6

related PR: https://github.com/NamseEnt/namseent/pull/184