### PR TITLE
Disable web security on electron

### DIFF
--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -32,6 +32,7 @@ function createWindow() {
         height: 720,
         webPreferences: {
             preload: path.join(__dirname, "preload.js"),
+            webSecurity: false,
         },
     });
     setOpenUrlEventHandler(app, mainWindow);

--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -33,6 +33,7 @@ function createWindow() {
         webPreferences: {
             preload: path.join(__dirname, "preload.js"),
             webSecurity: false,
+            allowRunningInsecureContent: false,
         },
     });
     setOpenUrlEventHandler(app, mainWindow);


### PR DESCRIPTION
# Before merging it

- [x] #292 needs to be merged first
- [x] #294 needs to be merged first

# Why disabled it?
Sometimes we need to bypass the cors. This is the simplest of many ways.
If there is a problem, we will have to use another method.