### PR TITLE
Put post-test job for pull request status check

### DIFF
--- a/.github/workflows/namui-test-host-linux.yml
+++ b/.github/workflows/namui-test-host-linux.yml
@@ -184,6 +184,7 @@ jobs:
       #     tag: ${{ env.INNER_IMAGE_TAG }}
 
   post-test:
+    if: always() && contains(join(needs.*.result, ','), 'success')
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/namui-test-host-linux.yml
+++ b/.github/workflows/namui-test-host-linux.yml
@@ -182,3 +182,20 @@ jobs:
       #     name: namui-test-host
       #     token: ${{ github.token }}
       #     tag: ${{ env.INNER_IMAGE_TAG }}
+
+  post-test:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    needs:
+      - set-up
+      - update-namui-test-host-image
+      # PLEASE ADD ALL TEST HERE!
+      - test-namui-cli
+      - test-namui
+      - test-luda-editor-client
+      - test-namui-prebuilt
+      - test-nrpc
+      - test-namui-sample
+      - test-image-cropper
+    # NOTE: This is for status check of pull request.

--- a/.github/workflows/namui-test-host-linux.yml
+++ b/.github/workflows/namui-test-host-linux.yml
@@ -199,3 +199,5 @@ jobs:
       - test-namui-sample
       - test-image-cropper
     # NOTE: This is for status check of pull request.
+    steps:
+      - run: ""


### PR DESCRIPTION
Github only protect merging pull request per job, not action. So I add post-test to make sure every tests have been passed.

![image](https://user-images.githubusercontent.com/3580430/175764000-87385b0d-af58-414d-9d51-a63f6c59b237.png)
