### PR TITLE
Hide text input focus information

### DIFF
--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -15,6 +15,7 @@ struct TextInputExample {
     left_text: String,
     center_text: String,
     right_text: String,
+    left_value: Option<f32>,
 }
 
 impl TextInputExample {
@@ -26,6 +27,7 @@ impl TextInputExample {
             left_text: "Left".to_string(),
             center_text: "Center".to_string(),
             right_text: "Right".to_string(),
+            left_value: None,
         }
     }
 }
@@ -136,7 +138,28 @@ impl Entity for TextInputExample {
             },
         });
 
-        render![left, center, right]
+        let left_value_text = namui::text(TextParam {
+            x: 200.0,
+            y: 500.0,
+            align: TextAlign::Left,
+            baseline: TextBaseline::Top,
+            text: self
+                .left_value
+                .map(|v| v.to_string())
+                .unwrap_or("is't not f32".to_string()),
+            font_type: namui::FontType {
+                font_weight: namui::FontWeight::REGULAR,
+                language: namui::Language::Ko,
+                serif: false,
+                size: 20,
+            },
+            style: namui::TextStyle {
+                color: namui::Color::BLACK,
+                ..Default::default()
+            },
+        });
+
+        render![left, center, right, left_value_text]
     }
 
     fn update(&mut self, event: &dyn std::any::Any) {
@@ -145,10 +168,16 @@ impl Entity for TextInputExample {
                 text_input::Event::TextUpdated(text_updated) => {
                     if self.left_text_input.get_id().eq(&text_updated.id) {
                         self.left_text = text_updated.text.clone();
+                        self.left_value = self.left_text.parse().ok(); // NOTE: You don't have to check value in here, it's would be better UX checking it on blur.
                     } else if self.center_text_input.get_id().eq(&text_updated.id) {
                         self.center_text = text_updated.text.clone();
                     } else if self.right_text_input.get_id().eq(&text_updated.id) {
                         self.right_text = text_updated.text.clone();
+                    }
+                }
+                text_input::Event::Blur(blur) => {
+                    if self.left_text_input.get_id().eq(&blur.id) {
+                        self.left_value = self.left_text.parse().ok();
                     }
                 }
                 _ => {}

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -2,7 +2,7 @@ mod common;
 pub(crate) mod draw;
 mod font;
 mod manager;
-use std::{any::Any, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 mod namui_state;
 mod skia;
 pub use common::*;

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -2,7 +2,7 @@ mod common;
 pub(crate) mod draw;
 mod font;
 mod manager;
-use std::{sync::Arc, time::Duration};
+use std::{any::Any, sync::Arc, time::Duration};
 mod namui_state;
 mod skia;
 pub use common::*;

--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -13,7 +13,6 @@ pub type Selection = Option<Range<usize>>;
 pub struct TextInput {
     pub(crate) selection: Selection,
     pub(crate) id: String,
-    pub(crate) is_focused: bool,
 }
 #[derive(Clone, Debug)]
 pub struct Props {
@@ -26,12 +25,16 @@ pub struct TextInputCustomData {
     pub props: Props,
 }
 pub enum Event {
-    Focus(TextInputFocus),
-    Blur,
+    Focus(Focus),
+    Blur(Blur),
     TextUpdated(TextUpdated),
     SelectionUpdated(SelectionUpdated),
 }
-pub struct TextInputFocus {
+
+pub struct Blur {
+    pub id: String,
+}
+pub struct Focus {
     pub id: String,
     pub selection: Selection,
 }
@@ -49,7 +52,6 @@ impl TextInput {
         TextInput {
             selection: None,
             id: crate::nanoid(),
-            is_focused: false,
         }
     }
     pub fn get_id(&self) -> &str {
@@ -75,16 +77,15 @@ impl TextInput {
             match event {
                 Event::Focus(focus) => {
                     if focus.id == self.id {
-                        self.is_focused = true;
                         self.selection = focus.selection.clone();
                     } else {
-                        self.is_focused = false;
-                        self.selection = None;
+                        self.selection = None; // TODO: Remove this and draw unfocus caret in different way
                     }
                 }
-                Event::Blur => {
-                    self.is_focused = false;
-                    self.selection = None;
+                Event::Blur(blur) => {
+                    if blur.id == self.id {
+                        self.selection = None; // TODO: Remove this and draw unfocus caret in different way
+                    }
                 }
                 Event::SelectionUpdated(selection_updated) => {
                     if selection_updated.id == self.id {


### PR DESCRIPTION
I removed focus boolean from text_input because it would not sync if user didn't update it.

Only single text_input can be focused, so I decide hiding focus information from text_input, and put it into manager.

During that editing, I passed text_input id in blur event so user can check that text input is done or not.