### PR TITLE
Apply on_top filter to text_input

### DIFF
--- a/namui/src/namui/namui_context/main_loop/post_update_and_render.rs
+++ b/namui/src/namui/namui_context/main_loop/post_update_and_render.rs
@@ -24,13 +24,15 @@ impl NamuiContext {
                     }
                 }
                 NamuiEvent::MouseDown(raw_mouse_event) => {
-                    crate::system::text_input::on_mouse_down_in(&self, &raw_mouse_event);
+                    crate::system::text_input::on_mouse_down_in_before_attach_event_calls();
 
                     self.rendering_tree.call_mouse_event(
                         MouseEventType::Down,
                         raw_mouse_event,
                         &self,
                     );
+
+                    crate::system::text_input::on_mouse_down_in_after_attach_event_calls();
                 }
                 NamuiEvent::MouseUp(raw_mouse_event) => {
                     crate::system::text_input::on_mouse_up_in();

--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -84,8 +84,11 @@ impl TextInput {
 
         let line_texts = LineTexts::new(&props.text, &fonts, &paint, Some(props.rect.width()));
 
-        let custom_props = props.clone();
-        (render![
+        let custom_data = TextInputCustomData {
+            text_input: self.clone(),
+            props: props.clone(),
+        };
+        render([
             namui::rect(RectParam {
                 rect: props.rect,
                 style: props.rect_style,
@@ -93,9 +96,15 @@ impl TextInput {
             self.draw_texts_divided_by_selection(&props, &fonts, &paint, &line_texts),
             self.draw_caret(&props, &line_texts),
         ])
-        .with_custom(TextInputCustomData {
-            text_input: self.clone(),
-            props: custom_props,
+        .with_custom(custom_data.clone())
+        .attach_event(|builder| {
+            let custom_data = custom_data.clone();
+            builder.on_mouse_down_in(move |event| {
+                system::text_input::on_mouse_down_in_at_attach_event_calls(
+                    event.local_xy,
+                    &custom_data,
+                )
+            });
         })
     }
     pub fn update(&mut self, event: &dyn std::any::Any) {

--- a/namui/src/namui/system/text_input/find.rs
+++ b/namui/src/namui/system/text_input/find.rs
@@ -26,31 +26,3 @@ pub fn find_text_input_by_id(
 
     return_value
 }
-pub fn find_front_text_input_on_mouse(
-    rendering_tree: &RenderingTree,
-    raw_mouse_event: &RawMouseEvent,
-) -> Option<TextInputCustomData> {
-    let mut return_value: Option<TextInputCustomData> = None;
-
-    rendering_tree.visit_rln(|rendering_tree, utils| {
-        match rendering_tree {
-            RenderingTree::Special(special) => match special {
-                render::SpecialRenderingNode::Custom(custom) => {
-                    if let Some(custom_data) = custom.data.downcast_ref::<TextInputCustomData>() {
-                        let is_custom_in_mouse = utils.is_xy_in(raw_mouse_event.xy);
-
-                        if is_custom_in_mouse {
-                            return_value = Some(custom_data.clone());
-                            return ControlFlow::Break(());
-                        }
-                    }
-                }
-                _ => {}
-            },
-            _ => {}
-        };
-        ControlFlow::Continue(())
-    });
-
-    return_value
-}


### PR DESCRIPTION
# What Happened?
- `on_top`'s mouse event filtering doesn't worked with text_input
  - Because `on_top` mouse filtering was on [`call_mouse_event`](https://github.com/NamseEnt/namseent/blob/master/namui/src/namui/render/rendering_tree/mod.rs#L214), which called after [`text_input`'s `on_mouse_down_in`](https://github.com/NamseEnt/namseent/blob/03997970ec349e6babb1e44d02ca9d176e63805f/namui/src/namui/namui_context/main_loop/post_update_and_render.rs#L27).
- So I opened modal and clicked it, the text input behind the modal was clicked even I stop propagation.

# How did I fix
- Called `text_input`'s mouse down event handler with `text_input` rendering tree's `attach_event`. So it finally works with `RenderingTree`'s `call_mouse_event` logic.

Tested in visual novel editor and namui text_input sample