### PR TITLE
Chmod test outputs before exit

### DIFF
--- a/namui-cli/src/procedures/linux/wasm_unknown_web/test.rs
+++ b/namui-cli/src/procedures/linux/wasm_unknown_web/test.rs
@@ -65,12 +65,14 @@ pub fn test(manifest_path: &PathBuf) -> Result<(), Box<dyn Error>> {
                 "wasm-pack test --headless --chrome {}",
                 directory.to_str().unwrap()
             ),
+            "exit_code=$?".to_string(),
             format!(
                 "find {} -user $(whoami) -print0 | xargs -0 chmod 777",
                 source_bind_path.to_str().unwrap()
             ),
+            "exit $exit_code".to_string(),
         ]
-        .join(" && ")
+        .join("; ")
     );
 
     let args = ["run", "--rm"]


### PR DESCRIPTION
I found that when `namui test` fail, it doesn't chmod outputs, like `target`. So after failure, when I run `cargo check`, it makes permission error like this.
![image](https://user-images.githubusercontent.com/3580430/170353635-d200f460-4332-41cb-b61a-f8f851b75b86.png)

To solve this problem, I saved exit code and run chmod then exit with previous exit code.