### PR TITLE
Fix deprecating set-output command

### DIFF
--- a/.github/actions/init-test-job/action.yml
+++ b/.github/actions/init-test-job/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: bash
-      run: time echo "::set-output name=dir::$(npm config get cache)"
+      run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-luda-editor.yml
+++ b/.github/workflows/deploy-luda-editor.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Get npm cache directory
         id: npm-cache-dir
-        run: echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: npm-cache


### PR DESCRIPTION
I got a meessage from github action
![image](https://user-images.githubusercontent.com/3580430/198886645-8a8f05ea-bf3e-4315-86b8-1b3c2ea3cb38.png)

and they said it's deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/