### PR TITLE
Only prevent default on alt key

### DIFF
--- a/namui/src/namui/system/keyboard.rs
+++ b/namui/src/namui/system/keyboard.rs
@@ -45,17 +45,8 @@ impl KeyboardSystem {
                         let mut pressing_code_set = pressing_code_set.write().unwrap();
                         pressing_code_set.insert(code);
 
-                        match code {
-                            Code::Space
-                            | Code::ArrowLeft
-                            | Code::ArrowRight
-                            | Code::ArrowUp
-                            | Code::ArrowDown
-                            | Code::AltLeft
-                            | Code::AltRight => {
-                                event.prevent_default();
-                            }
-                            _ => {}
+                        if event.alt_key() {
+                            event.prevent_default();
                         }
 
                         crate::event::send(crate::NamuiEvent::KeyDown(crate::RawKeyboardEvent {


### PR DESCRIPTION
Related PR: #206 
Related Zulip: https://namseent.zulipchat.com/#narrow/stream/332914-.EA.B8.B0.EC.88.A0.EC.97.B0.EA.B5.AC.EC.86.8C/topic/Fix.20text-input.20space

I found that key-down's preventing default block input space and arrow keys. I fixed it.

Check list
- It still block alt+arrow key
- It doesn't block space and arrow key in text input