### PR TITLE
Prevent arrow & space key for scroll & history move

### DIFF
--- a/namui/src/namui/manager/web/keyboard_manager.rs
+++ b/namui/src/namui/manager/web/keyboard_manager.rs
@@ -23,71 +23,86 @@ impl KeyboardManager {
     }
     pub fn new() -> Self {
         let pressing_code_set = Arc::new(RwLock::new(HashSet::new()));
-
-        let pressing_code_set_key_down = pressing_code_set.clone();
-        let key_down_closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
-            let code_string = event.code();
-            let code = Code::from_str(&code_string);
-            if code.is_err() {
-                crate::log!(
-                    "[DEBUG] Fail to get code from key_down callback {}",
-                    code_string
-                );
-                return;
-            }
-            let code = code.unwrap();
-            pressing_code_set_key_down.write().unwrap().insert(code);
-            if event.key() == "Alt" {
-                event.prevent_default();
-            }
-            crate::log!("key down: {}", code_string);
-
-            crate::event::send(crate::NamuiEvent::KeyDown(crate::KeyEvent { code }));
-        }) as Box<dyn FnMut(_)>);
-
-        let pressing_code_set_key_up = pressing_code_set.clone();
-        let key_up_closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
-            let code_string = event.code();
-            let code = Code::from_str(&code_string);
-            if code.is_err() {
-                crate::log!(
-                    "[DEBUG] Fail to get code from key_up callback {}",
-                    code_string
-                );
-                return;
-            }
-            let code = code.unwrap();
-            pressing_code_set_key_up.write().unwrap().remove(&code);
-            crate::log!("key up: {}", code_string);
-        }) as Box<dyn FnMut(_)>);
-
-        let pressing_code_set_clear = pressing_code_set.clone();
-        let clear_closure = Closure::wrap(Box::new(move || {
-            pressing_code_set_clear.write().unwrap().clear();
-        }) as Box<dyn FnMut()>);
-
         let document = window().unwrap().document().unwrap();
 
         document
-            .add_event_listener_with_callback("keydown", key_down_closure.as_ref().unchecked_ref())
+            .add_event_listener_with_callback(
+                "keydown",
+                Closure::wrap(Box::new({
+                    let pressing_code_set = pressing_code_set.clone();
+                    move |event: web_sys::KeyboardEvent| {
+                        let code_string = event.code();
+                        let code = Code::from_str(&code_string);
+                        if code.is_err() {
+                            crate::log!(
+                                "[DEBUG] Fail to get code from key_down callback {}",
+                                code_string
+                            );
+                            return;
+                        }
+                        let code = code.unwrap();
+                        pressing_code_set.write().unwrap().insert(code);
+
+                        match code {
+                            Code::Space
+                            | Code::ArrowLeft
+                            | Code::ArrowRight
+                            | Code::ArrowUp
+                            | Code::ArrowDown
+                            | Code::AltLeft
+                            | Code::AltRight => {
+                                event.prevent_default();
+                            }
+                            _ => {}
+                        }
+
+                        crate::event::send(crate::NamuiEvent::KeyDown(crate::KeyEvent { code }));
+                    }
+                }) as Box<dyn FnMut(_)>)
+                .into_js_value()
+                .unchecked_ref(),
+            )
             .unwrap();
 
         document
-            .add_event_listener_with_callback("keyup", key_up_closure.as_ref().unchecked_ref())
+            .add_event_listener_with_callback(
+                "keyup",
+                Closure::wrap(Box::new({
+                    let pressing_code_set = pressing_code_set.clone();
+                    move |event: web_sys::KeyboardEvent| {
+                        let code_string = event.code();
+                        let code = Code::from_str(&code_string);
+                        if code.is_err() {
+                            crate::log!(
+                                "[DEBUG] Fail to get code from key_up callback {}",
+                                code_string
+                            );
+                            return;
+                        }
+                        let code = code.unwrap();
+                        pressing_code_set.write().unwrap().remove(&code);
+                    }
+                }) as Box<dyn FnMut(_)>)
+                .into_js_value()
+                .unchecked_ref(),
+            )
             .unwrap();
 
         ["blur", "visibilitychange"].iter().for_each(|event_name| {
             document
                 .add_event_listener_with_callback(
-                    event_name,
-                    clear_closure.as_ref().unchecked_ref(),
+                    *event_name,
+                    Closure::wrap(Box::new({
+                        let pressing_code_set = pressing_code_set.clone();
+                        move || {
+                            pressing_code_set.write().unwrap().clear();
+                        }
+                    }) as Box<dyn FnMut()>)
+                    .into_js_value()
+                    .unchecked_ref(),
                 )
                 .unwrap();
         });
-
-        key_down_closure.forget();
-        key_up_closure.forget();
-        clear_closure.forget();
 
         KeyboardManager {
             pressing_code_set: pressing_code_set.clone(),


### PR DESCRIPTION
I found that Alt+ArrowLeft activate `go back` button. I prevent it with code clean (https://github.com/NamseEnt/namseent/issues/185)