### PR TITLE
Render before draw

### DIFF
--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -81,6 +81,8 @@ pub async fn start<TProps>(
         match event.downcast_ref::<NamuiEvent>() {
             Some(NamuiEvent::AnimationFrame) => {
                 invoke_and_flush_all_animation_frame_callbacks();
+                state.update(event.as_ref());
+                namui_context.rendering_tree = state.render(props);
 
                 update_fps_info(&mut namui_context.fps_info);
 


### PR DESCRIPTION
Related slack message : https://projectluda.slack.com/archives/C015ELKQE67/p1656074655253679

Pros
- You don't have to send empty event to play video or animation.

Cons
- Drawing to monitor could be delayed
  - But I don't think so because our render function is very cheap and fast. we already handle over 600 events(=600 renders) per second.
- There could be meaningless render if there are no video or animation.

Other Idea (that can be another answer so you have to take a look)
- Provide `fn namui::every_frame(rendering_tree: RenderingTree) -> RenderingTree` which return special rendering node, then namui will check on AnimationFrame event whether that `namui_context.rendering_tree` has `SpecialRenderingNode::EveryFrame` or not. If it exists then it will render before draw.