### PR TITLE
Reset pressing code on window.blur

### DIFF
--- a/namui/src/namui/manager/web/keyboard_manager.rs
+++ b/namui/src/namui/manager/web/keyboard_manager.rs
@@ -88,21 +88,29 @@ impl KeyboardManager {
             )
             .unwrap();
 
+        let reset_pressing_code_set_closure = Closure::wrap(Box::new({
+            let pressing_code_set = pressing_code_set.clone();
+            move || {
+                pressing_code_set.write().unwrap().clear();
+            }
+        }) as Box<dyn FnMut()>)
+        .into_js_value();
+
         ["blur", "visibilitychange"].iter().for_each(|event_name| {
             document
                 .add_event_listener_with_callback(
                     *event_name,
-                    Closure::wrap(Box::new({
-                        let pressing_code_set = pressing_code_set.clone();
-                        move || {
-                            pressing_code_set.write().unwrap().clear();
-                        }
-                    }) as Box<dyn FnMut()>)
-                    .into_js_value()
-                    .unchecked_ref(),
+                    reset_pressing_code_set_closure.unchecked_ref(),
                 )
                 .unwrap();
         });
+        window()
+            .unwrap()
+            .add_event_listener_with_callback(
+                "blur",
+                reset_pressing_code_set_closure.unchecked_ref(),
+            )
+            .unwrap();
 
         KeyboardManager {
             pressing_code_set: pressing_code_set.clone(),


### PR DESCRIPTION
I found that document.blur or document.visibilitychange event weren't called when I switch to other window which cover whole web page.
I mean, if I switch to small, pop-up-styled, window like Kakao Talk, it doesn't call blur or visibilitychange.

I found solution from stackoverflow, so window.blur will called if user switch window even into popup window.
reference: https://stereologics.wordpress.com/2015/04/02/about-page-visibility-api-hidden-visibilitychange-visibilitystate/