### PR TITLE
Padding rendering tree

### DIFF
--- a/namui/src/namui/render/mod.rs
+++ b/namui/src/namui/render/mod.rs
@@ -1,5 +1,6 @@
 pub mod image;
 pub mod matrix;
+pub mod padding;
 pub mod path;
 pub mod rect;
 pub mod rendering_tree;
@@ -9,6 +10,7 @@ pub mod text_input;
 
 pub use image::*;
 pub use matrix::*;
+pub use padding::*;
 pub use path::*;
 pub use rect::*;
 pub use rendering_tree::*;

--- a/namui/src/namui/render/padding.rs
+++ b/namui/src/namui/render/padding.rs
@@ -1,0 +1,50 @@
+use crate::*;
+
+impl RenderingTree {
+    pub fn padding(self, padding: impl Padding) -> RenderingTree {
+        let ltrb = padding.to_ltrb();
+        let bounding_box = self.get_bounding_box();
+        render([
+            rect(RectParam {
+                rect: match bounding_box {
+                    Some(bounding_box) => Rect::Xywh {
+                        x: (bounding_box.x() + ltrb.left).min(0.px()),
+                        y: (bounding_box.y() + ltrb.top).min(0.px()),
+                        width: bounding_box.width() + ltrb.left + ltrb.right,
+                        height: bounding_box.height() + ltrb.top + ltrb.bottom,
+                    },
+                    None => Rect::default(),
+                },
+                style: RectStyle {
+                    stroke: None,
+                    fill: Some(RectFill {
+                        color: Color::TRANSPARENT,
+                    }),
+                    round: None,
+                },
+            }),
+            translate(ltrb.left, ltrb.top, self),
+        ])
+    }
+}
+
+pub trait Padding {
+    fn to_ltrb(&self) -> Ltrb<Px>;
+}
+
+impl Padding for Rect<Px> {
+    fn to_ltrb(&self) -> Ltrb<Px> {
+        self.as_ltrb()
+    }
+}
+
+impl Padding for Px {
+    fn to_ltrb(&self) -> Ltrb<Px> {
+        Ltrb {
+            left: *self,
+            top: *self,
+            right: *self,
+            bottom: *self,
+        }
+    }
+}

--- a/namui/src/namui/render/special/attach_event.rs
+++ b/namui/src/namui/render/special/attach_event.rs
@@ -74,7 +74,17 @@ pub type KeyboardEventCallback = Arc<dyn Fn(&KeyboardEvent)>;
 
 impl std::fmt::Debug for AttachEventNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "rendering_tree: {:?}, on_mouse_move_in: {:?}, on_mouse_move_out: {:?}, on_mouse_down_in: {:?}, on_mouse_up_in: {:?}, on_wheel: {:?}", self.rendering_tree, self.on_mouse_move_in.is_some(), self.on_mouse_move_out.is_some(), self.on_mouse_down_in.is_some(), self.on_mouse_up_in.is_some(), self.on_wheel.is_some())
+        f.debug_struct("AttachEventNode")
+            .field("on_mouse_move_in", &self.on_mouse_move_in.is_some())
+            .field("on_mouse_move_out", &self.on_mouse_move_out.is_some())
+            .field("on_mouse_down_in", &self.on_mouse_down_in.is_some())
+            .field("on_mouse_down_out", &self.on_mouse_down_out.is_some())
+            .field("on_mouse_up_in", &self.on_mouse_up_in.is_some())
+            .field("on_mouse_up_out", &self.on_mouse_up_out.is_some())
+            .field("on_wheel", &self.on_wheel.is_some())
+            .field("on_key_down", &self.on_key_down.is_some())
+            .field("on_key_up", &self.on_key_up.is_some())
+            .finish()
     }
 }
 


### PR DESCRIPTION
Support padding for rendering tree easily

Usage

```rust
typography::title::left_top("Image", Color::WHITE); // [Image]

typography::title::left_top("Image", Color::WHITE).padding(12.px()); // [  Image  ]
```