### PR TITLE
Support open external feature

### DIFF
--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require("electron");
+const { app, BrowserWindow, ipcMain, shell } = require("electron");
 const isDev = require("electron-is-dev");
 const { existsSync, readFileSync } = require("fs");
 const path = require("path");
@@ -13,6 +13,7 @@ if (!gotTheLock) {
 
     app.whenReady().then(() => {
         ipcMain.handle("config", () => config);
+        ipcMain.on("open-external", (event, url) => shell.openExternal(url));
         createWindow();
     });
 

--- a/namui-cli/electron/src/namuiApi/index.js
+++ b/namui-cli/electron/src/namuiApi/index.js
@@ -1,7 +1,9 @@
 const { deepLink } = require("./deepLink");
 const { fileSystem } = require("./fileSystem");
+const { openExternal } = require("./openExternal");
 
 exports.namuiApi = {
     fileSystem,
     deepLink,
+    openExternal,
 };

--- a/namui-cli/electron/src/namuiApi/openExternal.js
+++ b/namui-cli/electron/src/namuiApi/openExternal.js
@@ -1,0 +1,7 @@
+const { ipcRenderer } = require("electron");
+
+function openExternal(url) {
+    ipcRenderer.send("open-external", url);
+}
+
+exports.openExternal = openExternal;

--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -1,4 +1,5 @@
 mod codes;
+mod open_external;
 mod request_animation_frame;
 mod set_timeout;
 pub mod types;
@@ -6,6 +7,7 @@ pub mod types;
 use super::render::{RenderingData, RenderingTree};
 use crate::*;
 pub use codes::*;
+pub use open_external::*;
 pub use request_animation_frame::*;
 use serde::{Deserialize, Serialize};
 use serde_repr::*;

--- a/namui/src/namui/common/open_external.rs
+++ b/namui/src/namui/common/open_external.rs
@@ -1,0 +1,20 @@
+use namui_cfg::namui_cfg;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+extern "C" {
+    #[namui_cfg(target_env = "electron")]
+    #[wasm_bindgen(js_namespace = ["window", "namuiApi"], js_name = openExternal)]
+    fn open_external_(url: &str);
+}
+#[namui_cfg(target_env = "electron")]
+pub fn open_external(url: &str) {
+    open_external_(url);
+}
+
+#[namui_cfg(not(target_env = "electron"))]
+pub fn open_external(url: &str) {
+    let _ = web_sys::window()
+        .unwrap()
+        .open_with_url_and_target(url, "_blank");
+}


### PR DESCRIPTION
# Before merging it

- [x] #292 needs to be merged first
- [x] #294 needs to be merged first

# Behavior
## on electron
Same as `shell.openExternal(url)`.
In most cases, it opens with a default browser rather than an electron.

## on non-electron
Same as ` web_sys::window().unwrap().open_with_url_and_target(url, "_blank");`
