### PR TITLE
Support Keydown, Focus for text_input

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -31,26 +31,21 @@ impl LoadedSequenceEditorPage {
                 }
             }
         } else if let Some(event) = event.downcast_ref::<text_input::Event>() {
-            match event {
-                text_input::Event::Focus(_)
-                | text_input::Event::Blur(_)
-                | text_input::Event::SelectionUpdated(_) => {}
-                text_input::Event::TextUpdated(updated) => {
-                    let selected_cut_id =
-                        self.line_text_inputs
-                            .iter()
-                            .find_map(|(cut_id, text_input)| {
-                                if text_input.is_focused() {
-                                    Some(cut_id)
-                                } else {
-                                    None
-                                }
-                            });
-                    self.editor_history_system
-                        .mutate_cut(selected_cut_id.unwrap(), |cut| {
-                            cut.line = updated.text.clone();
+            if let text_input::Event::TextUpdated { text, .. } = event {
+                let selected_cut_id =
+                    self.line_text_inputs
+                        .iter()
+                        .find_map(|(cut_id, text_input)| {
+                            if text_input.is_focused() {
+                                Some(cut_id)
+                            } else {
+                                None
+                            }
                         });
-                }
+                self.editor_history_system
+                    .mutate_cut(selected_cut_id.unwrap(), |cut| {
+                        cut.line = text.clone();
+                    });
             }
         }
         //         else if let Some(event) = event.downcast_ref::<crate::storage::Event>() {

--- a/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
@@ -23,8 +23,8 @@ impl RenameModal {
         }
     }
     pub fn update(&mut self, event: &dyn std::any::Any) {
-        if let Some(text_input::Event::TextUpdated(event)) = event.downcast_ref() {
-            self.sequence_name = event.text.clone();
+        if let Some(text_input::Event::TextUpdated { text, .. }) = event.downcast_ref() {
+            self.sequence_name = text.clone();
         }
         if let Some(namui::event::NamuiEvent::KeyUp(event)) = event.downcast_ref() {
             if event.code == Code::Enter {

--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -152,18 +152,18 @@ impl Entity for TextInputExample {
     fn update(&mut self, event: &dyn std::any::Any) {
         if let Some(event) = event.downcast_ref::<text_input::Event>() {
             match event {
-                text_input::Event::TextUpdated(text_updated) => {
-                    if self.left_text_input.get_id().eq(&text_updated.id) {
-                        self.left_text = text_updated.text.clone();
+                text_input::Event::TextUpdated { id, text, .. } => {
+                    if self.left_text_input.get_id().eq(id) {
+                        self.left_text = text.clone();
                         self.left_value = self.left_text.parse().ok(); // NOTE: You don't have to check value in here, it's would be better UX checking it on blur.
-                    } else if self.center_text_input.get_id().eq(&text_updated.id) {
-                        self.center_text = text_updated.text.clone();
-                    } else if self.right_text_input.get_id().eq(&text_updated.id) {
-                        self.right_text = text_updated.text.clone();
+                    } else if self.center_text_input.get_id().eq(id) {
+                        self.center_text = text.clone();
+                    } else if self.right_text_input.get_id().eq(id) {
+                        self.right_text = text.clone();
                     }
                 }
-                text_input::Event::Blur(blur) => {
-                    if self.left_text_input.get_id().eq(&blur.id) {
+                text_input::Event::Blur { id } => {
+                    if self.left_text_input.get_id().eq(id) {
                         self.left_value = self.left_text.parse().ok();
                     }
                 }

--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -34,28 +34,28 @@ pub struct TextInputCustomData {
     pub props: Props,
 }
 pub enum Event {
-    Focus(Focus),
-    Blur(Blur),
-    TextUpdated(TextUpdated),
-    SelectionUpdated(SelectionUpdated),
+    Focus {
+        id: String,
+        selection: Selection,
+    },
+    Blur {
+        id: String,
+    },
+    TextUpdated {
+        id: String,
+        text: String,
+        selection: Selection,
+    },
+    SelectionUpdated {
+        id: String,
+        selection: Selection,
+    },
+    KeyDown {
+        id: String,
+        code: Code,
+    },
 }
 
-pub struct Blur {
-    pub id: String,
-}
-pub struct Focus {
-    pub id: String,
-    pub selection: Selection,
-}
-pub struct TextUpdated {
-    pub id: String,
-    pub text: String,
-    pub selection: Selection,
-}
-pub struct SelectionUpdated {
-    pub id: String,
-    pub selection: Selection,
-}
 impl TextInput {
     pub fn new() -> TextInput {
         TextInput {
@@ -110,33 +110,37 @@ impl TextInput {
     pub fn update(&mut self, event: &dyn std::any::Any) {
         if let Some(event) = event.downcast_ref::<Event>() {
             match event {
-                Event::Focus(focus) => {
-                    if focus.id == self.id {
-                        self.selection = focus.selection.clone();
+                Event::Focus { id, selection } => {
+                    if self.id.eq(id) {
+                        self.selection = selection.clone();
                     } else {
                         self.selection = None; // TODO: Remove this and draw unfocus caret in different way
                     }
                 }
-                Event::Blur(blur) => {
-                    if blur.id == self.id {
+                Event::Blur { id } => {
+                    if self.id.eq(id) {
                         self.selection = None; // TODO: Remove this and draw unfocus caret in different way
                     }
                 }
-                Event::SelectionUpdated(selection_updated) => {
-                    if selection_updated.id == self.id {
-                        self.selection = selection_updated.selection.clone();
+                Event::SelectionUpdated { id, selection } => {
+                    if self.id.eq(id) {
+                        self.selection = selection.clone();
                     }
                 }
-                Event::TextUpdated(text_updated) => {
-                    if text_updated.id == self.id {
-                        self.selection = text_updated.selection.clone();
+                Event::TextUpdated { id, selection, .. } => {
+                    if self.id.eq(id) {
+                        self.selection = selection.clone();
                     }
                 }
+                Event::KeyDown { .. } => {}
             }
         }
     }
     pub fn is_focused(&self) -> bool {
         crate::system::text_input::is_focused(&self.id)
+    }
+    pub fn focus(&self) {
+        crate::system::text_input::focus(&self.id)
     }
 }
 

--- a/namui/src/namui/system/text_input/key_down.rs
+++ b/namui/src/namui/system/text_input/key_down.rs
@@ -16,14 +16,6 @@ pub enum KeyInInterest {
 }
 
 pub(crate) fn on_key_down(namui_context: &NamuiContext, raw_keyboard_event: &RawKeyboardEvent) {
-    let key_in_interest = match raw_keyboard_event.code {
-        Code::ArrowUp => KeyInInterest::ArrowUpDown(ArrowUpDown::Up),
-        Code::ArrowDown => KeyInInterest::ArrowUpDown(ArrowUpDown::Down),
-        Code::Home => KeyInInterest::HomeEnd(HomeEnd::Home),
-        Code::End => KeyInInterest::HomeEnd(HomeEnd::End),
-        _ => return,
-    };
-
     let input_element = get_input_element();
     let last_focused_text_input_id = TEXT_INPUT_SYSTEM.last_focused_text_input_id.lock().unwrap();
 
@@ -39,6 +31,27 @@ pub(crate) fn on_key_down(namui_context: &NamuiContext, raw_keyboard_event: &Raw
         return;
     }
     let custom_data = custom_data.unwrap();
+
+    crate::event::send(text_input::Event::KeyDown {
+        id: last_focused_text_input_id.clone(),
+        code: raw_keyboard_event.code,
+    });
+
+    handle_selection_change(&custom_data, input_element, raw_keyboard_event);
+}
+
+fn handle_selection_change(
+    custom_data: &TextInputCustomData,
+    input_element: HtmlTextAreaElement,
+    raw_keyboard_event: &RawKeyboardEvent,
+) {
+    let key_in_interest = match raw_keyboard_event.code {
+        Code::ArrowUp => KeyInInterest::ArrowUpDown(ArrowUpDown::Up),
+        Code::ArrowDown => KeyInInterest::ArrowUpDown(ArrowUpDown::Down),
+        Code::Home => KeyInInterest::HomeEnd(HomeEnd::Home),
+        Code::End => KeyInInterest::HomeEnd(HomeEnd::End),
+        _ => return,
+    };
 
     let selection = custom_data
         .text_input

--- a/namui/src/namui/system/text_input/mod.rs
+++ b/namui/src/namui/system/text_input/mod.rs
@@ -195,7 +195,6 @@ fn on_selection_change() {
 }
 
 pub fn focus(text_input_id: &str) {
-    crate::log!("Focus");
     let input_element = get_input_element();
     input_element.focus().unwrap();
     TEXT_INPUT_SYSTEM

--- a/namui/src/namui/system/text_input/mod.rs
+++ b/namui/src/namui/system/text_input/mod.rs
@@ -150,11 +150,11 @@ fn on_text_element_input(input_element: &HtmlTextAreaElement) {
     let last_focused_text_input_id = last_focused_text_input_id.as_ref().unwrap();
     let selection = get_selection(&input_element);
 
-    crate::event::send(text_input::Event::TextUpdated(TextUpdated {
+    crate::event::send(text_input::Event::TextUpdated {
         id: last_focused_text_input_id.clone(),
         text: text.to_string(),
         selection,
-    }))
+    })
 }
 fn get_selection(input_element: &HtmlTextAreaElement) -> text_input::Selection {
     let selection_start = input_element.selection_start().unwrap();
@@ -188,10 +188,19 @@ fn on_selection_change() {
 
     let selection = get_selection(&input_element);
 
-    crate::event::send(text_input::Event::SelectionUpdated(
-        text_input::SelectionUpdated {
-            id: text_input_id,
-            selection,
-        },
-    ));
+    crate::event::send(text_input::Event::SelectionUpdated {
+        id: text_input_id,
+        selection,
+    });
+}
+
+pub fn focus(text_input_id: &str) {
+    crate::log!("Focus");
+    let input_element = get_input_element();
+    input_element.focus().unwrap();
+    TEXT_INPUT_SYSTEM
+        .last_focused_text_input_id
+        .lock()
+        .unwrap()
+        .replace(text_input_id.to_string());
 }

--- a/namui/src/namui/system/text_input/mouse_event.rs
+++ b/namui/src/namui/system/text_input/mouse_event.rs
@@ -17,7 +17,7 @@ pub(crate) fn on_mouse_down_in_after_attach_event_calls() {
         let mut last_focused_text_input_id =
             TEXT_INPUT_SYSTEM.last_focused_text_input_id.lock().unwrap();
         if let Some(id) = last_focused_text_input_id.as_ref() {
-            crate::event::send(text_input::Event::Blur(text_input::Blur { id: id.clone() }));
+            crate::event::send(text_input::Event::Blur { id: id.clone() });
         }
         *last_focused_text_input_id = None;
     }
@@ -36,9 +36,9 @@ pub(crate) fn on_mouse_down_in_at_attach_event_calls(
 
     if let Some(last_focused_text_input_id) = &*last_focused_text_input_id {
         if last_focused_text_input_id.ne(&custom_data.text_input.id) {
-            crate::event::send(text_input::Event::Blur(text_input::Blur {
+            crate::event::send(text_input::Event::Blur {
                 id: last_focused_text_input_id.clone(),
-            }));
+            });
         }
     }
 
@@ -116,9 +116,9 @@ fn update_focus_with_mouse_movement(
 
     input_element.focus().unwrap();
 
-    let event = text_input::Event::Focus(Focus {
+    let event = text_input::Event::Focus {
         id: custom_data.text_input.id.clone(),
         selection,
-    });
+    };
     crate::event::send(event);
 }


### PR DESCRIPTION
# What I did

- Support keydown event like react
  - Usage Example) you can stop input when `Enter` key down.
- Focus text input by api
  - Usage Example) You can focus text input when you open modal.
  - Current known issue: focus function may keep wrong selection.
- `enum Event` become nested.