### PR TITLE
Make attach_event builder can break chain

### DIFF
--- a/image-cropper/src/app/cropper/canvas/canvas.rs
+++ b/image-cropper/src/app/cropper/canvas/canvas.rs
@@ -184,7 +184,7 @@ impl Canvas {
                             _ => (),
                         };
                         namui::event::send(CanvasEvent::MouseMoveInCanvas(local_xy_on_image))
-                    })
+                    });
             }),
             clip(
                 namui::PathBuilder::new().add_rect(&namui::LtrbRect {

--- a/image-cropper/src/app/cropper/render_back_button.rs
+++ b/image-cropper/src/app/cropper/render_back_button.rs
@@ -24,7 +24,7 @@ pub fn render_back_button(wh: &Wh<f32>) -> RenderingTree {
                 namui::event::send(RouterEvent::PageChangeRequestedToFileSelectorEvent(
                     Box::new(|| FileSelector::new()),
                 ));
-            })
+            });
         })
         .with_mouse_cursor(namui::MouseCursor::Pointer),
         namui::text(TextParam {

--- a/image-cropper/src/app/cropper/render_save_button.rs
+++ b/image-cropper/src/app/cropper/render_save_button.rs
@@ -20,7 +20,7 @@ pub fn render_save_button(wh: &Wh<f32>) -> RenderingTree {
             },
         })
         .attach_event(|builder| {
-            builder.on_mouse_down(|_| namui::event::send(CropperEvent::SaveButtonClicked))
+            builder.on_mouse_down(|_| namui::event::send(CropperEvent::SaveButtonClicked));
         })
         .with_mouse_cursor(namui::MouseCursor::Pointer),
         namui::text(TextParam {

--- a/image-cropper/src/app/cropper/selection/poly_selection.rs
+++ b/image-cropper/src/app/cropper/selection/poly_selection.rs
@@ -46,7 +46,7 @@ impl PolySelection {
                     .attach_event(|builder| {
                         builder.on_mouse_down(move |_| {
                             namui::event::send(SelectionEvent::PolySelectionCreateButtonClicked)
-                        })
+                        });
                     })
                     .with_mouse_cursor(namui::MouseCursor::Pointer)
                 }
@@ -86,7 +86,7 @@ impl SelectionTrait for PolySelection {
                                     target_id: id.clone(),
                                 })
                             }
-                        })
+                        });
                     }),
                     self.render_selection_create_button(scale),
                 ])

--- a/image-cropper/src/app/cropper/selection/rect_selection.rs
+++ b/image-cropper/src/app/cropper/selection/rect_selection.rs
@@ -48,7 +48,7 @@ impl SelectionTrait for RectSelection {
                             target_id: id.clone(),
                         })
                     }
-                })
+                });
             }),
             render_handles(&scaled_xywh, self.id.clone()),
         ])
@@ -116,7 +116,7 @@ fn render_handles(xywh: &XywhRect<f32>, selection_id: String) -> RenderingTree {
                     selection_id,
                     direction,
                 })
-            })
+            });
         })
     }))
 }

--- a/image-cropper/src/app/file_selector/render_file_select_dialog_open_button.rs
+++ b/image-cropper/src/app/file_selector/render_file_select_dialog_open_button.rs
@@ -22,7 +22,7 @@ pub fn render_file_select_dialog_open_button(wh: Wh<f32>) -> RenderingTree {
         .attach_event(|builder| {
             builder.on_mouse_down(|_| {
                 namui::event::send(FileSelectorEvent::FileSelectDialogOpenButtonClicked);
-            })
+            });
         })
         .with_mouse_cursor(namui::MouseCursor::Pointer),
         namui::text(TextParam {

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/button.rs
@@ -43,7 +43,7 @@ pub fn render_button(
             if event.button == Some(MouseButton::Left) {
                 on_click();
             }
-        })
+        });
     });
     translate(
         xywh.x,

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/back_button.rs
@@ -57,7 +57,7 @@ impl ImageBrowser {
                         browser_id: browser_id.clone(),
                         item: ImageBrowserItem::Back,
                     });
-                })
+                });
             }),
             text(TextParam {
                 x: item_size.width / 2.0,

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/browser_item.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/browser_item.rs
@@ -43,7 +43,7 @@ pub fn render_browser_item(props: &BrowserItemProps) -> RenderingTree {
                     browser_id: browser_id.clone(),
                     item: item.clone(),
                 });
-            })
+            });
         }),
         text(TextParam {
             x: props.item_size.width / 2.0,

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/empty_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/empty_button.rs
@@ -53,7 +53,7 @@ impl ImageBrowser {
                         browser_id: browser_id.clone(),
                         item: ImageBrowserItem::Empty,
                     });
-                })
+                });
             }),
             text(TextParam {
                 x: item_size.width / 2.0,

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/image_browser/scroll.rs
@@ -140,7 +140,7 @@ impl Scroll {
                 namui::event::send(EditorEvent::ScrolledEvent {
                     scroll_y: next_scroll_y,
                 });
-            })
+            });
         });
 
         namui::translate(x, y, render![whole_rect, inner, scroll_bar])

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/background_wysiwyg_editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/background_wysiwyg_editor/mod.rs
@@ -188,7 +188,7 @@ fn render_inner_image(
                         mouse_xy: event.global_xy,
                         container_size: container_size.clone(),
                     })
-                })
+                });
             })
             .with_mouse_cursor(MouseCursor::Move),
     )

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/character_wysiwyg_editor/cropper.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/character_wysiwyg_editor/cropper.rs
@@ -69,7 +69,7 @@ fn render_handles(dest_rect: &LtrbRect, container_size: &Wh<f32>) -> RenderingTr
                             mouse_xy: mouse_event.global_xy,
                             container_size: container_size,
                         })
-                    })
+                    });
                 })
             })
             .collect(),

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/character_wysiwyg_editor/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/character_wysiwyg_editor/mod.rs
@@ -176,7 +176,7 @@ fn render_inner_image(
                         mouse_xy: event.global_xy,
                         container_size: container_size.clone(),
                     })
-                })
+                });
             })
             .with_mouse_cursor(MouseCursor::Move),
     )

--- a/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/resizer.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/clip_editor/camera_clip_editor/wysiwyg_editor/resizer.rs
@@ -90,7 +90,7 @@ impl Resizer {
                                     height: source_rect.height,
                                 },
                             })
-                        })
+                        });
                     })
                 })
                 .collect::<Vec<RenderingTree>>(),

--- a/luda-editor/luda-editor-client/src/app/editor/context_menu/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/context_menu/mod.rs
@@ -80,7 +80,7 @@ impl ContextMenu {
                                 time_to_create_clip,
                             ));
                         }
-                    })
+                    });
                 }),
                 text(TextParam {
                     x: 10.0,

--- a/luda-editor/luda-editor-client/src/app/editor/sequence_player/buttons.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/sequence_player/buttons.rs
@@ -61,7 +61,7 @@ pub(super) fn render_buttons(props: &ButtonsProps) -> RenderingTree {
                     true => ButtonsEvent::PlayButtonClicked,
                     false => ButtonsEvent::PauseButtonClicked,
                 })
-            })
+            });
         }),
         path(play_pause_toggle_button, button_paint)
     ]

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/time_ruler/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/time_ruler/mod.rs
@@ -78,7 +78,7 @@ pub(super) fn render_time_ruler(props: &TimeRulerProps) -> RenderingTree {
                     };
                     event_builder
                         .on_mouse_down(time_ruler_dragging_closure)
-                        .on_mouse_move_in(time_ruler_dragging_closure)
+                        .on_mouse_move_in(time_ruler_dragging_closure);
                 }),
                 render_time_texts(&TimeTextsProps {
                     gradations: &gradations,

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/mod.rs
@@ -146,7 +146,7 @@ impl TimelineBody {
                             mouse_position_in_time: get_mouse_position_in_time(event.local_xy.x),
                         })
                     }
-                })
+                });
         });
         render![
             border,

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/camera_track_body/mod.rs
@@ -106,7 +106,7 @@ impl CameraTrackBody {
                             + PixelSize(event.local_xy.x) * time_per_pixel,
                     })
                 }
-            })
+            });
         });
         render![
             body_border,

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/resizable_clip_body/mod.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/resizable_clip_body/mod.rs
@@ -122,7 +122,7 @@ impl ResizableClipBody {
                     click_in_time: timeline_start_at + PixelSize(event.local_xy.x) * time_per_pixel,
                     clicked_part,
                 });
-            })
+            });
         });
 
         let sashes = if is_sashes_showing {

--- a/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/timeline/timeline_body/track_body/subtitle_track_body/subtitle_clip_body.rs
@@ -141,7 +141,7 @@ impl SubtitleClipBody {
                                 click_in_time: timeline_start_at
                                     + PixelSize(event.local_xy.x + x) * time_per_pixel,
                             });
-                        })
+                        });
                     }),
                 render_text_box(
                     &subtitle_text,

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/go_back_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/go_back_button.rs
@@ -21,7 +21,7 @@ pub fn render_go_back_button(wh: Wh<f32>) -> RenderingTree {
         })
         .with_mouse_cursor(namui::MouseCursor::Pointer)
         .attach_event(move |builder| {
-            builder.on_mouse_down(move |_| namui::event::send(TopBarEvent::GoBackButtonClicked))
+            builder.on_mouse_down(move |_| namui::event::send(TopBarEvent::GoBackButtonClicked));
         }),
         namui::text(namui::TextParam {
             text: "Go back".to_string(),

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/meta_update_button.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/meta_update_button.rs
@@ -25,8 +25,9 @@ pub fn render_meta_update_button(props: &MetaUpdateButtonProps) -> RenderingTree
         })
         .with_mouse_cursor(namui::MouseCursor::Pointer)
         .attach_event(move |builder| {
-            builder
-                .on_mouse_down(move |_| namui::event::send(MetaContainerEvent::MetaReloadRequested))
+            builder.on_mouse_down(move |_| {
+                namui::event::send(MetaContainerEvent::MetaReloadRequested)
+            });
         }),
         namui::text(namui::TextParam {
             text: "Update Meta".to_string(),

--- a/luda-editor/luda-editor-client/src/app/editor/top_bar/sheet_sequence_syncer_bar.rs
+++ b/luda-editor/luda-editor-client/src/app/editor/top_bar/sheet_sequence_syncer_bar.rs
@@ -71,7 +71,7 @@ pub(super) fn render_sheet_sequence_syncer_bar(
     .attach_event(|builder| {
         builder.on_mouse_up(|_| {
             namui::event::send(SheetSequenceSyncerEvent::RequestSyncStart);
-        })
+        });
     });
     let button_text = namui::text(TextParam {
         x: button_width / 2.0,

--- a/luda-editor/luda-editor-client/src/app/sequence_list/list/list.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/list/list.rs
@@ -83,7 +83,7 @@ pub fn render_list(
                 namui::event::send(SequenceListEvent::ScrolledEvent {
                     scroll_y: next_scroll_y,
                 });
-            })
+            });
         }),
         namui::clip(
             namui::PathBuilder::new().add_rect(&namui::LtrbRect {

--- a/luda-editor/luda-editor-client/src/app/sequence_list/list/open_button.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/list/open_button.rs
@@ -34,7 +34,7 @@ pub fn render_open_button(
                             )
                         },
                     )));
-                })
+                });
             })
             .with_mouse_cursor(namui::MouseCursor::Pointer),
         render_button_text(wh, "Open".to_string())

--- a/luda-editor/luda-editor-client/src/app/sequence_list/list/preview_slider.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/list/preview_slider.rs
@@ -24,7 +24,7 @@ pub fn render_preview_slider(
                 let title = title.clone();
                 let progress = (event.local_xy.x / wh.width).clamp(0.0, 1.0);
                 namui::event::send(SequenceListEvent::PreviewSliderMovedEvent { title, progress });
-            })
+            });
         }),
         namui::translate(
             thumb_x,

--- a/luda-editor/luda-editor-client/src/app/sequence_list/list/title_button.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/list/title_button.rs
@@ -23,7 +23,7 @@ pub fn render_title_button(width: f32, title: &String) -> RenderingTreeRow {
                         namui::event::send(SequenceListEvent::SequenceTitleButtonClickedEvent {
                             title,
                         });
-                    })
+                    });
                 }),
             render_button_text(button_wh, title.clone()),
         ],

--- a/luda-editor/luda-editor-client/src/app/sequence_list/sync_sequences_button.rs
+++ b/luda-editor/luda-editor-client/src/app/sequence_list/sync_sequences_button.rs
@@ -10,7 +10,7 @@ pub fn render_sync_sequences_button(wh: Wh<f32>) -> RenderingTree {
             .attach_event(move |builder| {
                 builder.on_mouse_down(move |_| {
                     namui::event::send(SequenceListEvent::SyncSequencesButtonClickedEvent {});
-                })
+                });
             })
             .with_mouse_cursor(namui::MouseCursor::Pointer),
         render_button_text(wh, "Sync sequences from Google Spreadsheet".to_string())

--- a/namui-prebuilt/src/scroll_view.rs
+++ b/namui-prebuilt/src/scroll_view.rs
@@ -126,7 +126,7 @@ impl ScrollView {
                 );
 
                 namui::event::send(Event::Scrolled(button_id.clone(), next_scroll_y));
-            })
+            });
         });
 
         namui::translate(

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -129,7 +129,7 @@ impl AttachEventBuilder {
         self.on_wheel = Some(Arc::new(on_wheel));
         self
     }
-    
+
     pub fn on_key_down(&mut self, on_key_down: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
         self.on_key_down = Some(Arc::new(on_key_down));
         self

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -76,26 +76,15 @@ pub struct AttachEventBuilder {
     pub(crate) on_key_up: Option<KeyboardEventCallback>,
 }
 
-#[derive(Default)]
-pub struct AttachEventBuilder2 {
-    pub(crate) on_mouse_move_in: Option<MouseEventCallback>,
-    pub(crate) on_mouse_move_out: Option<MouseEventCallback>,
-    // onClickOut: Option<MouseEventCallback>,
-    // onMouseIn?: () => void;
-    pub(crate) on_mouse_down: Option<MouseEventCallback>,
-    pub(crate) on_mouse_up: Option<MouseEventCallback>,
-    pub(crate) on_wheel: Option<WheelEventCallback>,
-}
-
 impl RenderingTree {
     pub fn attach_event(
         self,
-        attach_event_build: impl Fn(AttachEventBuilder) -> AttachEventBuilder,
+        attach_event_build: impl Fn(&mut AttachEventBuilder),
     ) -> RenderingTree {
-        let builder = AttachEventBuilder {
+        let mut builder = AttachEventBuilder {
             ..Default::default()
         };
-        let builder = attach_event_build(builder);
+        attach_event_build(&mut builder);
         RenderingTree::Special(SpecialRenderingNode::AttachEvent(AttachEventNode {
             rendering_tree: Box::new(self),
             on_mouse_move_in: builder.on_mouse_move_in,
@@ -107,64 +96,9 @@ impl RenderingTree {
             on_key_up: builder.on_key_up,
         }))
     }
-
-    pub fn attach_event2(
-        self,
-        attach_event_build: impl Fn(&mut AttachEventBuilder2),
-    ) -> RenderingTree {
-        let mut builder = AttachEventBuilder2 {
-            ..Default::default()
-        };
-        attach_event_build(&mut builder);
-        RenderingTree::Special(SpecialRenderingNode::AttachEvent(AttachEventNode {
-            rendering_tree: Box::new(self),
-            on_mouse_move_in: builder.on_mouse_move_in,
-            on_mouse_move_out: builder.on_mouse_move_out,
-            on_mouse_down: builder.on_mouse_down,
-            on_mouse_up: builder.on_mouse_up,
-            on_wheel: builder.on_wheel,
-        }))
-    }
 }
 
 impl AttachEventBuilder {
-    pub fn on_mouse_move_in(mut self, on_mouse_move_in: impl Fn(&MouseEvent) + 'static) -> Self {
-        self.on_mouse_move_in = Some(Arc::new(on_mouse_move_in));
-        self
-    }
-
-    pub fn on_mouse_move_out(mut self, on_mouse_move_out: impl Fn(&MouseEvent) + 'static) -> Self {
-        self.on_mouse_move_out = Some(Arc::new(on_mouse_move_out));
-        self
-    }
-
-    pub fn on_mouse_down(mut self, on_mouse_down: impl Fn(&MouseEvent) + 'static) -> Self {
-        self.on_mouse_down = Some(Arc::new(on_mouse_down));
-        self
-    }
-
-    pub fn on_mouse_up(mut self, on_mouse_up: impl Fn(&MouseEvent) + 'static) -> Self {
-        self.on_mouse_up = Some(Arc::new(on_mouse_up));
-        self
-    }
-
-    pub fn on_wheel(mut self, on_wheel: impl Fn(&WheelEvent) + 'static) -> Self {
-        self.on_wheel = Some(Arc::new(on_wheel));
-        self
-    }
-
-    pub fn on_key_down(mut self, on_key_down: impl Fn(&KeyboardEvent) + 'static) -> Self {
-        self.on_key_down = Some(Arc::new(on_key_down));
-        self
-    }
-
-    pub fn on_key_up(mut self, on_key_up: impl Fn(&KeyboardEvent) + 'static) -> Self {
-        self.on_key_up = Some(Arc::new(on_key_up));
-        self
-    }
-}
-
-impl AttachEventBuilder2 {
     pub fn on_mouse_move_in(
         &mut self,
         on_mouse_move_in: impl Fn(&MouseEvent) + 'static,

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -129,4 +129,14 @@ impl AttachEventBuilder {
         self.on_wheel = Some(Arc::new(on_wheel));
         self
     }
+    
+    pub fn on_key_down(&mut self, on_key_down: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
+        self.on_key_down = Some(Arc::new(on_key_down));
+        self
+    }
+
+    pub fn on_key_up(&mut self, on_key_up: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
+        self.on_key_up = Some(Arc::new(on_key_up));
+        self
+    }
 }

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -76,6 +76,19 @@ pub struct AttachEventBuilder {
     pub(crate) on_key_up: Option<KeyboardEventCallback>,
 }
 
+#[derive(Default)]
+pub struct AttachEventBuilder2 {
+    pub(crate) on_mouse_move_in: Option<MouseEventCallback>,
+    pub(crate) on_mouse_move_out: Option<MouseEventCallback>,
+    // onClickOut: Option<MouseEventCallback>,
+    // onMouseIn?: () => void;
+    pub(crate) on_mouse_down: Option<MouseEventCallback>,
+    pub(crate) on_mouse_up: Option<MouseEventCallback>,
+    pub(crate) on_wheel: Option<WheelEventCallback>,
+    pub(crate) on_key_down: Option<KeyboardEventCallback>,
+    pub(crate) on_key_up: Option<KeyboardEventCallback>,
+}
+
 impl RenderingTree {
     pub fn attach_event(
         self,
@@ -85,6 +98,26 @@ impl RenderingTree {
             ..Default::default()
         };
         let builder = attach_event_build(builder);
+        RenderingTree::Special(SpecialRenderingNode::AttachEvent(AttachEventNode {
+            rendering_tree: Box::new(self),
+            on_mouse_move_in: builder.on_mouse_move_in,
+            on_mouse_move_out: builder.on_mouse_move_out,
+            on_mouse_down: builder.on_mouse_down,
+            on_mouse_up: builder.on_mouse_up,
+            on_wheel: builder.on_wheel,
+            on_key_down: builder.on_key_down,
+            on_key_up: builder.on_key_up,
+        }))
+    }
+
+    pub fn attach_event2(
+        self,
+        attach_event_build: impl Fn(&mut AttachEventBuilder2),
+    ) -> RenderingTree {
+        let mut builder = AttachEventBuilder2 {
+            ..Default::default()
+        };
+        attach_event_build(&mut builder);
         RenderingTree::Special(SpecialRenderingNode::AttachEvent(AttachEventNode {
             rendering_tree: Box::new(self),
             on_mouse_move_in: builder.on_mouse_move_in,
@@ -130,6 +163,49 @@ impl AttachEventBuilder {
     }
 
     pub fn on_key_up(mut self, on_key_up: impl Fn(&KeyboardEvent) + 'static) -> Self {
+        self.on_key_up = Some(Arc::new(on_key_up));
+        self
+    }
+}
+
+impl AttachEventBuilder2 {
+    pub fn on_mouse_move_in(
+        &mut self,
+        on_mouse_move_in: impl Fn(&MouseEvent) + 'static,
+    ) -> &mut Self {
+        self.on_mouse_move_in = Some(Arc::new(on_mouse_move_in));
+        self
+    }
+
+    pub fn on_mouse_move_out(
+        &mut self,
+        on_mouse_move_out: impl Fn(&MouseEvent) + 'static,
+    ) -> &mut Self {
+        self.on_mouse_move_out = Some(Arc::new(on_mouse_move_out));
+        self
+    }
+
+    pub fn on_mouse_down(&mut self, on_mouse_down: impl Fn(&MouseEvent) + 'static) -> &mut Self {
+        self.on_mouse_down = Some(Arc::new(on_mouse_down));
+        self
+    }
+
+    pub fn on_mouse_up(&mut self, on_mouse_up: impl Fn(&MouseEvent) + 'static) -> &mut Self {
+        self.on_mouse_up = Some(Arc::new(on_mouse_up));
+        self
+    }
+
+    pub fn on_wheel(&mut self, on_wheel: impl Fn(&WheelEvent) + 'static) -> &mut Self {
+        self.on_wheel = Some(Arc::new(on_wheel));
+        self
+    }
+
+    pub fn on_key_down(&mut self, on_key_down: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
+        self.on_key_down = Some(Arc::new(on_key_down));
+        self
+    }
+
+    pub fn on_key_up(&mut self, on_key_up: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
         self.on_key_up = Some(Arc::new(on_key_up));
         self
     }

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -85,8 +85,6 @@ pub struct AttachEventBuilder2 {
     pub(crate) on_mouse_down: Option<MouseEventCallback>,
     pub(crate) on_mouse_up: Option<MouseEventCallback>,
     pub(crate) on_wheel: Option<WheelEventCallback>,
-    pub(crate) on_key_down: Option<KeyboardEventCallback>,
-    pub(crate) on_key_up: Option<KeyboardEventCallback>,
 }
 
 impl RenderingTree {
@@ -125,8 +123,6 @@ impl RenderingTree {
             on_mouse_down: builder.on_mouse_down,
             on_mouse_up: builder.on_mouse_up,
             on_wheel: builder.on_wheel,
-            on_key_down: builder.on_key_down,
-            on_key_up: builder.on_key_up,
         }))
     }
 }
@@ -197,16 +193,6 @@ impl AttachEventBuilder2 {
 
     pub fn on_wheel(&mut self, on_wheel: impl Fn(&WheelEvent) + 'static) -> &mut Self {
         self.on_wheel = Some(Arc::new(on_wheel));
-        self
-    }
-
-    pub fn on_key_down(&mut self, on_key_down: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
-        self.on_key_down = Some(Arc::new(on_key_down));
-        self
-    }
-
-    pub fn on_key_up(&mut self, on_key_up: impl Fn(&KeyboardEvent) + 'static) -> &mut Self {
-        self.on_key_up = Some(Arc::new(on_key_up));
         self
     }
 }


### PR DESCRIPTION
# What's the problem

Can't move same variable to multiple event handler.

![image](https://user-images.githubusercontent.com/3580430/175562005-3c6ce407-3e9d-4478-af28-eb1b880a9800.png)

![image](https://user-images.githubusercontent.com/3580430/175561596-2cfff3a2-8900-4017-8be0-b4e27e464a97.png)

# How to solve that?

## Idea 1. Break chain

![image](https://user-images.githubusercontent.com/3580430/175563204-36d9c020-aea4-49a7-af33-ae1c708e71e2.png)

It can be solved if I break chain, but look at (1). it's too ugly. We have to create new builder because previous builder has been moved.

## Idea 2. use &mut instead move

![image](https://user-images.githubusercontent.com/3580430/175563493-87c509c3-2fbb-4587-a57f-707d54c1aaa5.png)

It can break chain, but don't have to re-assign builder because we didn't move builder. Still can chain events.

I believe Idea 2 is the answer. So I impl that.

It's the breaking change because this new attach fn doesn't return builder. So If review pass, I will change every current our code into this style.

- [x] Review Passed
- [x] Change all attach_event
- [x] Last Review
