### PR TITLE
Generate runtime project in build

### DIFF
--- a/namui-cli/src/services/wasm_watch_build_service.rs
+++ b/namui-cli/src/services/wasm_watch_build_service.rs
@@ -122,6 +122,11 @@ impl WasmWatchBuildService {
         let build_dist_path = project_root_path.join("pkg");
         let runtime_target_dir = project_root_path.join("target/namui");
         let rust_build_service = RustBuildService::new();
+        
+        runtime_project::wasm::generate_runtime_project(GenerateRuntimeProjectArgs {
+            target_dir: runtime_target_dir.clone(),
+            project_path: project_root_path.clone(),
+        })?;
 
         match rust_build_service.cancel_and_start_build(&BuildOption {
             target,


### PR DESCRIPTION
I found that `build` doesn't make runtime project