### PR TITLE
Get local xy in wheel event without id

### DIFF
--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
@@ -110,7 +110,6 @@ impl Scroll {
             },
             ..Default::default()
         })
-        .with_id(&whole_rect_id)
         .attach_event(move |builder| {
             let width = inner_width + scroll_bar_width;
             let height = height;

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
@@ -95,7 +95,6 @@ impl Scroll {
             ],
             false => RenderingTree::Empty,
         };
-        let whole_rect_id = namui::nanoid();
         let whole_rect = rect(RectParam {
             x: 0.0,
             y: 0.0,
@@ -115,7 +114,6 @@ impl Scroll {
         .attach_event(move |builder| {
             let width = inner_width + scroll_bar_width;
             let height = height;
-            let whole_rect_id = whole_rect_id.clone();
             builder.on_wheel(move |event| {
                 let managers = namui::managers();
 
@@ -123,8 +121,8 @@ impl Scroll {
                 let mouse_position = mouse_manager.mouse_position();
                 let whole_rect_xy = event
                     .namui_context
-                    .get_rendering_tree_xy(&whole_rect_id)
-                    .unwrap();
+                    .get_rendering_tree_xy(event.target)
+                    .expect("failed to get whole_rect xy");
 
                 let is_mouse_in_timeline = mouse_position.x as f32 >= whole_rect_xy.x
                     && mouse_position.x as f32 <= whole_rect_xy.x + width

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
@@ -71,7 +71,6 @@ impl TimelineBody {
                 )
             })
             .collect::<Vec<_>>();
-        let border_id = "timeline_border";
         let border = namui::rect(namui::RectParam {
             x: 0.0,
             y: 0.0,
@@ -90,7 +89,6 @@ impl TimelineBody {
             },
             ..Default::default()
         })
-        .with_id(border_id)
         .attach_event(move |builder| {
             let width = props.width;
             let height = props.height;
@@ -106,8 +104,8 @@ impl TimelineBody {
                     let mouse_position = mouse_manager.mouse_position();
                     let timeline_xy = event
                         .namui_context
-                        .get_rendering_tree_xy(border_id)
-                        .unwrap();
+                        .get_rendering_tree_xy_by_id(event.target)
+                        .expect("failed to get timeline xy");
 
                     let is_mouse_in_timeline = mouse_position.x as f32 >= timeline_xy.x
                         && mouse_position.x as f32 <= timeline_xy.x + width

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
@@ -104,7 +104,7 @@ impl TimelineBody {
                     let mouse_position = mouse_manager.mouse_position();
                     let timeline_xy = event
                         .namui_context
-                        .get_rendering_tree_xy_by_id(event.target)
+                        .get_rendering_tree_xy(event.target)
                         .expect("failed to get timeline xy");
 
                     let is_mouse_in_timeline = mouse_position.x as f32 >= timeline_xy.x

--- a/namui-prebuilt/src/scroll_view.rs
+++ b/namui-prebuilt/src/scroll_view.rs
@@ -84,7 +84,6 @@ impl ScrollView {
             }),],
             false => RenderingTree::Empty,
         };
-        let whole_rect_id = namui::nanoid();
         let whole_rect = rect(RectParam {
             x: 0.0,
             y: 0.0,
@@ -98,11 +97,9 @@ impl ScrollView {
             },
             ..Default::default()
         })
-        .with_id(&whole_rect_id)
         .attach_event(move |builder| {
             let width = content_bounding_box.width + props.scroll_bar_width;
             let height = props.height;
-            let whole_rect_id = whole_rect_id.clone();
             let button_id = button_id.clone();
             builder.on_wheel(move |event| {
                 let managers = namui::managers();
@@ -111,7 +108,7 @@ impl ScrollView {
                 let mouse_position = mouse_manager.mouse_position();
                 let whole_rect_xy = event
                     .namui_context
-                    .get_rendering_tree_xy(&whole_rect_id)
+                    .get_rendering_tree_xy(event.target)
                     .unwrap();
 
                 let is_mouse_in_timeline = mouse_position.x as f32 >= whole_rect_xy.x

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -30,8 +30,11 @@ pub struct NamuiContext {
     pub(crate) fallback_font_typefaces: Vec<Arc<Typeface>>,
 }
 impl NamuiContext {
-    pub fn get_rendering_tree_xy(&self, id: &str) -> Option<Xy<f32>> {
+    pub fn get_rendering_tree_xy_by_id(&self, id: &str) -> Option<Xy<f32>> {
         self.rendering_tree.get_xy_by_id(id)
+    }
+    pub fn get_rendering_tree_xy(&self, rendering_tree: &RenderingTree) -> Option<Xy<f32>> {
+        self.rendering_tree.get_xy_of_child(rendering_tree)
     }
 }
 

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -132,11 +132,11 @@ pub async fn start<TProps>(
                 namui_context.rendering_tree = state.render(props);
             }
             Some(NamuiEvent::Wheel(xy)) => {
-                namui_context.rendering_tree.call_wheel_event(&WheelEvent {
-                    id: format!("wheel-{:?}-{}", now(), nanoid()),
-                    delta_xy: xy,
-                    namui_context: &namui_context,
-                });
+                namui_context.rendering_tree.call_wheel_event(
+                    format!("wheel-{:?}-{}", now(), nanoid()),
+                    xy,
+                    &namui_context,
+                );
                 state.update(event.as_ref());
                 namui_context.rendering_tree = state.render(props);
             }

--- a/namui/src/namui/render/rendering_tree/mod.rs
+++ b/namui/src/namui/render/rendering_tree/mod.rs
@@ -105,13 +105,23 @@ impl RenderingTree {
             RenderingTree::Empty => {}
         }
     }
-    pub fn call_wheel_event(&self, wheel_event: &WheelEvent) {
+    pub fn call_wheel_event(
+        &self,
+        event_id: String,
+        delta_xy: &Xy<f32>,
+        namui_context: &NamuiContext,
+    ) {
         self.visit_rln(|node, _| {
             if let RenderingTree::Special(special) = node {
                 if let SpecialRenderingNode::AttachEvent(attach_event) = special {
                     // NOTE : Should i check if the mouse is in the attach_event?
                     if let Some(on_wheel) = &attach_event.on_wheel {
-                        on_wheel(wheel_event);
+                        on_wheel(&WheelEvent {
+                            delta_xy,
+                            id: event_id.clone(),
+                            namui_context,
+                            target: node,
+                        });
                     }
                 }
             }

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -38,6 +38,7 @@ pub struct WheelEvent<'a> {
     pub id: String,
     pub delta_xy: &'a Xy<f32>,
     pub namui_context: &'a NamuiContext,
+    pub target: &'a RenderingTree,
 }
 pub type MouseEventCallback = Arc<dyn Fn(&MouseEvent)>;
 pub type WheelEventCallback = Arc<dyn Fn(&WheelEvent)>;


### PR DESCRIPTION
Previously we put rendering-tree-xy-getting-method using renderingTree's reference. So in wheel event, I put the way to get local xy easily using namui context and target.