### PR TITLE
Support keyboard event

### DIFF
--- a/image-cropper/src/app/cropper/canvas/canvas.rs
+++ b/image-cropper/src/app/cropper/canvas/canvas.rs
@@ -125,25 +125,25 @@ impl Canvas {
                         if keyboard_manager.any_code_press([namui::Code::ControlLeft]) {
                             zoom(
                                 event.delta_xy,
-                                &offset,
-                                &local_mouse_position,
-                                &canvas_wh,
-                                &image_size,
+                                offset,
+                                local_mouse_position,
+                                canvas_wh,
+                                image_size,
                                 scale,
                             )
                         } else if keyboard_manager.any_code_press([namui::Code::ShiftLeft]) {
                             scroll(
-                                &Xy {
+                                Xy {
                                     x: event.delta_xy.y,
                                     y: event.delta_xy.x,
                                 },
-                                &offset,
-                                &canvas_wh,
-                                &image_size,
+                                offset,
+                                canvas_wh,
+                                image_size,
                                 scale,
                             )
                         } else {
-                            scroll(event.delta_xy, &offset, &canvas_wh, &image_size, scale)
+                            scroll(event.delta_xy, offset, canvas_wh, image_size, scale)
                         }
                     })
                     .on_mouse_down(move |event| {
@@ -174,11 +174,11 @@ impl Canvas {
                         };
                         match current_tool_type {
                             ToolType::Hand => handle_hand_tool_drag(
-                                &hand_tool_pushed_position,
-                                &local_xy_on_image,
-                                &offset,
-                                &canvas_wh,
-                                &image_size,
+                                hand_tool_pushed_position,
+                                local_xy_on_image,
+                                offset,
+                                canvas_wh,
+                                image_size,
                                 scale,
                             ),
                             _ => (),
@@ -251,11 +251,11 @@ fn render_background(wh: &Wh<f32>) -> RenderingTree {
 }
 
 fn handle_hand_tool_drag(
-    moved_from: &Option<Xy<f32>>,
-    moved_to: &Xy<f32>,
-    offset: &Xy<f32>,
-    canvas_wh: &Wh<f32>,
-    image_size: &Wh<f32>,
+    moved_from: Option<Xy<f32>>,
+    moved_to: Xy<f32>,
+    offset: Xy<f32>,
+    canvas_wh: Wh<f32>,
+    image_size: Wh<f32>,
     scale: f32,
 ) {
     if let Some(last_position) = moved_from {
@@ -263,17 +263,11 @@ fn handle_hand_tool_drag(
             x: (last_position.x - moved_to.x) * scale,
             y: (last_position.y - moved_to.y) * scale,
         };
-        scroll(&scaled_delta_xy, offset, canvas_wh, image_size, scale)
+        scroll(scaled_delta_xy, offset, canvas_wh, image_size, scale)
     }
 }
 
-fn scroll(
-    delta_xy: &Xy<f32>,
-    offset: &Xy<f32>,
-    canvas_wh: &Wh<f32>,
-    image_size: &Wh<f32>,
-    scale: f32,
-) {
+fn scroll(delta_xy: Xy<f32>, offset: Xy<f32>, canvas_wh: Wh<f32>, image_size: Wh<f32>, scale: f32) {
     let scaled_delta_xy = Xy {
         x: delta_xy.x / scale,
         y: delta_xy.y / scale,
@@ -283,11 +277,11 @@ fn scroll(
 }
 
 fn zoom(
-    delta_xy: &Xy<f32>,
-    offset: &Xy<f32>,
-    local_mouse_position: &Xy<f32>,
-    canvas_wh: &Wh<f32>,
-    image_size: &Wh<f32>,
+    delta_xy: Xy<f32>,
+    offset: Xy<f32>,
+    local_mouse_position: Xy<f32>,
+    canvas_wh: Wh<f32>,
+    image_size: Wh<f32>,
     scale: f32,
 ) {
     const ZOOM_MULTIPLIER: f32 = 1.0 / 1000.0;
@@ -307,8 +301,8 @@ fn zoom(
 
 fn clamp_offset_xy(
     offset_xy: Xy<f32>,
-    canvas_wh: &Wh<f32>,
-    image_wh: &Wh<f32>,
+    canvas_wh: Wh<f32>,
+    image_wh: Wh<f32>,
     scale: f32,
 ) -> Xy<f32> {
     let max_diff = Wh {
@@ -325,7 +319,7 @@ fn clamp_offset_xy(
     }
 }
 
-fn clamp_scale(scale: f32, canvas_wh: &Wh<f32>, image_wh: &Wh<f32>) -> f32 {
+fn clamp_scale(scale: f32, canvas_wh: Wh<f32>, image_wh: Wh<f32>) -> f32 {
     let ratio = Xy {
         x: image_wh.width / canvas_wh.width,
         y: image_wh.height / canvas_wh.height,

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -200,6 +200,14 @@ pub struct RawMouseEvent {
 }
 
 #[derive(Debug)]
-pub struct KeyEvent {
+pub struct RawWheelEvent {
+    pub id: String,
+    pub delta_xy: Xy<f32>,
+}
+
+#[derive(Debug)]
+pub struct RawKeyboardEvent {
+    pub id: String,
     pub code: Code,
+    pub pressing_codes: HashSet<Code>,
 }

--- a/namui/src/namui/event/mod.rs
+++ b/namui/src/namui/event/mod.rs
@@ -1,4 +1,4 @@
-use crate::{namui, KeyEvent, RawMouseEvent};
+use crate::{namui, RawKeyboardEvent, RawMouseEvent, RawWheelEvent};
 use once_cell::sync::OnceCell;
 use std::any::Any;
 use tokio::sync::mpsc::{self, unbounded_channel};
@@ -24,9 +24,10 @@ pub enum NamuiEvent {
     MouseDown(RawMouseEvent),
     MouseUp(RawMouseEvent),
     MouseMove(RawMouseEvent),
-    KeyDown(KeyEvent),
+    KeyDown(RawKeyboardEvent),
+    KeyUp(RawKeyboardEvent),
     ScreenResize(namui::Wh<i16>),
-    Wheel(namui::Xy<f32>),
+    Wheel(RawWheelEvent),
 }
 
 #[cfg(test)]

--- a/namui/src/namui/manager/mock/wheel_manager.rs
+++ b/namui/src/namui/manager/mock/wheel_manager.rs
@@ -1,25 +1,7 @@
-use crate::namui::{self, namui_state::NamuiState, NamuiInternal, Xy};
-use wasm_bindgen::{prelude::Closure, JsCast};
-use web_sys::HtmlElement;
-
 pub struct WheelManager {}
 
 impl WheelManager {
     pub fn new() -> Self {
-        let wheel_closure = Closure::wrap(Box::new(move |event: web_sys::WheelEvent| {
-            namui::event::send(namui::NamuiEvent::Wheel(Xy {
-                x: event.delta_x() as f32,
-                y: event.delta_y() as f32,
-            }));
-        }) as Box<dyn FnMut(_)>);
-
-        let window = namui::window();
-        let document = window.document().unwrap();
-        document
-            .add_event_listener_with_callback("wheel", wheel_closure.as_ref().unchecked_ref())
-            .unwrap();
-        wheel_closure.forget();
-
         Self {}
     }
 }

--- a/namui/src/namui/manager/web/keyboard_manager.rs
+++ b/namui/src/namui/manager/web/keyboard_manager.rs
@@ -41,7 +41,8 @@ impl KeyboardManager {
                             return;
                         }
                         let code = code.unwrap();
-                        pressing_code_set.write().unwrap().insert(code);
+                        let mut pressing_code_set = pressing_code_set.write().unwrap();
+                        pressing_code_set.insert(code);
 
                         match code {
                             Code::Space
@@ -56,7 +57,16 @@ impl KeyboardManager {
                             _ => {}
                         }
 
-                        crate::event::send(crate::NamuiEvent::KeyDown(crate::KeyEvent { code }));
+                        crate::event::send(crate::NamuiEvent::KeyDown(crate::RawKeyboardEvent {
+                            id: format!(
+                                "keydown-{:?}-{:?}-{}",
+                                code,
+                                crate::now(),
+                                crate::nanoid()
+                            ),
+                            code,
+                            pressing_codes: pressing_code_set.clone(),
+                        }));
                     }
                 }) as Box<dyn FnMut(_)>)
                 .into_js_value()
@@ -80,7 +90,14 @@ impl KeyboardManager {
                             return;
                         }
                         let code = code.unwrap();
-                        pressing_code_set.write().unwrap().remove(&code);
+                        let mut pressing_code_set = pressing_code_set.write().unwrap();
+                        pressing_code_set.remove(&code);
+
+                        crate::event::send(crate::NamuiEvent::KeyUp(crate::RawKeyboardEvent {
+                            id: format!("keyup-{:?}-{:?}-{}", code, crate::now(), crate::nanoid()),
+                            code,
+                            pressing_codes: pressing_code_set.clone(),
+                        }));
                     }
                 }) as Box<dyn FnMut(_)>)
                 .into_js_value()

--- a/namui/src/namui/manager/web/wheel_manager.rs
+++ b/namui/src/namui/manager/web/wheel_manager.rs
@@ -1,4 +1,7 @@
-use crate::namui::{self, Xy};
+use crate::{
+    namui::{self, Xy},
+    RawWheelEvent,
+};
 use wasm_bindgen::{prelude::Closure, JsCast};
 
 pub struct WheelManager {}
@@ -15,9 +18,12 @@ impl WheelManager {
                         event.prevent_default()
                     }
 
-                    namui::event::send(namui::NamuiEvent::Wheel(Xy {
-                        x: event.delta_x() as f32,
-                        y: event.delta_y() as f32,
+                    namui::event::send(namui::NamuiEvent::Wheel(RawWheelEvent {
+                        id: format!("wheel-{:?}-{:?}", namui::now(), namui::now()),
+                        delta_xy: Xy {
+                            x: event.delta_x() as f32,
+                            y: event.delta_y() as f32,
+                        },
                     }));
                 }) as Box<dyn FnMut(_)>)
                 .into_js_value()

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -142,11 +142,27 @@ pub async fn start<TProps>(
                 state.update(event.as_ref());
                 namui_context.rendering_tree = state.render(props);
             }
-            Some(NamuiEvent::Wheel(xy)) => {
-                namui_context.rendering_tree.call_wheel_event(
-                    format!("wheel-{:?}-{}", now(), nanoid()),
-                    xy,
+            Some(NamuiEvent::Wheel(raw_wheel_event)) => {
+                namui_context
+                    .rendering_tree
+                    .call_wheel_event(raw_wheel_event, &namui_context);
+                state.update(event.as_ref());
+                namui_context.rendering_tree = state.render(props);
+            }
+            Some(NamuiEvent::KeyDown(raw_keyboard_event)) => {
+                namui_context.rendering_tree.call_keyboard_event(
+                    raw_keyboard_event,
                     &namui_context,
+                    render::DownUp::Down,
+                );
+                state.update(event.as_ref());
+                namui_context.rendering_tree = state.render(props);
+            }
+            Some(NamuiEvent::KeyUp(raw_keyboard_event)) => {
+                namui_context.rendering_tree.call_keyboard_event(
+                    raw_keyboard_event,
+                    &namui_context,
+                    render::DownUp::Up,
                 );
                 state.update(event.as_ref());
                 namui_context.rendering_tree = state.render(props);


### PR DESCRIPTION
Yes, Keyboard down and up.

# Why?
- It's not enough to get keyboard event with NamuiEvent in user side because they want to bring the information that only can be captured in render fn. It's impossible to get props in event handler if they use NamuiEvent::KeyDown because NamuiEvent only has the information about namui, not rendering state.

# Example
## Before

![image](https://user-images.githubusercontent.com/3580430/175552652-44688f4e-d68f-4ac0-8719-6a482b8e0b24.png)

No, I don't want to keep `self.selected_point_ids` in Self because it's just the props!

## After

![image](https://user-images.githubusercontent.com/3580430/175552839-192e2696-28c2-427f-acaf-d83e4350c640.png)

in render

![image](https://user-images.githubusercontent.com/3580430/175552803-77ddf2ad-f60a-43e7-9758-7bb574fc9b3e.png)

in update. Oh yes!
