### PR TITLE
Exit build on wasm-pack error #289

### DIFF
--- a/namui-cli/src/procedures/linux/wasm_linux_electron/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_linux_electron/start.rs
@@ -88,6 +88,7 @@ async fn build(
         }
         BuildResult::Failed(err) => {
             eprintln!("failed to build: {}", err);
+            std::process::exit(1);
         }
     }
 }

--- a/namui-cli/src/procedures/linux/wasm_unknown_web/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_unknown_web/start.rs
@@ -88,6 +88,7 @@ async fn build(
         }
         BuildResult::Failed(err) => {
             eprintln!("failed to build: {}", err);
+            std::process::exit(1);
         }
     }
 }

--- a/namui-cli/src/procedures/linux/wasm_windows_electron/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_windows_electron/start.rs
@@ -93,6 +93,7 @@ async fn build(
         }
         BuildResult::Failed(err) => {
             eprintln!("failed to build: {}", err);
+            std::process::exit(1);
         }
     }
 }


### PR DESCRIPTION
Previously namui-cli didn't stop building when wasm-pack failed.

So I made it stop and exit process when wasm-pack failed, not cuz of cargo build.

![image](https://user-images.githubusercontent.com/3580430/181360079-e79d8d97-1fca-441c-980e-35d12bba0338.png)

I tested 
1) wasm-pack only error
2) cargo check error(it doesn't exit process.)
3) well-working source code without error