### PR TITLE
Fix rust version 1.64

### DIFF
--- a/docker-images/namui-test-host/linux.Dockerfile
+++ b/docker-images/namui-test-host/linux.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1-alpine
+FROM rust:1.62-alpine
 
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTFLAGS="-D warnings"

--- a/docker-images/namui-test-host/linux.Dockerfile
+++ b/docker-images/namui-test-host/linux.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1.62-alpine
+FROM rust:1.64-alpine
 
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTFLAGS="-D warnings"

--- a/namui-cli/src/procedures/linux/wasm_unknown_web/test.rs
+++ b/namui-cli/src/procedures/linux/wasm_unknown_web/test.rs
@@ -60,6 +60,7 @@ pub fn test(manifest_path: &PathBuf) -> Result<(), crate::Error> {
     let command_to_pass_to_docker = format!(
         "{}",
         [
+            format!("rustc --version"),
             format!(
                 "RUSTFLAGS=\"-D warnings\" wasm-pack test --headless --chrome {}",
                 directory.to_str().unwrap()


### PR DESCRIPTION
I had a problem that `namui test` docker uses rust version 1.58.
![image](https://user-images.githubusercontent.com/3580430/192584453-19eefecb-61ce-4f36-8a33-909e8f5a6693.png)

let's fix the rust version of docker.