### PR TITLE
Comment for font weight

### DIFF
--- a/namui/src/namui/common/mod.rs
+++ b/namui/src/namui/common/mod.rs
@@ -92,11 +92,17 @@ pub enum FontWeight {
     _900 = 900,
 }
 impl FontWeight {
+    /// 100
     pub const THIN: FontWeight = FontWeight::_100;
+    /// 300
     pub const LIGHT: FontWeight = FontWeight::_300;
+    /// 400
     pub const REGULAR: FontWeight = FontWeight::_400;
+    /// 500
     pub const MEDIUM: FontWeight = FontWeight::_500;
+    /// 700
     pub const BOLD: FontWeight = FontWeight::_700;
+    /// 900
     pub const BLACK: FontWeight = FontWeight::_900;
 
     pub fn iter() -> impl Iterator<Item = FontWeight> {


### PR DESCRIPTION
It was difficult how bold the font weight constant variables were. I put comment so vscode shows it.

![image](https://user-images.githubusercontent.com/3580430/191538893-9dbfb861-2d66-4acd-97d0-7749635cffcf.png)
