### PR TITLE
Init font and fs before start

### DIFF
--- a/luda-editor/luda-editor-client/src/app/main.rs
+++ b/luda-editor/luda-editor-client/src/app/main.rs
@@ -1,7 +1,7 @@
 use super::app::App;
 
 pub async fn main() {
-    let namui_context = namui::init();
+    let namui_context = namui::init().await;
 
     namui::start(namui_context, &mut App::new(), &()).await
 }

--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub async fn start() {
-    let namui_context = namui::init();
+    let namui_context = namui::init().await;
 
     namui::start(namui_context, &mut TextInputExample::new(), &()).await
 }

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -53,8 +53,12 @@ pub trait Entity {
     fn render(&self, props: &Self::Props) -> RenderingTree;
 }
 
-pub fn init() -> NamuiContext {
-    Namui::init()
+pub async fn init() -> NamuiContext {
+    let mut namui_context = Namui::init();
+
+    join(init_font(&mut namui_context), init_filesystem()).await;
+
+    namui_context
 }
 
 pub async fn start<TProps>(
@@ -62,8 +66,6 @@ pub async fn start<TProps>(
     state: &mut dyn Entity<Props = TProps>,
     props: &TProps,
 ) {
-    join(init_font(&mut namui_context), init_filesystem()).await;
-
     namui_context.rendering_tree = state.render(props);
 
     Namui::request_animation_frame(Box::new(move || {


### PR DESCRIPTION
I failed to read bundle dir on `fn new` of my entity, and found that fs starts initing in `fn start` of namui. I moved it to `fn init` of namui.