### PR TITLE
Draw on top

### DIFF
--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -16,7 +16,7 @@ pub use event::NamuiEvent;
 pub use namui_cfg::*;
 pub use namui_context::NamuiContext;
 pub use render::{
-    absolute, clip, image::*, path::*, react, rect::*, rotate, scale, text::*, text_input,
+    absolute, clip, image::*, on_top, path::*, react, rect::*, rotate, scale, text::*, text_input,
     transform, translate, ImageSource, KeyboardEvent, Matrix3x3, MouseCursor, MouseEvent,
     MouseEventCallback, MouseEventType, React, RenderingData, RenderingTree, TextInput,
     WheelEventCallback,

--- a/namui/src/namui/render/rendering_tree/visit.rs
+++ b/namui/src/namui/render/rendering_tree/visit.rs
@@ -87,7 +87,8 @@ impl RenderingTree {
                     | SpecialRenderingNode::MouseCursor(_)
                     | SpecialRenderingNode::WithId(_)
                     | SpecialRenderingNode::Custom(_)
-                    | SpecialRenderingNode::React(_) => {}
+                    | SpecialRenderingNode::React(_)
+                    | SpecialRenderingNode::OnTop(_) => {}
                 },
                 _ => {}
             }
@@ -148,7 +149,8 @@ impl RenderingTree {
                     | SpecialRenderingNode::MouseCursor(_)
                     | SpecialRenderingNode::WithId(_)
                     | SpecialRenderingNode::Custom(_)
-                    | SpecialRenderingNode::React(_) => {}
+                    | SpecialRenderingNode::React(_)
+                    | SpecialRenderingNode::OnTop(_) => {}
                 }
             }
         }
@@ -169,6 +171,8 @@ fn is_xy_clip_in_by_ancestors(xy: Xy<Px>, ancestors: &[&RenderingTree]) -> bool 
                 if !clip.is_clip_in(local_xy) {
                     return false;
                 }
+            } else if let SpecialRenderingNode::OnTop(_) = special {
+                return true;
             }
         }
     }
@@ -184,7 +188,7 @@ mod tests {
 
     #[test]
     #[wasm_bindgen_test]
-    fn visiting_order_should_be_rln() {
+    fn rln_visiting_order_should_be_rln() {
         /*
             tree:
                  0

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -1,7 +1,14 @@
 use super::SpecialRenderingNode;
 use crate::*;
 use serde::Serialize;
-use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
+use std::{
+    collections::HashSet,
+    ops::ControlFlow,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 #[derive(Serialize, Clone)]
 pub struct AttachEventNode {
@@ -29,7 +36,6 @@ pub struct AttachEventNode {
     pub on_key_up: Option<KeyboardEventCallback>,
 }
 
-#[derive(Clone)]
 pub struct MouseEvent<'a> {
     pub id: String,
     pub namui_context: &'a NamuiContext,
@@ -38,6 +44,12 @@ pub struct MouseEvent<'a> {
     pub global_xy: Xy<Px>,
     pub pressing_buttons: HashSet<MouseButton>,
     pub button: Option<MouseButton>,
+    pub(crate) is_stop_propagation: Arc<AtomicBool>,
+}
+impl MouseEvent<'_> {
+    pub fn stop_propagation(&self) {
+        self.is_stop_propagation.store(true, Ordering::Relaxed);
+    }
 }
 pub enum MouseEventType {
     Down,

--- a/namui/src/namui/render/special/mod.rs
+++ b/namui/src/namui/render/special/mod.rs
@@ -3,6 +3,7 @@ pub mod attach_event;
 pub mod clip;
 pub mod custom;
 pub mod mouse_cursor;
+pub mod on_top;
 pub mod react;
 pub mod rotate;
 pub mod scale;
@@ -15,6 +16,7 @@ pub use attach_event::*;
 pub use clip::*;
 pub use custom::*;
 pub use mouse_cursor::*;
+pub use on_top::*;
 pub use react::*;
 pub use rotate::*;
 pub use scale::*;
@@ -36,4 +38,5 @@ pub enum SpecialRenderingNode {
     Scale(ScaleNode),
     Transform(TransformNode),
     React(ReactNode),
+    OnTop(OnTopNode),
 }

--- a/namui/src/namui/render/special/on_top.rs
+++ b/namui/src/namui/render/special/on_top.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use super::SpecialRenderingNode;
+use crate::RenderingTree;
+use serde::Serialize;
+
+/// `OnTopNode` ignores clip and draw on top of other nodes.
+#[derive(Serialize, Clone, Debug)]
+pub struct OnTopNode {
+    pub(crate) rendering_tree: Arc<RenderingTree>,
+}
+
+/// `on_top` ignores clip and draw on top of other nodes.
+pub fn on_top(rendering_tree: RenderingTree) -> RenderingTree {
+    RenderingTree::Special(SpecialRenderingNode::OnTop(OnTopNode {
+        rendering_tree: Arc::new(rendering_tree),
+    }))
+}

--- a/namui/src/namui/render/special/react.rs
+++ b/namui/src/namui/render/special/react.rs
@@ -199,6 +199,11 @@ fn is_same_special_variant(a: &SpecialRenderingNode, b: &SpecialRenderingNode) -
                 return true;
             }
         }
+        SpecialRenderingNode::OnTop(_) => {
+            if let SpecialRenderingNode::OnTop(_) = b {
+                return true;
+            }
+        }
     };
     false
 }

--- a/namui/src/namui/render/special/react.rs
+++ b/namui/src/namui/render/special/react.rs
@@ -143,69 +143,7 @@ pub fn reconciliate(prev_tree: &RenderingTree, next_tree: &RenderingTree, event:
 }
 
 fn is_same_special_variant(a: &SpecialRenderingNode, b: &SpecialRenderingNode) -> bool {
-    match a {
-        SpecialRenderingNode::Translate(_) => {
-            if let SpecialRenderingNode::Translate(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::Clip(_) => {
-            if let SpecialRenderingNode::Clip(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::AttachEvent(_) => {
-            if let SpecialRenderingNode::AttachEvent(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::MouseCursor(_) => {
-            if let SpecialRenderingNode::MouseCursor(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::WithId(_) => {
-            if let SpecialRenderingNode::WithId(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::Absolute(_) => {
-            if let SpecialRenderingNode::Absolute(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::Rotate(_) => {
-            if let SpecialRenderingNode::Rotate(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::Custom(_) => {
-            if let SpecialRenderingNode::Custom(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::Scale(_) => {
-            if let SpecialRenderingNode::Scale(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::Transform(_) => {
-            if let SpecialRenderingNode::Transform(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::React(_) => {
-            if let SpecialRenderingNode::React(_) = b {
-                return true;
-            }
-        }
-        SpecialRenderingNode::OnTop(_) => {
-            if let SpecialRenderingNode::OnTop(_) = b {
-                return true;
-            }
-        }
-    };
-    false
+    std::mem::discriminant(a) == std::mem::discriminant(b)
 }
 
 fn renew_react(tree: &RenderingTree, event: Option<&dyn Any>) {


### PR DESCRIPTION
`on_top` ignores clipping and draw in last order of drawing stage to draw on most top of display.

Previous :

https://user-images.githubusercontent.com/3580430/179544928-b1bc756e-ef8f-44ca-b25e-a57e3d81fdb8.mp4


After:

https://user-images.githubusercontent.com/3580430/179563138-62c9dc77-67f6-404d-a2dc-d8b32ab33f87.mp4


 What I did
- add `on_top`
- add `stop_propagation` on mouse event