### PR TITLE
Decode encoded bundle url

### DIFF
--- a/namui-cli/Cargo.lock
+++ b/namui-cli/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util 0.7.1",
+ "urlencoding",
  "warp",
  "webbrowser",
  "wsl",
@@ -1443,6 +1444,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "utf-8"

--- a/namui-cli/Cargo.toml
+++ b/namui-cli/Cargo.toml
@@ -24,3 +24,4 @@ wsl = "0.1.0"
 fs_extra = "1.2.0"
 namui-user-config = { path = "../namui-user-config" }
 tokio-util = { version = "0.7.1", features = ["codec"] }
+urlencoding = "2.1"


### PR DESCRIPTION
I found that namui-cli bundle server couldn't read url if it use non-ascii url like korean. I decoded url before read file. 
Tested getting image with bundle after this fix.