### PR TITLE
Support deep link

### DIFF
--- a/namui-cli/electron/forge.config.js
+++ b/namui-cli/electron/forge.config.js
@@ -1,6 +1,14 @@
+const config = getConfig();
+
 module.exports = {
     packagerConfig: {
         ignore: [".wsl-env"],
+        protocols: [
+            {
+                name: "Deep link schemes for namui app",
+                schemes: config.deepLinkSchemes,
+            },
+        ],
     },
     hooks: {
         postPackage: async (forgeConfig, options) => {
@@ -18,3 +26,22 @@ module.exports = {
         },
     },
 };
+
+function getConfig() {
+    const config = {
+        deepLinkSchemes: [],
+    };
+    const argv = [...process.argv];
+    while (argv.length) {
+        const arg = argv.pop();
+        if (arg.startsWith("deepLink=")) {
+            const deepLinkScheme = arg.slice("deepLink=".length);
+            const schemeNotExist =
+                config.deepLinkSchemes.findIndex(deepLinkScheme) < 0;
+            if (schemeNotExist) {
+                config.deepLinkSchemes.push(deepLinkScheme);
+            }
+        }
+    }
+    return config;
+}

--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -6,8 +6,6 @@ const path = require("path");
 const config = getConfig();
 const gotTheLock = app.requestSingleInstanceLock();
 
-let mainWindow;
-
 if (!gotTheLock) {
     app.quit();
 } else {
@@ -28,7 +26,7 @@ if (!gotTheLock) {
 }
 
 function createWindow() {
-    mainWindow = new BrowserWindow({
+    const mainWindow = new BrowserWindow({
         width: 1280,
         height: 720,
         webPreferences: {

--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -1,17 +1,41 @@
 const { app, BrowserWindow, ipcMain } = require("electron");
 const isDev = require("electron-is-dev");
+const { existsSync, readFileSync } = require("fs");
 const path = require("path");
 
 const config = getConfig();
+const gotTheLock = app.requestSingleInstanceLock();
+
+let mainWindow;
+
+if (!gotTheLock) {
+    app.quit();
+} else {
+    setAppAsDefaultProtocolClient(app, config.deepLinkSchemes);
+
+    app.whenReady().then(() => {
+        ipcMain.handle("config", () => config);
+        createWindow();
+    });
+
+    app.on("activate", function () {
+        if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    });
+
+    app.on("window-all-closed", function () {
+        if (process.platform !== "darwin") app.quit();
+    });
+}
 
 function createWindow() {
-    const mainWindow = new BrowserWindow({
+    mainWindow = new BrowserWindow({
         width: 1280,
         height: 720,
         webPreferences: {
             preload: path.join(__dirname, "preload.js"),
         },
     });
+    setOpenUrlEventHandler(app, mainWindow);
 
     if (config.test) {
         mainWindow.loadFile("../test.html");
@@ -46,6 +70,7 @@ function getConfig() {
         test: false,
         port: 8000,
         resourceRoot: path.join(__dirname, "../.."),
+        deepLinkSchemes: [],
     };
     const argv = [...process.argv];
     while (argv.length) {
@@ -58,7 +83,65 @@ function getConfig() {
         } else if (arg.startsWith("resourceRoot=")) {
             const resourceRoot = arg.slice("resourceRoot=".length);
             config.resourceRoot = resourceRoot;
+        } else if (arg.startsWith("deepLink=")) {
+            const deepLinkScheme = arg.slice("deepLink=".length);
+            const schemeNotExist =
+                config.deepLinkSchemes.findIndex(
+                    (value) => value === deepLinkScheme,
+                ) < 0;
+            if (schemeNotExist) {
+                config.deepLinkSchemes.push(deepLinkScheme);
+            }
         }
     }
+    config.deepLinkSchemes.push(...loadDeepLinkManifest(config.resourceRoot));
     return config;
+}
+
+function loadDeepLinkManifest(resourceRootPath) {
+    const deepLinkManifestPath = path.join(resourceRootPath, ".namuideeplink");
+    const deepLinkSchemes = [];
+    if (existsSync(deepLinkManifestPath)) {
+        const deepLinkManifestString = readFileSync(
+            deepLinkManifestPath,
+            "utf-8",
+        );
+        deepLinkManifestString.split("\n").forEach((line) => {
+            const trimmedLine = line.trim();
+            if (!trimmedLine) {
+                return;
+            }
+            if (trimmedLine.startsWith("#")) {
+                return;
+            }
+            deepLinkSchemes.push(trimmedLine);
+        });
+    }
+    return deepLinkSchemes;
+}
+
+function setOpenUrlEventHandler(app, mainWindow) {
+    let sendUrl = (url) => mainWindow.webContents.send("deep-link-opened", url);
+    app.on("open-url", (event, url) => {
+        sendUrl(url);
+    });
+
+    app.on("second-instance", (event, argv, workingDirectory) => {
+        const url = argv[argv.length - 1];
+        sendUrl(url);
+        if (mainWindow) {
+            if (mainWindow.isMinimized()) {
+                mainWindow.restore();
+            }
+            mainWindow.focus();
+        }
+    });
+}
+
+function setAppAsDefaultProtocolClient(app, deepLinkSchemes) {
+    let execPath = process.argv[0];
+    let argv = [path.join(__dirname, ".."), ...process.argv.slice(2)];
+    deepLinkSchemes.forEach((deepLinkScheme) => {
+        app.setAsDefaultProtocolClient(deepLinkScheme, execPath, argv);
+    });
 }

--- a/namui-cli/electron/src/namuiApi/deepLink.js
+++ b/namui-cli/electron/src/namuiApi/deepLink.js
@@ -1,0 +1,24 @@
+const { ipcRenderer } = require("electron/renderer");
+
+let recentlyOpenedUrl = undefined;
+let deepLinkOpenedEventListenerSet = new Set();
+
+function getRecentlyOpenedUrl() {
+    return recentlyOpenedUrl;
+}
+
+function addDeepLinkOpenedEventListener(listener) {
+    deepLinkOpenedEventListenerSet.add(listener);
+}
+
+ipcRenderer.addListener("deep-link-opened", (event, url) => {
+    recentlyOpenedUrl = url;
+    deepLinkOpenedEventListenerSet.forEach((listener) => {
+        listener(url);
+    });
+});
+
+exports.deepLink = {
+    getRecentlyOpenedUrl,
+    addDeepLinkOpenedEventListener,
+};

--- a/namui-cli/electron/src/namuiApi/index.js
+++ b/namui-cli/electron/src/namuiApi/index.js
@@ -1,5 +1,7 @@
+const { deepLink } = require("./deepLink");
 const { fileSystem } = require("./fileSystem");
 
 exports.namuiApi = {
     fileSystem,
+    deepLink,
 };

--- a/namui-cli/src/procedures/linux/wasm_linux_electron/build.rs
+++ b/namui-cli/src/procedures/linux/wasm_linux_electron/build.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     util::{
         get_cli_root_path, get_namui_bundle_manifest, overwrite_hot_reload_script_with_empty_file,
-        print_build_result,
+        print_build_result, NamuiDeepLinkManifest,
     },
 };
 use std::{
@@ -62,6 +62,12 @@ pub fn build(manifest_path: &Path, arch: Option<Arch>) -> Result<(), Box<dyn std
         &PathBuf::from(&package_result.output_path),
         &PathBuf::from(""),
     ));
+    if let Some(namui_deep_link_manifest) = NamuiDeepLinkManifest::try_load(&project_root_path)? {
+        ops.push(CollectOperation::new(
+            namui_deep_link_manifest.path(),
+            &PathBuf::from("resources"),
+        ));
+    }
     resource_collect_service.collect_resources(ops)?;
 
     let bundle_metadata_service = BundleMetadataService::new();

--- a/namui-cli/src/procedures/linux/wasm_linux_electron/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_linux_electron/start.rs
@@ -8,7 +8,7 @@ use crate::{
         rust_project_watch_service::RustProjectWatchService,
         wasm_bundle_web_server::WasmBundleWebServer,
     },
-    util::print_build_result,
+    util::{print_build_result, NamuiDeepLinkManifest},
 };
 use std::{
     path::{Path, PathBuf},
@@ -22,7 +22,16 @@ pub fn start(manifest_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let build_dist_path = manifest_path.parent().unwrap().join("pkg");
     let project_root_path = manifest_path.parent().unwrap().to_path_buf();
 
-    start_electron_dev_service(&PORT, CrossPlatform::None, &project_root_path)?;
+    let deep_link_schemes = match NamuiDeepLinkManifest::try_load(&project_root_path)? {
+        Some(namui_deep_link_manifest) => namui_deep_link_manifest.deep_link_schemes().clone(),
+        None => Vec::new(),
+    };
+    start_electron_dev_service(
+        &PORT,
+        CrossPlatform::None,
+        &project_root_path,
+        &deep_link_schemes,
+    )?;
     let bundle_metadata_service = Arc::new(BundleMetadataService::new());
     let rust_project_watch_service = Arc::new(RustProjectWatchService::new());
     let wasm_bundle_web_server =

--- a/namui-cli/src/procedures/linux/wasm_windows_electron/build.rs
+++ b/namui-cli/src/procedures/linux/wasm_windows_electron/build.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     util::{
         get_cli_root_path, get_namui_bundle_manifest, overwrite_hot_reload_script_with_empty_file,
-        print_build_result,
+        print_build_result, NamuiDeepLinkManifest,
     },
 };
 use std::{
@@ -62,6 +62,12 @@ pub fn build(manifest_path: &Path, arch: Option<Arch>) -> Result<(), Box<dyn std
         &PathBuf::from(&package_result.output_path),
         &PathBuf::from(""),
     ));
+    if let Some(namui_deep_link_manifest) = NamuiDeepLinkManifest::try_load(&project_root_path)? {
+        ops.push(CollectOperation::new(
+            namui_deep_link_manifest.path(),
+            &PathBuf::from("resources"),
+        ));
+    }
     resource_collect_service.collect_resources(ops)?;
 
     let bundle_metadata_service = BundleMetadataService::new();

--- a/namui-cli/src/procedures/linux/wasm_windows_electron/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_windows_electron/start.rs
@@ -8,7 +8,7 @@ use crate::{
         rust_project_watch_service::RustProjectWatchService,
         wasm_bundle_web_server::WasmBundleWebServer,
     },
-    util::print_build_result,
+    util::{print_build_result, NamuiDeepLinkManifest},
 };
 use std::{
     path::{Path, PathBuf},
@@ -26,7 +26,16 @@ pub fn start(manifest_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let build_dist_path = manifest_path.parent().unwrap().join("pkg");
     let project_root_path = manifest_path.parent().unwrap().to_path_buf();
 
-    start_electron_dev_service(&PORT, CrossPlatform::WslToWindows, &project_root_path)?;
+    let deep_link_schemes = match NamuiDeepLinkManifest::try_load(&project_root_path)? {
+        Some(namui_deep_link_manifest) => namui_deep_link_manifest.deep_link_schemes().clone(),
+        None => Vec::new(),
+    };
+    start_electron_dev_service(
+        &PORT,
+        CrossPlatform::WslToWindows,
+        &project_root_path,
+        &deep_link_schemes,
+    )?;
     let bundle_metadata_service = Arc::new(BundleMetadataService::new());
     let rust_project_watch_service = Arc::new(RustProjectWatchService::new());
     let wasm_bundle_web_server =

--- a/namui-cli/src/services/electron_dev_service.rs
+++ b/namui-cli/src/services/electron_dev_service.rs
@@ -13,18 +13,26 @@ pub fn start_electron_dev_service(
     port: &u16,
     cross_platform: CrossPlatform,
     project_root_path: &PathBuf,
+    deep_link_schemes: &Vec<String>,
 ) -> Result<Child, String> {
+    let mut args = Vec::new();
+    args.push("run".to_string());
+    args.push(match cross_platform {
+        CrossPlatform::WslToWindows => "start:windows".to_string(),
+        CrossPlatform::None => "start".to_string(),
+    });
+    args.push(format!("port={}", port.to_string()));
+    args.push(format!(
+        "resourceRoot={}",
+        project_root_path.to_str().unwrap_or("")
+    ));
+    for deep_link_scheme in deep_link_schemes {
+        args.push(format!("deepLink={}", deep_link_scheme));
+    }
+
     Command::new("npm")
         .current_dir(get_electron_root_path())
-        .args([
-            "run",
-            match cross_platform {
-                CrossPlatform::WslToWindows => "start:windows",
-                CrossPlatform::None => "start",
-            },
-            format!("port={}", port.to_string()).as_str(),
-            format!("resourceRoot={}", project_root_path.to_str().unwrap_or("")).as_str(),
-        ])
+        .args(args)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/namui-cli/src/util/mod.rs
+++ b/namui-cli/src/util/mod.rs
@@ -1,15 +1,18 @@
 #[macro_use]
 mod debug_println;
-pub use debug_println::*;
-mod print_build_result;
-pub use print_build_result::*;
 mod get_cli_root_path;
-pub use get_cli_root_path::*;
-mod namui_bundle_manifest;
-pub use namui_bundle_manifest::*;
 mod get_electron_root_path;
-pub use get_electron_root_path::*;
+mod namui_bundle_manifest;
+mod namui_deep_link_manifest;
 mod overwrite_hot_reload_script_with_empty_file;
-pub use overwrite_hot_reload_script_with_empty_file::*;
+mod print_build_result;
 mod user_config;
+
+pub use debug_println::*;
+pub use get_cli_root_path::*;
+pub use get_electron_root_path::*;
+pub use namui_bundle_manifest::*;
+pub use namui_deep_link_manifest::*;
+pub use overwrite_hot_reload_script_with_empty_file::*;
+pub use print_build_result::*;
 pub use user_config::*;

--- a/namui-cli/src/util/namui_deep_link_manifest/mod.rs
+++ b/namui-cli/src/util/namui_deep_link_manifest/mod.rs
@@ -1,0 +1,2 @@
+mod namui_deep_link_manifest;
+pub use namui_deep_link_manifest::*;

--- a/namui-cli/src/util/namui_deep_link_manifest/namui_deep_link_manifest.rs
+++ b/namui-cli/src/util/namui_deep_link_manifest/namui_deep_link_manifest.rs
@@ -1,0 +1,67 @@
+use std::{error::Error, fs, path::PathBuf};
+
+pub struct NamuiDeepLinkManifest {
+    path: PathBuf,
+    deep_link_schemes: Vec<String>,
+}
+impl NamuiDeepLinkManifest {
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    pub fn deep_link_schemes(&self) -> &Vec<String> {
+        &self.deep_link_schemes
+    }
+
+    pub fn try_load(project_root_path: &PathBuf) -> Result<Option<Self>, Box<dyn Error>> {
+        let namui_deep_link_manifest_path = project_root_path.join(".namuideeplink");
+        match namui_deep_link_manifest_path.exists() {
+            true => {
+                let namui_deep_link_manifest_file = fs::read(&namui_deep_link_manifest_path)?;
+                let namui_deep_link_manifest_string =
+                    String::from_utf8(namui_deep_link_manifest_file)?;
+                let deep_link_schemes =
+                    parse_namui_deep_link_manifest(namui_deep_link_manifest_string.as_str());
+
+                Ok(Some(NamuiDeepLinkManifest {
+                    path: namui_deep_link_manifest_path.clone(),
+                    deep_link_schemes,
+                }))
+            }
+            false => Ok(None),
+        }
+    }
+}
+
+fn parse_namui_deep_link_manifest(namui_deep_link_manifest_string: &str) -> Vec<String> {
+    let mut deep_link_schemes = Vec::new();
+    for line in namui_deep_link_manifest_string.lines() {
+        let trimmed_line = line.trim();
+        if trimmed_line.len() == 0 || trimmed_line.starts_with("#") {
+            continue;
+        }
+        deep_link_schemes.push(trimmed_line.to_string());
+    }
+    deep_link_schemes
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        let input = "
+        # comment
+        one
+
+        two
+        "
+        .to_string();
+        let expected_schemes = vec!["one", "two"];
+        let mut actual_schemes = parse_namui_deep_link_manifest(input.as_str()).into_iter();
+        for expected_scheme in expected_schemes {
+            assert_eq!(actual_schemes.next().unwrap(), expected_scheme);
+        }
+    }
+}

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -155,3 +155,8 @@ pub struct RawKeyboardEvent {
     pub code: Code,
     pub pressing_codes: HashSet<Code>,
 }
+
+#[derive(Debug)]
+pub struct DeepLinkOpenedEvent {
+    pub url: String,
+}

--- a/namui/src/namui/event/mod.rs
+++ b/namui/src/namui/event/mod.rs
@@ -1,4 +1,4 @@
-use crate::{namui, RawKeyboardEvent, RawMouseEvent, RawWheelEvent};
+use crate::{namui, DeepLinkOpenedEvent, RawKeyboardEvent, RawMouseEvent, RawWheelEvent};
 use once_cell::sync::OnceCell;
 use std::any::Any;
 use tokio::sync::mpsc::{self, unbounded_channel};
@@ -27,6 +27,7 @@ pub enum NamuiEvent {
     KeyUp(RawKeyboardEvent),
     ScreenResize(namui::Wh<i16>),
     Wheel(RawWheelEvent),
+    DeepLinkOpened(DeepLinkOpenedEvent),
 }
 
 #[cfg(test)]

--- a/namui/src/namui/namui_context/main_loop/post_update_and_render.rs
+++ b/namui/src/namui/namui_context/main_loop/post_update_and_render.rs
@@ -60,7 +60,7 @@ impl NamuiContext {
                     self.rendering_tree
                         .call_keyboard_event(raw_keyboard_event, &self, DownUp::Up);
                 }
-                NamuiEvent::ScreenResize(_) => {}
+                NamuiEvent::ScreenResize(_) | NamuiEvent::DeepLinkOpened(_) => {}
             }
         }
         let now = crate::now();

--- a/namui/src/namui/namui_context/main_loop/pre_update_and_render.rs
+++ b/namui/src/namui/namui_context/main_loop/pre_update_and_render.rs
@@ -18,7 +18,8 @@ impl NamuiContext {
                 | NamuiEvent::MouseMove(_)
                 | NamuiEvent::KeyDown(_)
                 | NamuiEvent::KeyUp(_)
-                | NamuiEvent::Wheel(_) => {}
+                | NamuiEvent::Wheel(_)
+                | NamuiEvent::DeepLinkOpened(_) => {}
             }
         }
     }

--- a/namui/src/namui/system/deep_link.rs
+++ b/namui/src/namui/system/deep_link.rs
@@ -1,0 +1,35 @@
+use super::InitResult;
+use namui_cfg::namui_cfg;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+extern "C" {
+    #[namui_cfg(target_env = "electron")]
+    #[wasm_bindgen(js_namespace = ["window", "namuiApi", "deepLink"], js_name = getRecentlyOpenedUrl)]
+    fn get_recently_opened_url_() -> Option<String>;
+
+    #[namui_cfg(target_env = "electron")]
+    #[wasm_bindgen(js_namespace = ["window", "namuiApi", "deepLink"], js_name = addDeepLinkOpenedEventListener)]
+    fn add_deep_link_opened_event_listener(callback: &js_sys::Function);
+}
+
+#[namui_cfg(target_env = "electron")]
+pub(crate) async fn init() -> InitResult {
+    use crate::{DeepLinkOpenedEvent, NamuiEvent};
+    use wasm_bindgen::{prelude::Closure, JsCast};
+    let callback = Closure::wrap(Box::new(|url: String| {
+        crate::event::send(NamuiEvent::DeepLinkOpened(DeepLinkOpenedEvent { url }));
+    }) as Box<dyn Fn(String)>);
+    add_deep_link_opened_event_listener(callback.into_js_value().unchecked_ref());
+    Ok(())
+}
+
+#[namui_cfg(not(target_env = "electron"))]
+pub(crate) async fn init() -> InitResult {
+    Ok(())
+}
+
+#[namui_cfg(target_env = "electron")]
+pub fn get_recently_opened_url() -> Option<String> {
+    get_recently_opened_url_()
+}

--- a/namui/src/namui/system/mod.rs
+++ b/namui/src/namui/system/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod deep_link;
 pub mod file;
 pub mod font;
 pub(crate) mod graphics;
@@ -36,6 +37,7 @@ pub(crate) async fn init() -> InitResult {
         time::init(),
         typeface::init(),
         wheel::init(),
+        deep_link::init(),
     )?;
 
     Ok(())


### PR DESCRIPTION
# Before merging it

- [x] #292 needs to be merged fisrt

# How to use deeplink
Create a `.namuideeplink` file in the project root. The project root is where `.namuibundle` is located.

## `.namuideeplink` file
- One scheme per line.
- You can write comments with #.
ex)
```
luda-editor
# this line and
# this line will ignored.
other-scheme
```
will receive `luda-editor://some.url` and `other-scheme://other.url`


