### PR TITLE
Provide context in mouse event

### DIFF
--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -102,9 +102,11 @@ pub async fn start<TProps>(
                         .text_input_manager
                         .on_mouse_down(&namui_context, &raw_mouse_event);
                 }
-                namui_context
-                    .rendering_tree
-                    .call_mouse_event(MouseEventType::Down, raw_mouse_event);
+                namui_context.rendering_tree.call_mouse_event(
+                    MouseEventType::Down,
+                    raw_mouse_event,
+                    &namui_context,
+                );
                 state.update(event.as_ref());
                 namui_context.rendering_tree = state.render(props);
             }
@@ -115,9 +117,11 @@ pub async fn start<TProps>(
                         .text_input_manager
                         .on_mouse_up(&namui_context, &raw_mouse_event);
                 }
-                namui_context
-                    .rendering_tree
-                    .call_mouse_event(MouseEventType::Up, raw_mouse_event);
+                namui_context.rendering_tree.call_mouse_event(
+                    MouseEventType::Up,
+                    raw_mouse_event,
+                    &namui_context,
+                );
                 state.update(event.as_ref());
                 namui_context.rendering_tree = state.render(props);
             }
@@ -128,9 +132,11 @@ pub async fn start<TProps>(
                         .text_input_manager
                         .on_mouse_move(&namui_context, &raw_mouse_event);
                 }
-                namui_context
-                    .rendering_tree
-                    .call_mouse_event(MouseEventType::Move, raw_mouse_event);
+                namui_context.rendering_tree.call_mouse_event(
+                    MouseEventType::Move,
+                    raw_mouse_event,
+                    &namui_context,
+                );
                 state.update(event.as_ref());
                 namui_context.rendering_tree = state.render(props);
             }

--- a/namui/src/namui/render/rendering_tree/mod.rs
+++ b/namui/src/namui/render/rendering_tree/mod.rs
@@ -161,6 +161,7 @@ impl RenderingTree {
         &self,
         mouse_event_type: MouseEventType,
         raw_mouse_event: &RawMouseEvent,
+        namui_context: &NamuiContext,
     ) {
         self.visit_rln(|node, utils| {
             match node {
@@ -183,6 +184,7 @@ impl RenderingTree {
                                 pressing_buttons: raw_mouse_event.pressing_buttons.clone(),
                                 button: raw_mouse_event.button,
                                 target: node,
+                                namui_context,
                             };
                             match is_mouse_in {
                                 true => {

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -21,7 +21,7 @@ pub struct AttachEventNode {
     pub on_wheel: Option<WheelEventCallback>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MouseEvent<'a> {
     pub id: String,
     pub local_xy: Xy<f32>,
@@ -29,6 +29,7 @@ pub struct MouseEvent<'a> {
     pub pressing_buttons: HashSet<MouseButton>,
     pub button: Option<MouseButton>,
     pub target: &'a RenderingTree,
+    pub namui_context: &'a NamuiContext,
 }
 pub enum MouseEventType {
     Down,


### PR DESCRIPTION
Like wheel event, I suggest providing namui context in mouse event to get position of parent's location.

example:

```rs
parent.with_id(self.id)
// ...
children.attach_event(|builder| {
  builder.on_mouse_down_in(|event| {
    let parent_global_xy = event.context.get_rendering_tree_xy_by_id(self.id).unwrap();
    let my_global_xy = event.context.get_rendering_tree_xy(event.target).unwrap();
    let local_xy = my_global_xy - parent_global_xy;
  })
});
```

I would like to use this code in namui animation editor to get the mouse local xy position in specific window.