### PR TITLE
Expose common_for_f32_type macro

### DIFF
--- a/image-cropper/src/app/cropper/render_app_bar.rs
+++ b/image-cropper/src/app/cropper/render_app_bar.rs
@@ -5,7 +5,7 @@ use namui::prelude::*;
 
 pub fn render_app_bar(wh: Wh<Px>) -> RenderingTree {
     const MARGIN: Px = px(8.0);
-    let inner_height = wh.height - 2.0 * MARGIN;
+    let inner_height = wh.height - MARGIN * 2.0;
     let button_wh = Wh {
         width: px(128.0),
         height: inner_height,

--- a/image-cropper/src/app/file_selector/file_selector.rs
+++ b/image-cropper/src/app/file_selector/file_selector.rs
@@ -64,7 +64,7 @@ impl FileSelector {
         const MARGIN: Px = px(16.0);
         const BUTTON_HEIGHT: Px = px(36.0);
         let button_wh = Wh {
-            width: props.screen_wh.width - (2.0 * MARGIN),
+            width: props.screen_wh.width - (MARGIN * 2.0),
             height: BUTTON_HEIGHT,
         };
         render([

--- a/luda-editor/client/src/components/context_menu.rs
+++ b/luda-editor/client/src/components/context_menu.rs
@@ -45,7 +45,7 @@ impl ContextMenu {
         let cell_wh = Wh::new(160.px(), 24.px());
 
         let menus = self.items.iter().enumerate().map(|(index, item)| {
-            let y = index * cell_wh.height;
+            let y = cell_wh.height * index;
             let is_selected = self.mouse_over_item_id.as_ref() == Some(&item.id);
             let border = if is_selected {
                 simple_rect(cell_wh, Color::BLACK, 1.px(), Color::WHITE)

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/filtered_image_list.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/filtered_image_list.rs
@@ -57,8 +57,8 @@ impl ImageSelectModal {
                     Some(image.id) == self.selected_image.as_ref().map(|image| image.id);
 
                 translate(
-                    column_index * (image_width + padding) + padding,
-                    row_index * (image_width + padding),
+                    (image_width + padding) * column_index + padding,
+                    (image_width + padding) * row_index,
                     render([
                         namui::image(ImageParam {
                             rect: Rect::from_xy_wh(Xy::zero(), Wh::single(image_width)),

--- a/namui-animation-editor/src/time_point_editor/wysiwyg_window/update/dragging/resize.rs
+++ b/namui-animation-editor/src/time_point_editor/wysiwyg_window/update/dragging/resize.rs
@@ -69,13 +69,13 @@ impl Act<Animation> for DragResizeCircleAction {
                 update_xy(
                     layer,
                     self.keyframe_point_id,
-                    self.rotation_angle.cos() * reversed_rotated_delta_in_real.x / 2.0f32,
+                    reversed_rotated_delta_in_real.x * self.rotation_angle.cos() / 2.0f32,
                     XY::X,
                 )?;
                 update_xy(
                     layer,
                     self.keyframe_point_id,
-                    self.rotation_angle.sin() * reversed_rotated_delta_in_real.x / 2.0f32,
+                    reversed_rotated_delta_in_real.x * self.rotation_angle.sin() / 2.0f32,
                     XY::Y,
                 )?;
             }
@@ -83,13 +83,13 @@ impl Act<Animation> for DragResizeCircleAction {
                 update_xy(
                     layer,
                     self.keyframe_point_id,
-                    -self.rotation_angle.sin() * reversed_rotated_delta_in_real.y / 2.0f32,
+                    reversed_rotated_delta_in_real.y * -self.rotation_angle.sin() / 2.0f32,
                     XY::X,
                 )?;
                 update_xy(
                     layer,
                     self.keyframe_point_id,
-                    self.rotation_angle.cos() * reversed_rotated_delta_in_real.y / 2.0f32,
+                    reversed_rotated_delta_in_real.y * self.rotation_angle.cos() / 2.0f32,
                     XY::Y,
                 )?;
             }

--- a/namui-animation-editor/src/time_ruler/gradations.rs
+++ b/namui-animation-editor/src/time_ruler/gradations.rs
@@ -32,7 +32,7 @@ pub fn render_gradations(props: &GradationsProps) -> RenderingTree {
 
         for i in 1..SUB_GRADATION_FREQUENCY {
             gradation_properties.push(GradationProperty {
-                x: x + i * props.gap_px / SUB_GRADATION_FREQUENCY,
+                x: x + (props.gap_px * i) / SUB_GRADATION_FREQUENCY,
                 is_big: false,
             });
         }

--- a/namui-prebuilt/src/button.rs
+++ b/namui-prebuilt/src/button.rs
@@ -48,7 +48,7 @@ pub fn text_button_fit(
 
     render([
         simple_rect(
-            Wh::new(width + 2 * side_padding, height),
+            Wh::new(width + side_padding * 2, height),
             stroke_color,
             stroke_width,
             fill_color,

--- a/namui-prebuilt/src/list_view.rs
+++ b/namui-prebuilt/src/list_view.rs
@@ -64,12 +64,12 @@ impl ListView {
         let rendered_items = visible_items.map(|(index, item)| {
             translate(
                 px(0.0),
-                index * props.item_wh.height,
+                props.item_wh.height * index,
                 (props.item_render)(props.item_wh, item),
             )
         });
 
-        let content_height = item_len * props.item_wh.height;
+        let content_height = props.item_wh.height * item_len;
 
         let transparent_pillar = rect(RectParam {
             rect: Rect::Xywh {

--- a/namui/src/namui/animation/image_keyframe_graph.rs
+++ b/namui/src/namui/animation/image_keyframe_graph.rs
@@ -108,7 +108,7 @@ impl KeyframeValue<ImageInterpolation> for ImageKeyframe {
                 let velocity = {
                     let length = vector.length();
 
-                    let vt = (PI / 2.0) * length * (PI * time_ratio).sin();
+                    let vt = length * (PI / 2.0) * (PI * time_ratio).sin();
                     vt
                 };
                 let sx = (velocity.as_f32() / 1000.0).min(1.25).max(1.0);

--- a/namui/src/namui/common/types/angle.rs
+++ b/namui/src/namui/common/types/angle.rs
@@ -119,45 +119,45 @@ impl Display for Angle {
     }
 }
 
-super::impl_op_forward_ref!(*|lhs: Angle, rhs: f32| -> Angle {
+crate::impl_op_forward_ref!(*|lhs: Angle, rhs: f32| -> Angle {
     match lhs {
         Angle::Radian(x) => Angle::Radian(x * rhs),
         Angle::Degree(x) => Angle::Degree(x * rhs),
     }
 });
 
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i8| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u8| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i16| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u16| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i32| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u32| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i64| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u64| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i128| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u128| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: isize| -> Angle { lhs * rhs as f32 });
-super::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: usize| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i8| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u8| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i16| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u16| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i32| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u32| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i64| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u64| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: i128| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: u128| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: isize| -> Angle { lhs * rhs as f32 });
+crate::impl_op_forward_ref_reversed!(*|lhs: Angle, rhs: usize| -> Angle { lhs * rhs as f32 });
 
-super::impl_op_forward_ref!(/|lhs: Angle, rhs: f32| -> Angle {
+crate::impl_op_forward_ref!(/|lhs: Angle, rhs: f32| -> Angle {
     match lhs {
         Angle::Radian(x) => Angle::Radian(x / rhs),
         Angle::Degree(x) => Angle::Degree(x / rhs),
     }
 });
 
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i8| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u8| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i16| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u16| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i32| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u32| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i64| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u64| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i128| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u128| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: isize| -> Angle { lhs / rhs as f32 });
-super::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: usize| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i8| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u8| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i16| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u16| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i32| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u32| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i64| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u64| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: i128| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: u128| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: isize| -> Angle { lhs / rhs as f32 });
+crate::impl_op_forward_ref_reversed!(/|lhs: Angle, rhs: usize| -> Angle { lhs / rhs as f32 });
 
 auto_ops::impl_op!(+=|lhs: &mut Angle, rhs: Angle| {
     match lhs {

--- a/namui/src/namui/common/types/macros.rs
+++ b/namui/src/namui/common/types/macros.rs
@@ -65,15 +65,15 @@ macro_rules! common_for_f32_type {
         $crate::types::macros::impl_op_forward_ref!(/|x: $your_type, y: $your_type| -> f32 {
             x.0 / y.0
         });
-        auto_ops::impl_op!(-|x: $your_type| -> $your_type {
+        $crate::auto_ops::impl_op!(-|x: $your_type| -> $your_type {
             (-(x.as_f32())).into()
         });
 
-        auto_ops::impl_op!(+=|x: &mut $your_type, y: $your_type| {
+        $crate::auto_ops::impl_op!(+=|x: &mut $your_type, y: $your_type| {
             x.0 = (*x + y).0;
         });
 
-        auto_ops::impl_op!(-=|x: &mut $your_type, y: $your_type| {
+        $crate::auto_ops::impl_op!(-=|x: &mut $your_type, y: $your_type| {
             x.0 = (*x - y).0;
         });
 
@@ -117,11 +117,11 @@ macro_rules! common_for_f32_type {
             (lhs.as_f32() % rhs).into()
         });
 
-        auto_ops::impl_op!(/=|lhs: &mut $your_type, rhs: f32| {
+        $crate::auto_ops::impl_op!(/=|lhs: &mut $your_type, rhs: f32| {
             lhs.0 = (*lhs / rhs).0;
         });
-        auto_ops::impl_op!(/=|lhs: &mut $your_type, rhs: i32| { *lhs /= (rhs as f32) });
-        auto_ops::impl_op!(/=|lhs: &mut $your_type, rhs: usize| { *lhs /= (rhs as f32) });
+        $crate::auto_ops::impl_op!(/=|lhs: &mut $your_type, rhs: i32| { *lhs /= (rhs as f32) });
+        $crate::auto_ops::impl_op!(/=|lhs: &mut $your_type, rhs: usize| { *lhs /= (rhs as f32) });
 
         pub const fn $short_term(value: f32) -> $your_type {
             $your_type(value)
@@ -149,10 +149,10 @@ pub use common_for_f32_type;
 #[macro_export]
 macro_rules! impl_op_forward_ref {
     ($op:tt |$lhs_i:ident : $lhs:ty, $rhs_i:ident : $rhs:ty| -> $out:ty $body:block) => {
-        auto_ops::impl_op!($op|$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
-        auto_ops::impl_op!($op|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out { *$lhs_i $op $rhs_i });
-        auto_ops::impl_op!($op|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out { $lhs_i $op *$rhs_i });
-        auto_ops::impl_op!($op|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out { *$lhs_i $op *$rhs_i });
+        $crate::auto_ops::impl_op!($op|$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::auto_ops::impl_op!($op|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out { *$lhs_i $op $rhs_i });
+        $crate::auto_ops::impl_op!($op|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out { $lhs_i $op *$rhs_i });
+        $crate::auto_ops::impl_op!($op|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out { *$lhs_i $op *$rhs_i });
     };
 }
 pub use impl_op_forward_ref;

--- a/namui/src/namui/common/types/mod.rs
+++ b/namui/src/namui/common/types/mod.rs
@@ -1,7 +1,7 @@
 mod angle;
 mod int_px;
 mod ltrb;
-pub(crate) mod macros;
+pub mod macros;
 mod one_zero;
 mod per;
 mod percent;
@@ -16,7 +16,7 @@ mod vector_types;
 pub use angle::*;
 pub use int_px::*;
 pub use ltrb::*;
-pub(crate) use macros::*;
+pub use macros::*;
 pub use one_zero::*;
 pub use per::*;
 pub use percent::*;

--- a/namui/src/namui/common/types/ratio.rs
+++ b/namui/src/namui/common/types/ratio.rs
@@ -1,3 +1,19 @@
 pub trait Ratio {
     fn as_f32(&self) -> f32;
 }
+
+impl Ratio for i32 {
+    fn as_f32(&self) -> f32 {
+        *self as f32
+    }
+}
+impl Ratio for f32 {
+    fn as_f32(&self) -> f32 {
+        *self
+    }
+}
+impl Ratio for usize {
+    fn as_f32(&self) -> f32 {
+        *self as f32
+    }
+}

--- a/namui/src/namui/common/types/rect.rs
+++ b/namui/src/namui/common/types/rect.rs
@@ -553,3 +553,36 @@ where
         }
     }
 }
+
+impl<T> std::ops::Add<Xy<T>> for Rect<T>
+where
+    T: std::ops::Add<Output = T> + Clone,
+{
+    type Output = Rect<T>;
+    fn add(self, rhs: Xy<T>) -> Self::Output {
+        match self {
+            Rect::Xywh {
+                x,
+                y,
+                width,
+                height,
+            } => Rect::Xywh {
+                x: x + rhs.x,
+                y: y + rhs.y,
+                width,
+                height,
+            },
+            Rect::Ltrb {
+                left,
+                top,
+                right,
+                bottom,
+            } => Rect::Ltrb {
+                left: left + rhs.x.clone(),
+                top: top + rhs.y.clone(),
+                right: right + rhs.x,
+                bottom: bottom + rhs.y,
+            },
+        }
+    }
+}

--- a/namui/src/namui/draw/image.rs
+++ b/namui/src/namui/draw/image.rs
@@ -170,21 +170,21 @@ fn calculate_contain_fit_dest_rect(image_size: Wh<Px>, command_rect: Rect<Px>) -
 
     if image_size.width / image_size.height > command_rect.width() / command_rect.height() {
         let k = command_rect.width() / image_size.width;
-        let delta_y = (command_rect.height() - k * image_size.height) / 2.0;
+        let delta_y = (command_rect.height() - image_size.height * k) / 2.0;
         return Rect::Xywh {
             x: command_rect.x(),
             y: command_rect.y() + delta_y,
             width: command_rect.width(),
-            height: k * image_size.height,
+            height: image_size.height * k,
         };
     }
 
     let k = command_rect.height() / image_size.height;
-    let delta_x = (command_rect.width() - k * image_size.width) / 2.0;
+    let delta_x = (command_rect.width() - image_size.width * k) / 2.0;
     return Rect::Xywh {
         x: command_rect.x() + delta_x,
         y: command_rect.y(),
-        width: k * image_size.width,
+        width: image_size.width * k,
         height: command_rect.height(),
     };
 }
@@ -201,21 +201,21 @@ fn calculate_cover_fit_src_rect(image_size: Wh<Px>, command_rect: Rect<Px>) -> R
 
     if image_size.width / image_size.height > command_rect.width() / command_rect.height() {
         let k = command_rect.height() / image_size.height;
-        let delta_x = (k * image_size.width - command_rect.width()) / (2.0 * k);
+        let delta_x = (image_size.width * k - command_rect.width()) / (2.0 * k);
         return Rect::Xywh {
             x: delta_x,
             y: px(0.0),
-            width: image_size.width - 2.0 * delta_x,
+            width: image_size.width - delta_x * 2.0,
             height: image_size.height,
         };
     }
 
     let k = command_rect.width() / image_size.width;
-    let delta_y = (k * image_size.height - command_rect.height()) / (2.0 * k);
+    let delta_y = (image_size.height * k - command_rect.height()) / (2.0 * k);
     return Rect::Xywh {
         x: px(0.0),
         y: delta_y,
         width: image_size.width,
-        height: image_size.height - 2.0 * delta_y,
+        height: image_size.height - delta_y * 2.0,
     };
 }

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -11,6 +11,7 @@ pub mod system;
 pub mod utils;
 
 pub use self::random::*;
+pub use auto_ops;
 pub use common::{types::*, *};
 pub use draw::{DrawCall, DrawCommand, PathDrawCommand, TextAlign, TextBaseline, TextDrawCommand};
 pub use event::NamuiEvent;

--- a/namui/src/namui/mod.rs
+++ b/namui/src/namui/mod.rs
@@ -23,6 +23,7 @@ pub use render::{
     MouseEventCallback, MouseEventType, React, RenderingData, RenderingTree, TextInput,
     WheelEventCallback,
 };
+pub use serde;
 pub use shader_macro::shader;
 pub use skia::{
     make_runtime_effect_shader, BlendMode, ClipOp, Color, FilterMode, Font, Image, MipmapMode,

--- a/namui/src/namui/render/matrix.rs
+++ b/namui/src/namui/render/matrix.rs
@@ -86,8 +86,7 @@ impl Matrix3x3 {
 
     pub fn transform_rect<T>(&self, rect: Rect<T>) -> Rect<T>
     where
-        f32: std::ops::Mul<T, Output = T> + Into<T>,
-        T: std::ops::Add<Output = T> + Copy,
+        T: std::ops::Add<Output = T> + Copy + std::ops::Mul<f32, Output = T> + From<f32>,
     {
         let Ltrb {
             left,
@@ -96,17 +95,17 @@ impl Matrix3x3 {
             bottom,
         } = rect.as_ltrb();
         Rect::Ltrb {
-            left: *self.values.index((0, 0)) * left
-                + *self.values.index((0, 1)) * top
+            left: left * *self.values.index((0, 0))
+                + top * *self.values.index((0, 1))
                 + (*self.values.index((0, 2))).into(),
-            top: *self.values.index((1, 0)) * left
-                + *self.values.index((1, 1)) * top
+            top: left * *self.values.index((1, 0))
+                + top * *self.values.index((1, 1))
                 + (*self.values.index((1, 2))).into(),
-            right: *self.values.index((0, 0)) * right
-                + *self.values.index((0, 1)) * bottom
+            right: right * *self.values.index((0, 0))
+                + bottom * *self.values.index((0, 1))
                 + (*self.values.index((0, 2))).into(),
-            bottom: *self.values.index((1, 0)) * right
-                + *self.values.index((1, 1)) * bottom
+            bottom: right * *self.values.index((1, 0))
+                + bottom * *self.values.index((1, 1))
                 + (*self.values.index((1, 2))).into(),
         }
     }

--- a/namui/src/namui/render/rect.rs
+++ b/namui/src/namui/render/rect.rs
@@ -76,8 +76,8 @@ pub fn rect(
             Rect::Xywh {
                 x: px(0.0),
                 y: px(0.0),
-                width: width - 2.0 * stroke_width,
-                height: height - 2.0 * stroke_width,
+                width: width - stroke_width * 2.0,
+                height: height - stroke_width * 2.0,
             },
         ),
         Some(RectStroke {


### PR DESCRIPTION
# What happened?

When external crate tried to use `common_for_f32_type` macro of namui, there were error like below

```
error[E0119]: conflicting implementations of trait `std::ops::Mul<&f32>` for type `app::game::types::tile::Tile`
 --> src/app/game/types/tile.rs:3:1
  |
3 | namui::common_for_f32_type!(Tile, tile, TileExt);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | |
  | first implementation here
  | conflicting implementation for `app::game::types::tile::Tile`
  |
  = note: upstream crates may add a new impl of trait `namui::Ratio` for type `&f32` in future versions
  = note: this error originates in the macro `$crate::_impl_binary_op_owned_borrowed` which comes from the expansion of the macro `namui::common_for_f32_type` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The error point is here
```rust
impl<T: $crate::types::Ratio> std::ops::Mul<T> for $your_type {
    type Output = $your_type;
    fn mul(self, rhs: T) -> Self::Output {
        (self.as_f32() * rhs.as_f32()).into()
    }
}
```
That mean, 
1. we implemented `$your_type * &f32` in that macro
2. also we implemented `$your_type * Ratio` in that macro
3. So, if upstream crates(=namui) add a new impl of trait `namui::Ratio` for type `&f32`, it could be problem.

So I decided to add a impl for trait `namui::Ratio` for type `f32` and `usize`, `i32`.
Therefore, We should make operation like `type * ratio`, not `ratio * type` because we cannot make `ratio * type` override in downstream crate.


Test

![image](https://user-images.githubusercontent.com/3580430/194105349-a9143677-5e2a-465c-931f-889d8e2d5f9a.png)
