### PR TITLE
Support multinline text input

### DIFF
--- a/namui/Cargo.toml
+++ b/namui/Cargo.toml
@@ -60,6 +60,7 @@ features = [
     "Crypto",
     "CssStyleDeclaration",
     "HtmlInputElement",
+    "HtmlTextAreaElement",
     "InputEvent",
     "AddEventListenerOptions",
     "FileList",

--- a/namui/sample/multiline-text/src/lib.rs
+++ b/namui/sample/multiline-text/src/lib.rs
@@ -22,10 +22,10 @@ impl Entity for MultilineTextExample {
         let mut trees = vec![];
         for horizontal in 0..3 {
             for vertical in 0..3 {
-                let x = wh.width / 2.0 - 400.px() + 400.px() * horizontal;
+                let x = wh.width / 2.0 - 500.px() + 500.px() * horizontal;
                 let y = wh.height / 2.0 - 400.px() + 400.px() * vertical;
                 let text_rendering_tree = namui::text(TextParam {
-                    text: "Hello\nWorld!\nMyFriend~".to_string(),
+                    text: "Helloy\nWorlg!\nMyFriend~".to_string(), /// y and g is for descend test
                     x,
                     y,
                     align: match horizontal {
@@ -41,7 +41,7 @@ impl Entity for MultilineTextExample {
                         _ => unreachable!(),
                     },
                     font_type: FontType {
-                        size: 12.int_px(),
+                        size: 64.int_px(),
                         serif: false,
                         language: Language::Ko,
                         font_weight: FontWeight::REGULAR,
@@ -90,7 +90,7 @@ impl Entity for MultilineTextExample {
                     _ => unreachable!(),
                 },
                 font_type: FontType {
-                    size: 12.int_px(),
+                    size: 100.int_px(),
                     serif: false,
                     language: Language::Ko,
                     font_weight: FontWeight::REGULAR,

--- a/namui/sample/multiline-text/src/lib.rs
+++ b/namui/sample/multiline-text/src/lib.rs
@@ -25,7 +25,8 @@ impl Entity for MultilineTextExample {
                 let x = wh.width / 2.0 - 500.px() + 500.px() * horizontal;
                 let y = wh.height / 2.0 - 400.px() + 400.px() * vertical;
                 let text_rendering_tree = namui::text(TextParam {
-                    text: "Helloy\nWorlg!\nMyFriend~".to_string(), /// y and g is for descend test
+                    text: "Helloy\nWorlg!\nMyFriend~".to_string(),
+                    /// y and g is for descend test
                     x,
                     y,
                     align: match horizontal {

--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -22,9 +22,9 @@ impl TextInputExample {
             left_text_input: namui::TextInput::new(),
             center_text_input: namui::TextInput::new(),
             right_text_input: namui::TextInput::new(),
-            left_text: "Left".to_string(),
-            center_text: "Center".to_string(),
-            right_text: "Right".to_string(),
+            left_text: "Left\nHelloy\n    SameText".to_string(),
+            center_text: "Center\nworldy\nSameText".to_string(),
+            right_text: "Right\n안녕하세요.\nSameText    ".to_string(),
             left_value: None,
         }
     }

--- a/namui/src/namui/common/types/int_px.rs
+++ b/namui/src/namui/common/types/int_px.rs
@@ -1,4 +1,5 @@
 use super::Px;
+use crate::PxExt;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, serde::Serialize)]
 pub struct IntPx(pub(crate) i32);
@@ -14,6 +15,12 @@ pub trait IntPxExt {
 impl IntPxExt for i32 {
     fn int_px(self) -> IntPx {
         IntPx(self)
+    }
+}
+
+impl IntPx {
+    pub fn into_px(self) -> Px {
+        (self.0 as f32).px()
     }
 }
 

--- a/namui/src/namui/common/types/macros.rs
+++ b/namui/src/namui/common/types/macros.rs
@@ -87,6 +87,12 @@ macro_rules! common_for_f32_type {
             }
         }
 
+        impl<'a> std::iter::Sum<&'a $your_type> for $your_type {
+            fn sum<I: Iterator<Item = &'a $your_type>>(iter: I) -> Self {
+                iter.fold(Self::default(), |acc, x| acc + x)
+            }
+        }
+
         $crate::types::macros::impl_op_forward_ref_reversed_for_f32_i32_usize!(*|lhs: $your_type, rhs: f32| -> $your_type {
             (lhs.as_f32() * rhs).into()
         });

--- a/namui/src/namui/render/text.rs
+++ b/namui/src/namui/render/text.rs
@@ -1,5 +1,5 @@
 use crate::{
-    draw::text::{get_bottom_of_baseline, get_left_in_align},
+    draw::text::{get_bottom_of_baseline, get_left_in_align, get_line_height},
     namui::{self, *},
 };
 
@@ -169,9 +169,9 @@ fn draw_background(param: &TextParam, font: &Font) -> RenderingTree {
 
     let font_metrics = font.metrics;
 
-    let height = -font_metrics.ascent + font_metrics.descent;
+    let height = get_line_height(param.font_type.size);
     let bottom_of_baseline = get_bottom_of_baseline(param.baseline, font_metrics);
-    let top = param.y + bottom_of_baseline + font_metrics.ascent;
+    let top = param.y + bottom_of_baseline + font_metrics.descent + font_metrics.ascent;
 
     let margin = background.margin.unwrap_or(Ltrb::default());
 

--- a/namui/src/namui/render/text_input/draw_caret.rs
+++ b/namui/src/namui/render/text_input/draw_caret.rs
@@ -1,23 +1,33 @@
 use super::*;
-use crate::{
-    draw::text::get_bottom_of_baseline,
-    namui::{self, get_text_width_internal, RenderingTree},
-    TextParam,
-};
+use crate::{draw::text::*, namui::*, TextParam};
 
 impl TextInput {
+    /// Caret is drawn at the end of the text.
     pub(crate) fn draw_caret(&self, text_param: &TextParam) -> RenderingTree {
         let selection = &self.selection;
         if selection.is_none() {
             return RenderingTree::Empty;
         };
         let selection = selection.as_ref().unwrap();
+        let line_texts = text_param.text.split_inclusive("\n").collect::<Vec<_>>();
 
-        let char_vec = text_param.text.chars().collect::<Vec<_>>();
-        let char_vec_len = char_vec.len();
-        let selection = selection.start.min(char_vec_len)..selection.end.min(char_vec_len); // Note: https://docs.google.com/document/d/1BYWl4DeCih52fjgxa8DHszISA3fOJxKrAtCYba6uJXE/edit#heading=h.xoyzkdbf352y
-        let left_text_string: String = char_vec[..selection.end].iter().collect();
-        let right_text_string: String = char_vec[selection.end..].iter().collect();
+        let caret = get_multiline_caret(selection.end, &text_param.text);
+
+        let line_height = get_line_height(text_param.font_type.size);
+
+        let multiline_y_baseline_offset =
+            get_multiline_y_baseline_offset(text_param.baseline, line_height, line_texts.len());
+
+        let y = text_param.y + multiline_y_baseline_offset + line_height * caret.line_index;
+        let line_text = if caret.line_index == line_texts.len() {
+            ""
+        } else {
+            line_texts[caret.line_index]
+        };
+        let char_vec = line_text.chars().collect::<Vec<_>>();
+
+        let left_text_string: String = char_vec[..caret.caret_index_in_line].iter().collect();
+        let right_text_string: String = char_vec[caret.caret_index_in_line..].iter().collect();
 
         let font = namui::font::get_font(text_param.font_type);
 
@@ -34,23 +44,23 @@ impl TextInput {
         let total_width = left_text_width + right_text_width;
 
         let left = match text_param.align {
-            namui::TextAlign::Left => text_param.x,
+            namui::TextAlign::Left => text_param.x - 1.px(),
             namui::TextAlign::Center => text_param.x - total_width / 2.0,
-            namui::TextAlign::Right => text_param.x - total_width,
+            namui::TextAlign::Right => text_param.x - total_width + 1.px(),
         } + left_text_width;
 
         let font_metrics = font.metrics;
-        let font_height = -font_metrics.ascent + font_metrics.descent;
         let top = get_bottom_of_baseline(text_param.baseline, font_metrics)
             + font_metrics.ascent
-            + text_param.y;
+            + font_metrics.descent
+            + y;
 
         crate::rect(RectParam {
             rect: Rect::Xywh {
                 x: left,
                 y: top,
-                width: 1.0.into(),
-                height: font_height,
+                width: 2.0.into(),
+                height: line_height,
             },
             style: RectStyle {
                 fill: Some(RectFill {
@@ -59,5 +69,37 @@ impl TextInput {
                 ..Default::default()
             },
         })
+    }
+}
+
+pub struct MultilineCaret {
+    pub line_index: usize,
+    pub caret_index_in_line: usize,
+}
+pub fn get_multiline_caret(selection_index: usize, text: &str) -> MultilineCaret {
+    let line_texts = text
+        .split_inclusive("\n")
+        .map(|text| text.chars().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let mut line_index = 0;
+    let mut line_start_character_index = 0;
+    loop {
+        if line_texts.len() == line_index {
+            break MultilineCaret {
+                line_index,
+                caret_index_in_line: 0,
+            };
+        }
+        let line_text = &line_texts[line_index];
+        if selection_index < line_start_character_index + line_text.len()
+            || !line_text.ends_with(&['\n'])
+        {
+            break MultilineCaret {
+                line_index,
+                caret_index_in_line: selection_index - line_start_character_index,
+            };
+        }
+        line_index += 1;
+        line_start_character_index += line_text.len();
     }
 }

--- a/namui/src/namui/render/text_input/draw_texts_divided_by_selection.rs
+++ b/namui/src/namui/render/text_input/draw_texts_divided_by_selection.rs
@@ -1,10 +1,18 @@
+use super::draw_caret::get_multiline_caret;
 use crate::{
+    draw::text::get_line_height,
     namui::{self, get_text_width_internal, RenderingTree, TextInput},
-    render, Px, TextParam, TextStyleBackground,
+    render, Font, Px, TextParam, TextStyleBackground,
 };
 
 impl TextInput {
     pub(crate) fn draw_texts_divided_by_selection(&self, text_param: TextParam) -> RenderingTree {
+        let font = namui::font::get_font(text_param.font_type);
+        if font.is_none() {
+            return RenderingTree::Empty;
+        }
+        let font = font.unwrap();
+
         let is_not_divided_by_selection = self
             .selection
             .as_ref()
@@ -14,6 +22,8 @@ impl TextInput {
             return namui::text(text_param);
         };
 
+        let line_texts = text_param.text.lines().collect::<Vec<_>>();
+
         let selection = self.selection.as_ref().unwrap();
 
         let (left_selection_index, right_selection_index) = if selection.start < selection.end {
@@ -22,73 +32,237 @@ impl TextInput {
             (selection.end, selection.start)
         };
 
-        let (left_text_string, selected_text_string, right_text_string) = (
-            &text_param.text[..left_selection_index],
-            &text_param.text[left_selection_index..right_selection_index],
-            &text_param.text[right_selection_index..],
-        );
+        let left_caret = get_multiline_caret(left_selection_index, &text_param.text);
+        let right_caret = get_multiline_caret(right_selection_index, &text_param.text);
 
-        let result = self.get_text_lefts(
+        let render_checking_background_order =
+            |render_only_selection_background: bool| -> RenderingTree {
+                let non_selected_upper_lines = if render_only_selection_background {
+                    RenderingTree::Empty
+                } else {
+                    render((0..left_caret.line_index).map(|line_index| {
+                        let y =
+                            text_param.y + get_line_height(text_param.font_type.size) * line_index;
+                        let line_text = line_texts[line_index];
+                        crate::text(TextParam {
+                            y,
+                            text: line_text.to_string(),
+                            ..text_param
+                        })
+                    }))
+                };
+
+                let is_single_line = left_caret.line_index == right_caret.line_index;
+                let selected_lines = if is_single_line {
+                    let y = text_param.y
+                        + get_line_height(text_param.font_type.size) * left_caret.line_index;
+                    self.render_single_line(
+                        &text_param,
+                        font.as_ref(),
+                        &line_texts[left_caret.line_index].chars().collect(),
+                        y,
+                        left_caret.caret_index_in_line,
+                        right_caret.caret_index_in_line,
+                        render_only_selection_background,
+                        false,
+                    )
+                } else {
+                    let line_indexes_in_the_middle =
+                        left_caret.line_index + 1..right_caret.line_index;
+
+                    let first_line = {
+                        let y = text_param.y
+                            + get_line_height(text_param.font_type.size) * left_caret.line_index;
+
+                        let first_line_text_with_newline =
+                            line_texts[left_caret.line_index].chars().collect();
+
+                        self.render_single_line(
+                            &text_param,
+                            font.as_ref(),
+                            &first_line_text_with_newline,
+                            y,
+                            left_caret.caret_index_in_line,
+                            first_line_text_with_newline.len(),
+                            render_only_selection_background,
+                            true,
+                        )
+                    };
+
+                    let middle_lines = line_indexes_in_the_middle.map(|line_index| {
+                        let y =
+                            text_param.y + get_line_height(text_param.font_type.size) * line_index;
+
+                        let line_text_with_newline = line_texts[line_index].chars().collect();
+
+                        self.render_single_line(
+                            &text_param,
+                            font.as_ref(),
+                            &line_text_with_newline,
+                            y,
+                            0,
+                            line_text_with_newline.len(),
+                            render_only_selection_background,
+                            true,
+                        )
+                    });
+
+                    let last_line = {
+                        let y = text_param.y
+                            + get_line_height(text_param.font_type.size) * right_caret.line_index;
+
+                        let text = if line_texts.len() == right_caret.line_index {
+                            ""
+                        } else {
+                            line_texts[right_caret.line_index]
+                        }
+                        .chars()
+                        .collect();
+
+                        self.render_single_line(
+                            &text_param,
+                            font.as_ref(),
+                            &text,
+                            y,
+                            0,
+                            right_caret.caret_index_in_line,
+                            render_only_selection_background,
+                            false,
+                        )
+                    };
+
+                    render([first_line, render(middle_lines), last_line])
+                };
+
+                let non_selected_lower_lines = if render_only_selection_background {
+                    RenderingTree::Empty
+                } else {
+                    render(
+                        (right_caret.line_index + 1..line_texts.len()).map(|line_index| {
+                            let y = text_param.y
+                                + get_line_height(text_param.font_type.size) * line_index;
+                            let line_text = line_texts[line_index];
+                            crate::text(TextParam {
+                                y,
+                                text: line_text.to_string(),
+                                ..text_param
+                            })
+                        }),
+                    )
+                };
+
+                render([
+                    non_selected_upper_lines,
+                    selected_lines,
+                    non_selected_lower_lines,
+                ])
+            };
+
+        render([
+            render_checking_background_order(true),
+            render_checking_background_order(false),
+        ])
+    }
+
+    fn render_single_line(
+        &self,
+        text_param: &TextParam,
+        font: &Font,
+        text: &Vec<char>,
+        y: Px,
+        left_caret_index: usize,
+        right_caret_index: usize,
+        render_only_selection_background: bool,
+        with_newline_background: bool,
+    ) -> RenderingTree {
+        let (left_text_string, selected_text_string, right_text_string) = (
+            &text[..left_caret_index].iter().collect::<String>(),
+            &text[left_caret_index..right_caret_index]
+                .iter()
+                .collect::<String>(),
+            &text[right_caret_index..].iter().collect::<String>(),
+        );
+        let (left_text_left, selected_text_left, right_text_left) = self.get_text_lefts(
             &text_param,
+            font,
             left_text_string,
             selected_text_string,
             right_text_string,
         );
-        if result.is_none() {
-            return RenderingTree::Empty;
-        };
 
-        let (left_text_left, selected_text_left, right_text_left) = result.unwrap();
+        if render_only_selection_background {
+            let left = selected_text_left;
+            let top = y;
+            let line_height = get_line_height(text_param.font_type.size);
 
-        let left_text_text_param = namui::TextParam {
-            x: left_text_left,
-            text: left_text_string.to_string(),
-            align: crate::TextAlign::Left,
-            ..text_param
-        };
+            let mut width = get_text_width_internal(font, &selected_text_string, None);
+            if with_newline_background {
+                width += font.get_glyph_widths(font.get_glyph_ids(" "), None)[0]
+            };
 
-        let selected_text_text_param = namui::TextParam {
-            x: selected_text_left,
-            text: selected_text_string.to_string(),
-            style: namui::TextStyle {
-                color: namui::Color::WHITE,
-                background: Some(TextStyleBackground {
-                    color: namui::Color::BLUE,
-                    ..Default::default()
-                }),
-                ..left_text_text_param.style
-            },
-            align: crate::TextAlign::Left,
-            ..text_param
-        };
-        let right_text_text_param = namui::TextParam {
-            x: right_text_left,
-            text: right_text_string.to_string(),
-            align: crate::TextAlign::Left,
-            ..text_param
-        };
+            namui::rect(crate::RectParam {
+                rect: crate::Rect::Xywh {
+                    x: left,
+                    y: top,
+                    width,
+                    height: line_height,
+                },
+                style: crate::RectStyle {
+                    stroke: None,
+                    fill: Some(crate::RectFill {
+                        color: namui::Color::BLUE,
+                    }),
+                    round: None,
+                },
+            })
+        } else {
+            let left_text_text_param = namui::TextParam {
+                x: left_text_left,
+                y,
+                text: left_text_string.to_string(),
+                align: crate::TextAlign::Left,
+                ..text_param.clone()
+            };
 
-        let left_text = namui::text(left_text_text_param);
-        let selected_text = namui::text(selected_text_text_param);
-        let right_text = namui::text(right_text_text_param);
+            let selected_text_text_param = namui::TextParam {
+                x: selected_text_left,
+                y,
+                text: selected_text_string.to_string(),
+                style: namui::TextStyle {
+                    color: namui::Color::WHITE,
+                    background: Some(TextStyleBackground {
+                        color: namui::Color::TRANSPARENT,
+                        ..Default::default()
+                    }),
+                    ..left_text_text_param.style
+                },
+                align: crate::TextAlign::Left,
+                ..text_param.clone()
+            };
+            let right_text_text_param = namui::TextParam {
+                x: right_text_left,
+                y,
+                text: right_text_string.to_string(),
+                align: crate::TextAlign::Left,
+                ..text_param.clone()
+            };
 
-        return render![left_text, selected_text, right_text];
+            let left_text = namui::text(left_text_text_param);
+            let selected_text = namui::text(selected_text_text_param);
+            let right_text = namui::text(right_text_text_param);
+
+            render([left_text, selected_text, right_text])
+        }
     }
 
     fn get_text_lefts(
         &self,
         text_param: &TextParam,
+        font: &Font,
         left_text_string: &str,
         selected_text_string: &str,
         right_text_string: &str,
-    ) -> Option<(Px, Px, Px)> {
-        let font = namui::font::get_font(text_param.font_type);
-
-        if font.is_none() {
-            return None;
-        }
-        let font = font.unwrap();
-
+    ) -> (Px, Px, Px) {
         let drop_shadow_x = text_param.style.drop_shadow.map(|shadow| shadow.x);
 
         let (left_text_width, selected_text_width, right_text_width) = (
@@ -106,17 +280,17 @@ impl TextInput {
         );
 
         match text_param.align {
-            namui::TextAlign::Left => Some(result),
-            namui::TextAlign::Center => Some((
+            namui::TextAlign::Left => result,
+            namui::TextAlign::Center => (
                 result.0 - total_width / 2.0,
                 result.1 - total_width / 2.0,
                 result.2 - total_width / 2.0,
-            )),
-            namui::TextAlign::Right => Some((
+            ),
+            namui::TextAlign::Right => (
                 result.0 - total_width,
                 result.1 - total_width,
                 result.2 - total_width,
-            )),
+            ),
         }
     }
 }

--- a/namui/src/namui/skia/types.rs
+++ b/namui/src/namui/skia/types.rs
@@ -1,4 +1,4 @@
-use crate::{Px, Rect};
+use crate::Px;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::hash_map::DefaultHasher,
@@ -15,8 +15,6 @@ pub struct FontMetrics {
     pub descent: Px,
     /// suggested spacing between descent of previous line and ascent of next line.
     pub leading: Px,
-    /// smallest rect containing all glyphs (relative to 0,0)
-    pub bounds: Option<Rect<Px>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, Hash, Eq, PartialEq)]

--- a/namui/src/namui/skia/web/font.rs
+++ b/namui/src/namui/skia/web/font.rs
@@ -8,7 +8,7 @@ unsafe impl Send for CanvasKitFont {}
 pub struct Font {
     pub(crate) id: String,
     pub(crate) canvas_kit_font: CanvasKitFont,
-    pub(crate) size: i16,
+    pub(crate) size: IntPx,
     pub(crate) metrics: FontMetrics,
     glyph_ids_caches: Mutex<lru::LruCache<String, Arc<GlyphIds>>>,
     glyph_widths_caches: Mutex<lru::LruCache<(Arc<GlyphIds>, Option<Paint>), Vec<Px>>>,
@@ -16,28 +16,21 @@ pub struct Font {
 }
 
 impl Font {
-    pub fn generate_id(typeface: &Typeface, size: i16) -> String {
+    pub fn generate_id(typeface: &Typeface, size: IntPx) -> String {
         format!("{}-{}", typeface.id, size)
     }
-    pub fn new(typeface: &Typeface, size: i16) -> Self {
-        let canvas_kit_font = CanvasKitFont::new(&typeface.canvas_kit_typeface, size);
+    pub fn new(typeface: &Typeface, size: IntPx) -> Self {
+        let canvas_kit_font = CanvasKitFont::new(&typeface.canvas_kit_typeface, size.0 as i16);
         Font {
             id: Self::generate_id(typeface, size),
             size,
             metrics: {
                 let canvas_kit_font_metrics = &canvas_kit_font.getMetrics();
-                let bounds = canvas_kit_font_metrics.bounds().map(|numbers| Rect::Ltrb {
-                    left: numbers[0].into(),
-                    top: numbers[1].into(),
-                    right: numbers[2].into(),
-                    bottom: numbers[3].into(),
-                });
 
                 FontMetrics {
                     ascent: canvas_kit_font_metrics.ascent().into(),
                     descent: canvas_kit_font_metrics.descent().into(),
                     leading: canvas_kit_font_metrics.leading().into(),
-                    bounds,
                 }
             },
             canvas_kit_font,

--- a/namui/src/namui/system/font/mod.rs
+++ b/namui/src/namui/system/font/mod.rs
@@ -1,7 +1,7 @@
 use super::InitResult;
 use crate::{
     namui::{skia::Font, FontType, TypefaceType},
-    Typeface,
+    IntPx, Typeface,
 };
 use dashmap::DashMap;
 use std::sync::Arc;
@@ -38,7 +38,7 @@ pub fn get_font(font_type: FontType) -> Option<Arc<Font>> {
         },
     }
 }
-pub fn get_font_of_typeface(typeface: Arc<Typeface>, font_size: i16) -> Arc<Font> {
+pub fn get_font_of_typeface(typeface: Arc<Typeface>, font_size: IntPx) -> Arc<Font> {
     let key = Font::generate_id(&typeface, font_size);
     let font = FONT_SYSTEM.typeface_fonts.get(&key);
     match font {
@@ -58,10 +58,10 @@ fn create_font_from_font_type(font_type: FontType) -> Result<Arc<Font>, String> 
     };
     let typeface = crate::typeface::get_typeface(typeface_type);
     match typeface {
-        Some(typeface) => Ok(crate_font(&typeface, font_type.size.0.try_into().unwrap())),
+        Some(typeface) => Ok(crate_font(&typeface, font_type.size)),
         None => Err(format!("Could not find typeface for {:?}", font_type)),
     }
 }
-fn crate_font(typeface: &Typeface, font_size: i16) -> Arc<Font> {
+fn crate_font(typeface: &Typeface, font_size: IntPx) -> Arc<Font> {
     Arc::new(Font::new(typeface, font_size))
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/3580430/188393965-af8bade7-54d4-46c8-b47b-3af22a715b3a.mp4

# What I did
Support multiple line text input

# Known issue

- In align right, it needs to put space(` `) width margin.
  - Will fix if we need right-align text input later.
- Caret position is not exactly same between align.
  - I think we don't have to fix it right now. it's very little pixel bug.
- Baseline won't work for multiline text input
  - Will fix if we need not-top baseline text input later.
- TextInput system's variable name is still `inputElement` even I changed it to `HTML textAreaElement`
  - I think we don't have to fix it because it's very similar both.
- overflow line break doesn't work
  - Will be next pr.