### PR TITLE
Start browser or electron after first build

### DIFF
--- a/namui-cli/src/procedures/linux/wasm_linux_electron/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_linux_electron/start.rs
@@ -14,15 +14,18 @@ pub fn start(manifest_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         Some(namui_deep_link_manifest) => namui_deep_link_manifest.deep_link_schemes().clone(),
         None => Vec::new(),
     };
-    start_electron_dev_service(
-        &PORT,
-        CrossPlatform::None,
-        &project_root_path,
-        &deep_link_schemes,
-    )?;
     WasmWatchBuildService::watch_and_build(WatchAndBuildArgs {
-        project_root_path,
+        project_root_path: project_root_path.clone(),
         port: PORT,
         target: Target::WasmLinuxElectron,
+        after_first_build: Some(move || {
+            start_electron_dev_service(
+                &PORT,
+                CrossPlatform::None,
+                &project_root_path,
+                &deep_link_schemes,
+            )
+            .unwrap();
+        }),
     })
 }

--- a/namui-cli/src/procedures/linux/wasm_unknown_web/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_unknown_web/start.rs
@@ -9,12 +9,14 @@ pub fn start(manifest_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let project_root_path = manifest_path.parent().unwrap().to_path_buf();
 
     let wasm_bundle_web_server_url = format!("http://localhost:{}", PORT);
-    let _ = webbrowser::open(&wasm_bundle_web_server_url);
     println!("server is running on {}", wasm_bundle_web_server_url);
 
     WasmWatchBuildService::watch_and_build(WatchAndBuildArgs {
         project_root_path,
         port: PORT,
         target: Target::WasmUnknownWeb,
+        after_first_build: Some(move || {
+            let _ = webbrowser::open(&wasm_bundle_web_server_url);
+        }),
     })
 }

--- a/namui-cli/src/procedures/linux/wasm_windows_electron/start.rs
+++ b/namui-cli/src/procedures/linux/wasm_windows_electron/start.rs
@@ -19,15 +19,18 @@ pub fn start(manifest_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         Some(namui_deep_link_manifest) => namui_deep_link_manifest.deep_link_schemes().clone(),
         None => Vec::new(),
     };
-    start_electron_dev_service(
-        &PORT,
-        CrossPlatform::WslToWindows,
-        &project_root_path,
-        &deep_link_schemes,
-    )?;
     WasmWatchBuildService::watch_and_build(WatchAndBuildArgs {
-        project_root_path,
+        project_root_path: project_root_path.clone(),
         port: PORT,
         target: Target::WasmWindowsElectron,
+        after_first_build: Some(move || {
+            start_electron_dev_service(
+                &PORT,
+                CrossPlatform::WslToWindows,
+                &project_root_path,
+                &deep_link_schemes,
+            )
+            .unwrap();
+        }),
     })
 }


### PR DESCRIPTION
Some code should be not run.
When I change the code and run `namui start`, it will run previously built code which may not be able to run.

So I changed namui-cli to run browser or electron after first build.