### PR TITLE
Floor position to prevent flickering

### DIFF
--- a/luda-adventure/src/app/game/render/translate_to_camera_screen.rs
+++ b/luda-adventure/src/app/game/render/translate_to_camera_screen.rs
@@ -8,8 +8,8 @@ impl Game {
         rendering_tree: RenderingTree,
     ) -> namui::RenderingTree {
         translate(
-            -(rendering_context.px_per_tile * rendering_context.screen_rect.x()),
-            -(rendering_context.px_per_tile * rendering_context.screen_rect.y()),
+            -(rendering_context.px_per_tile * rendering_context.screen_rect.x()).floor(),
+            -(rendering_context.px_per_tile * rendering_context.screen_rect.y()).floor(),
             rendering_tree,
         )
     }

--- a/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
+++ b/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
@@ -58,8 +58,8 @@ pub fn new_player(xy: Xy<Tile>) -> crate::ecs::Entity {
                 let position =
                     positioner.xy_with_interpolation(rendering_context.interpolation_progress);
                 translate(
-                    rendering_context.px_per_tile * (position.x + VISUAL_OFFSET_X),
-                    rendering_context.px_per_tile * (position.y + VISUAL_OFFSET_Y),
+                    (rendering_context.px_per_tile * (position.x + VISUAL_OFFSET_X)).floor(),
+                    (rendering_context.px_per_tile * (position.y + VISUAL_OFFSET_Y)).floor(),
                     render([
                         simple_rect(
                             Wh {

--- a/luda-adventure/src/app/game/types/game_object/types/positioner.rs
+++ b/luda-adventure/src/app/game/types/game_object/types/positioner.rs
@@ -32,7 +32,11 @@ impl Positioner {
         self.current_xy
     }
     pub fn xy_with_interpolation(&self, interpolation_progress: f32) -> Xy<Tile> {
-        self.previous_xy * (1.0 - interpolation_progress) + self.current_xy * interpolation_progress
+        if interpolation_progress >= 1.0 {
+            self.current_xy
+        } else {
+            self.previous_xy + (self.current_xy - self.previous_xy) * interpolation_progress
+        }
     }
 
     pub fn set_xy(&mut self, xy: Xy<Tile>) {

--- a/namui/src/namui/common/types/macros.rs
+++ b/namui/src/namui/common/types/macros.rs
@@ -67,6 +67,15 @@ macro_rules! common_for_f32_type {
             pub fn is_finite(&self) -> bool {
                 self.0.is_finite()
             }
+            pub fn floor(&self) -> $your_type {
+                self.0.floor().into()
+            }
+            pub fn ceil(&self) -> $your_type {
+                self.0.ceil().into()
+            }
+            pub fn round(&self) -> $your_type {
+                self.0.round().into()
+            }
         }
 
         $crate::types::impl_op_forward_ref!(+|x: $your_type, y: $your_type| -> $your_type {


### PR DESCRIPTION
After
https://user-images.githubusercontent.com/3580430/198870476-258aa8d4-4a5f-4b3c-8bd6-146693967deb.mp4

The reason why the character is shaking is not about floor. I think it's about the problem of interpolation with skipping ticks.
Before this commit, look at the wall, it already has been shaked.