### PR TITLE
Disable electron sandbox

### DIFF
--- a/namui-cli/electron/src/main.js
+++ b/namui-cli/electron/src/main.js
@@ -34,6 +34,7 @@ function createWindow() {
             preload: path.join(__dirname, "preload.js"),
             webSecurity: false,
             allowRunningInsecureContent: false,
+            sandbox: false,
         },
     });
     setOpenUrlEventHandler(app, mainWindow);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38313680/183815659-1153a110-cc78-40a9-9fe7-082b4d1f64ec.png)
This error occurs in Electron 20 and later versions.

It's related to [electron's update](https://www.electronjs.org/docs/latest/breaking-changes#default-changed-renderers-without-nodeintegration-true-are-sandboxed-by-default)


