### PR TITLE
Allow dead_code for canvas_kit

### DIFF
--- a/namui/src/namui/skia/web/canvas_kit/mod.rs
+++ b/namui/src/namui/skia/web/canvas_kit/mod.rs
@@ -1,4 +1,4 @@
-#![allow(unused_doc_comments)]
+#![allow(unused_doc_comments, dead_code)]
 
 mod canvas;
 mod canvas_kit;


### PR DESCRIPTION
We had a error on github action, deploying luda editor to aws.

![image](https://user-images.githubusercontent.com/3580430/191915867-4a139400-e3d7-4537-b29e-b6101024ec16.png)

It wasn't reproduced in my local computer, so I couldn't figured out it.

I put allow for dead_code in canvas_kit module, it's ok to put that. at that module I only put canvas_kit external library things.

Deployment has been successful after allow dead_code.

![image](https://user-images.githubusercontent.com/3580430/191916062-6d450584-0f56-4895-883f-2d93340387d5.png)
