### PR TITLE
Cache font information for optimization

### DIFF
--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -191,6 +191,7 @@ pub enum MouseButton {
     Right,
 }
 
+#[derive(Debug)]
 pub struct RawMouseEvent {
     pub id: String,
     pub xy: Xy<f32>,
@@ -198,6 +199,7 @@ pub struct RawMouseEvent {
     pub button: Option<MouseButton>,
 }
 
+#[derive(Debug)]
 pub struct KeyEvent {
     pub code: Code,
 }

--- a/namui/src/namui/draw/text.rs
+++ b/namui/src/namui/draw/text.rs
@@ -37,7 +37,7 @@ pub fn draw_text(namui_context: &NamuiContext, command: &TextDrawCommand) {
             .get(&font.id)
             .map(|bottom| bottom + font.size as f32)
             .unwrap_or_else(|| {
-                let metrics = font.get_metrics();
+                let metrics = font.metrics;
                 let bottom = command.y as f32 + get_bottom_of_baseline(&command.baseline, &metrics);
                 bottom_of_fonts.insert(font.id.clone(), bottom);
                 bottom
@@ -102,7 +102,7 @@ fn get_glyph_groups(
                 .map(|(glyph_id, _)| *glyph_id)
                 .collect();
 
-            let widths = font.get_glyph_widths(&available_glyph_ids, Option::Some(paint));
+            let widths = font.get_glyph_widths(available_glyph_ids.into(), Option::Some(paint));
 
             widths
                 .into_iter()
@@ -146,7 +146,7 @@ pub fn get_bottom_of_baseline(baseline: &TextBaseline, font_metrics: &FontMetric
     }
 }
 fn get_fallback_fonts(namui_context: &NamuiContext, font_size: i16) -> VecDeque<Arc<Font>> {
-    let mut managers = crate::managers();
+    let managers = crate::managers();
     namui_context
         .fallback_font_typefaces
         .iter()
@@ -168,18 +168,18 @@ impl TextDrawCommand {
         let glyph_ids = font.get_glyph_ids(&self.text);
 
         let paint = self.paint_builder.build();
-        let glyph_bounds = font.get_glyph_bounds(&glyph_ids, Some(&paint));
+        let glyph_bounds = font.get_glyph_bounds(glyph_ids.clone(), Some(&paint));
 
         glyph_bounds
             .iter()
             .map(|bound| (bound.top, bound.bottom))
             .reduce(|acc, (top, bottom)| (acc.0.min(top), acc.1.max(bottom)))
             .and_then(|(top, bottom)| {
-                let widths = font.get_glyph_widths(&glyph_ids, Option::Some(&paint));
+                let widths = font.get_glyph_widths(glyph_ids, Option::Some(&paint));
                 let width = widths.iter().fold(0.0, |prev, curr| prev + curr);
                 let x_axis_anchor = get_left_in_align(self.x as f32, self.align, width);
 
-                let metrics = font.get_metrics();
+                let metrics = font.metrics;
                 let y_axis_anchor =
                     self.y as f32 + get_bottom_of_baseline(&self.baseline, &metrics);
 

--- a/namui/src/namui/event/mod.rs
+++ b/namui/src/namui/event/mod.rs
@@ -17,6 +17,8 @@ pub fn send(event: impl Any + Send + Sync) {
     EVENT_SENDER.get().unwrap().send(Box::new(event)).unwrap();
 }
 
+
+#[derive(Debug)]
 pub enum NamuiEvent {
     AnimationFrame,
     MouseDown(RawMouseEvent),

--- a/namui/src/namui/render/text.rs
+++ b/namui/src/namui/render/text.rs
@@ -57,15 +57,6 @@ pub fn text(param: TextParam) -> RenderingTree {
                             // draw_shadow(),
                             draw_border(&param, font.clone()),
                             Some(draw_text(&param, font.clone())),
-                            // commands: vec![namui::DrawCommand::Text(namui::TextDrawCommand {
-                            //     text: param.text,
-                            //     x: 100,
-                            //     y: 100,
-                            //     align: namui::TextAlign::Left,
-                            //     baseline: namui::TextBaseline::Top,
-                            //     font,
-                            //     paint: param.paint,
-                            // })],
                         ]
                         .into_iter()
                         .filter_map(|command| command)
@@ -176,7 +167,7 @@ fn draw_background(param: &TextParam, font: &Font) -> RenderingTree {
         param.style.drop_shadow.map(|drop_shadow| drop_shadow.x),
     );
 
-    let font_metrics = font.get_metrics();
+    let font_metrics = font.metrics;
 
     let height = -font_metrics.ascent + font_metrics.descent;
     let bottom_of_baseline = get_bottom_of_baseline(&param.baseline, &font_metrics);
@@ -206,7 +197,7 @@ fn draw_background(param: &TextParam, font: &Font) -> RenderingTree {
 
 pub(crate) fn get_text_width_internal(font: &Font, text: &str, drop_shadow_x: Option<f32>) -> f32 {
     let glyph_ids = font.get_glyph_ids(text);
-    let glyph_widths = font.get_glyph_widths(&glyph_ids, Option::None);
+    let glyph_widths = font.get_glyph_widths(glyph_ids, Option::None);
     glyph_widths.iter().fold(0.0, |acc, cur| acc + cur) + drop_shadow_x.unwrap_or(0.0)
 }
 
@@ -214,12 +205,12 @@ pub fn get_text_width(text: &str, font_type: &FontType, drop_shadow_x: Option<f3
     let font = namui::managers().font_manager.get_font(&font_type);
     font.map(|font| {
         let glyph_ids = font.get_glyph_ids(text);
-        let glyph_widths = font.get_glyph_widths(&glyph_ids, Option::None);
+        let glyph_widths = font.get_glyph_widths(glyph_ids, Option::None);
         glyph_widths.iter().fold(0.0, |acc, cur| acc + cur) + drop_shadow_x.unwrap_or(0.0)
     })
 }
 
-fn get_glyphs_top_bottom(font: &Font, glyph_ids: &GlyphIds) -> Option<(f32, f32)> {
+fn get_glyphs_top_bottom(font: &Font, glyph_ids: Arc<GlyphIds>) -> Option<(f32, f32)> {
     if glyph_ids.len() == 0 {
         return None;
     }

--- a/namui/src/namui/render/text_input/draw_caret.rs
+++ b/namui/src/namui/render/text_input/draw_caret.rs
@@ -41,7 +41,7 @@ impl TextInput {
             namui::TextAlign::Right => text_param.x - total_width,
         } + left_text_width;
 
-        let font_metrics = font.get_metrics();
+        let font_metrics = font.metrics;
         let font_height = -font_metrics.ascent + font_metrics.descent;
         let top = get_bottom_of_baseline(&text_param.baseline, &font_metrics)
             + font_metrics.ascent

--- a/namui/src/namui/render/text_input/get_selection_on_mouse_down.rs
+++ b/namui/src/namui/render/text_input/get_selection_on_mouse_down.rs
@@ -82,7 +82,7 @@ fn get_one_click_selection(
 
 fn get_selection_index_of_x(font: &namui::Font, text: &str, local_x: f32) -> usize {
     let glyph_ids = font.get_glyph_ids(text);
-    let glyph_widths = font.get_glyph_widths(&glyph_ids, None);
+    let glyph_widths = font.get_glyph_widths(glyph_ids, None);
 
     let mut left = 0.0;
     let index = glyph_widths.iter().position(|width| {

--- a/namui/src/namui/skia/types.rs
+++ b/namui/src/namui/skia/types.rs
@@ -1,10 +1,10 @@
+use crate::Xy;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
+    sync::Arc,
 };
-
-use crate::Xy;
-use serde::{Deserialize, Serialize};
 
 pub type GlyphIds = [u16];
 
@@ -62,7 +62,7 @@ impl LtrbRect {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct FontMetrics {
     /// suggested space above the baseline. < 0
     pub ascent: f32,

--- a/namui/src/namui/skia/web/canvas.rs
+++ b/namui/src/namui/skia/web/canvas.rs
@@ -5,10 +5,12 @@ use super::*;
 pub(crate) struct Canvas(pub CanvasKitCanvas);
 impl Canvas {
     pub fn draw_text_blob(&self, text_blob: &TextBlob, x: f32, y: f32, paint: &Paint) {
-        self.0.drawTextBlob(&text_blob.0, x, y, &paint.0);
+        self.0
+            .drawTextBlob(&text_blob.0, x, y, &paint.canvas_kit_paint);
     }
     pub fn draw_path(&self, path: &Path, paint: &Paint) {
-        self.0.drawPath(&path.canvas_kit_path, &paint.0);
+        self.0
+            .drawPath(&path.canvas_kit_path, &paint.canvas_kit_paint);
     }
     pub fn translate(&self, dx: f32, dy: f32) {
         self.0.translate(dx, dy);
@@ -55,7 +57,7 @@ impl Canvas {
             dest_rect_lrtb_array,
             filter_mode.into_canvas_kit(),
             mipmap_mode.into_canvas_kit(),
-            paint.map(|p| &p.0),
+            paint.map(|paint| &paint.canvas_kit_paint),
         );
     }
     pub(crate) fn get_matrix(&self) -> [[f32; 3]; 3] {
@@ -98,7 +100,7 @@ impl Canvas {
 
     pub(crate) fn draw_text(&self, string: &str, x: f32, y: f32, paint: &Paint, font: &Font) {
         self.0
-            .drawText(string, x, y, &paint.0, &font.canvas_kit_font);
+            .drawText(string, x, y, &paint.canvas_kit_paint, &font.canvas_kit_font);
     }
     pub(crate) fn rotate(&self, radian: f32) {
         self.0


### PR DESCRIPTION
When I render so many text, it makes lags so I optimized rendering and drawing text with cache.

before
![image](https://user-images.githubusercontent.com/3580430/173587431-9de35101-0a9b-4825-8546-5893ee6b6813.png)

after
![image](https://user-images.githubusercontent.com/3580430/173587685-44394479-6bfb-4d83-aaad-c7e772907bde.png)

(I reduced event count so comparison is not accurate.)