### PR TITLE
Rename file dialog to file picker

### DIFF
--- a/namui/src/namui/system/file/mod.rs
+++ b/namui/src/namui/system/file/mod.rs
@@ -1,7 +1,7 @@
 pub mod bundle;
-pub mod dialog;
 mod electron;
 mod init;
+pub mod picker;
 pub mod system_drive;
 pub mod types;
 

--- a/namui/src/namui/system/file/picker/mod.rs
+++ b/namui/src/namui/system/file/picker/mod.rs
@@ -7,7 +7,7 @@ pub struct File {
     inner: web_sys::File,
 }
 
-/// NOTE: This would not emit any events if user cancels the file selection and closes the dialog.
+/// NOTE: This would not emit any events if user cancels the file selection and closes the picker.
 pub async fn open() -> Box<[File]> {
     let input = document()
         .create_element("input")


### PR DESCRIPTION
The name `File dialog` is very ambiguous so I renamed it to `file picker`