### PR TITLE
Clear canvas before draw

### DIFF
--- a/namui/src/namui/namui_context/main_loop/post_update_and_render.rs
+++ b/namui/src/namui/namui_context/main_loop/post_update_and_render.rs
@@ -8,6 +8,10 @@ impl NamuiContext {
                 NamuiEvent::AnimationFrame => {
                     self.update_fps_info();
 
+                    crate::graphics::surface()
+                        .canvas()
+                        .clear(Color::TRANSPARENT);
+
                     self.rendering_tree.draw();
 
                     self.set_mouse_cursor();

--- a/namui/src/namui/skia/web/canvas.rs
+++ b/namui/src/namui/skia/web/canvas.rs
@@ -3,6 +3,9 @@ use crate::{namui::render::Matrix3x3, *};
 
 pub(crate) struct Canvas(pub CanvasKitCanvas);
 impl Canvas {
+    pub fn clear(&self, color: Color) {
+        self.0.clear(&color.into_float32_array());
+    }
     pub fn draw_text_blob(&self, text_blob: &TextBlob, x: Px, y: Px, paint: &Paint) {
         self.0
             .drawTextBlob(&text_blob.0, x.into(), y.into(), &paint.canvas_kit_paint);

--- a/namui/src/namui/skia/web/canvas_kit/canvas.rs
+++ b/namui/src/namui/skia/web/canvas_kit/canvas.rs
@@ -3,13 +3,13 @@ use super::*;
 #[wasm_bindgen]
 extern "C" {
     pub type CanvasKitCanvas;
-    // /**
-    //     /// Fills the current clip with the given color using Src BlendMode.
-    //     /// This has the effect of replacing all pixels contained by clip with color.
-    //     /// @param color
-    //     ///
-    // #[wasm_bindgen(method)]
-    // pub(crate) fn clear(this: &CanvasKitCanvas, color: InputColor);
+
+    /// Fills the current clip with the given color using Src BlendMode.
+    /// This has the effect of replacing all pixels contained by clip with color.
+    /// @param color
+    ///
+    #[wasm_bindgen(method)]
+    pub(crate) fn clear(this: &CanvasKitCanvas, color: &js_sys::Float32Array);
 
     ///
     /// Replaces clip with the intersection or difference of the current clip and path,


### PR DESCRIPTION
# What happened?
I drew full page and I routed to other page, it didn't clear page. the previous page shows up.

# Why we didn't know that before?
Because all of our project draw in full scale. We always draw something using full screen. So I found this fault when I tried to draw empty after something.

# Performance Issue
No issue. If user want to stop clear canvas for best performance, I may make option about it. But it's fast sufficiently.