### PR TITLE
Support line_height_percent for text parameter

### DIFF
--- a/luda-editor/client/src/components/sequence_player.rs
+++ b/luda-editor/client/src/components/sequence_player.rs
@@ -189,7 +189,7 @@ impl SequencePlayer {
                                             )),
                                         }),
                                         color: Color::from_f01(1.0, 1.0, 1.0, opacity.as_f32()),
-                                        background: None,
+                                        ..Default::default()
                                     },
                                     max_width: Some(wh.width - margin * 2),
                                 })
@@ -204,7 +204,7 @@ impl SequencePlayer {
                             x: margin,
                             y: margin,
                             align: TextAlign::Left,
-                            baseline: TextBaseline::Middle,
+                            baseline: TextBaseline::Top,
                             font_type: FontType {
                                 serif: false,
                                 size: 24.int_px(),
@@ -222,7 +222,8 @@ impl SequencePlayer {
                                     color: Some(Color::from_f01(0.0, 0.0, 0.0, opacity.as_f32())),
                                 }),
                                 color: Color::from_f01(1.0, 1.0, 1.0, opacity.as_f32()),
-                                background: None,
+                                line_height_percent: 150.percent(),
+                                ..Default::default()
                             },
                             max_width: Some(wh.width - margin * 2),
                         })

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/character.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/character.rs
@@ -93,10 +93,8 @@ impl CharacterEditModal {
                                                 font_weight: FontWeight::MEDIUM,
                                             },
                                             text_style: TextStyle {
-                                                border: None,
-                                                drop_shadow: None,
                                                 color: stroke_color,
-                                                background: None,
+                                                ..Default::default()
                                             },
                                             event_handler: None,
                                         }),

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_edit_modal/render/label_input.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_edit_modal/render/label_input.rs
@@ -44,10 +44,8 @@ impl ImageEditModal {
                                     font_weight: FontWeight::REGULAR,
                                 },
                                 text_style: TextStyle {
-                                    border: None,
-                                    drop_shadow: None,
                                     color: Color::WHITE,
-                                    background: None,
+                                    ..Default::default()
                                 },
                                 event_handler: Some(text_input::EventHandler::new().on_key_down(
                                     |event| {

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/image_preview.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/image_preview.rs
@@ -59,10 +59,8 @@ impl ImageSelectModal {
                                     font_weight: FontWeight::REGULAR,
                                 },
                                 style: TextStyle {
-                                    border: None,
-                                    drop_shadow: None,
                                     color: Color::WHITE,
-                                    background: None,
+                                    ..Default::default()
                                 },
                                 max_width: Some(wh.width - 24.px()),
                             }),

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/label_list.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/label_list.rs
@@ -87,10 +87,8 @@ impl ImageSelectModal {
                         font_weight: FontWeight::BOLD,
                     },
                     style: TextStyle {
-                        border: None,
-                        drop_shadow: None,
                         color: stroke_color,
-                        background: None,
+                        ..Default::default()
                     },
                     max_width: None,
                 });

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/mod.rs
@@ -82,13 +82,12 @@ impl LoadedSequenceEditorPage {
                                             font_weight: FontWeight::REGULAR,
                                         },
                                         text_style: TextStyle {
-                                            border: None,
-                                            drop_shadow: None,
                                             color: match is_selected {
                                                 true => Color::BLUE,
                                                 false => Color::WHITE,
                                             },
-                                            background: None,
+                                            line_height_percent: 150.percent(),
+                                            ..Default::default()
                                         },
                                         event_handler: None,
                                     })

--- a/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
@@ -97,10 +97,8 @@ impl RenameModal {
                                 font_weight: FontWeight::REGULAR,
                             },
                             text_style: TextStyle {
-                                border: None,
-                                drop_shadow: None,
                                 color: Color::BLACK,
-                                background: None,
+                                ..Default::default()
                             },
                             event_handler: None,
                         }),

--- a/namui/sample/multiline-text/src/lib.rs
+++ b/namui/sample/multiline-text/src/lib.rs
@@ -42,10 +42,8 @@ impl Entity for MultilineTextExample {
                     font_weight: FontWeight::REGULAR,
                 },
                 style: TextStyle {
-                    border: None,
-                    drop_shadow: None,
                     color: Color::BLACK,
-                    background: None,
+                    ..Default::default()
                 },
                 max_width: None,
             });
@@ -99,10 +97,8 @@ impl Entity for MultilineTextExample {
                         font_weight: FontWeight::REGULAR,
                     },
                     style: TextStyle {
-                        border: None,
-                        drop_shadow: None,
                         color: Color::BLACK,
-                        background: None,
+                        ..Default::default()
                     },
                     max_width: None,
                 });
@@ -156,10 +152,8 @@ impl Entity for MultilineTextExample {
                         font_weight: FontWeight::REGULAR,
                     },
                     style: TextStyle {
-                        border: None,
-                        drop_shadow: None,
                         color: Color::BLACK,
-                        background: None,
+                        ..Default::default()
                     },
                     max_width: Some(278.px()),
                 });

--- a/namui/src/namui/common/text/mod.rs
+++ b/namui/src/namui/common/text/mod.rs
@@ -26,9 +26,6 @@ pub fn get_fallback_fonts(font_size: IntPx) -> VecDeque<Arc<Font>> {
         .map(|typeface| crate::font::get_font_of_typeface(typeface.clone(), font_size))
         .collect()
 }
-pub fn get_line_height(font_size: IntPx) -> Px {
-    font_size.into_px() * 110.percent()
-}
 pub fn get_multiline_y_baseline_offset(
     baseline: TextBaseline,
     line_height: Px,

--- a/namui/src/namui/draw/text.rs
+++ b/namui/src/namui/draw/text.rs
@@ -14,6 +14,7 @@ pub struct TextDrawCommand {
     pub align: TextAlign,
     pub baseline: TextBaseline,
     pub max_width: Option<Px>,
+    pub line_height_percent: Percent,
 }
 
 #[derive(Debug, Serialize, Copy, Clone)]
@@ -43,7 +44,7 @@ impl TextDrawCommand {
 
         let line_texts = LineTexts::new(&self.text, &fonts, &paint, self.max_width);
 
-        let line_height = get_line_height(self.font.size);
+        let line_height = self.line_height_px();
 
         let mut bottom_of_fonts: HashMap<String, Px> = HashMap::new();
 
@@ -108,7 +109,7 @@ impl TextDrawCommand {
 
         let line_texts = LineTexts::new(&self.text, &fonts, &paint, self.max_width);
 
-        let line_height = get_line_height(self.font.size);
+        let line_height = self.line_height_px();
 
         let multiline_y_baseline_offset =
             get_multiline_y_baseline_offset(self.baseline, line_height, line_texts.line_len());
@@ -172,5 +173,9 @@ impl TextDrawCommand {
         self.get_bounding_box()
             .map(|bound| bound.is_xy_inside(xy))
             .unwrap_or(false)
+    }
+
+    fn line_height_px(&self) -> Px {
+        self.font.size.into_px() * self.line_height_percent
     }
 }

--- a/namui/src/namui/render/text.rs
+++ b/namui/src/namui/render/text.rs
@@ -17,12 +17,25 @@ pub struct TextStyleBackground {
     pub color: Color,
     pub margin: Option<Ltrb<Px>>,
 }
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct TextStyle {
     pub border: Option<TextStyleBorder>,
     pub drop_shadow: Option<TextStyleDropShadow>,
     pub color: Color,
     pub background: Option<TextStyleBackground>,
+    pub line_height_percent: Percent,
+}
+
+impl Default for TextStyle {
+    fn default() -> Self {
+        Self {
+            border: Default::default(),
+            drop_shadow: Default::default(),
+            color: Default::default(),
+            background: Default::default(),
+            line_height_percent: 110.percent(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -132,6 +145,7 @@ fn draw_text(param: &TextParam, font: Arc<Font>) -> DrawCommand {
         align: param.align,
         baseline: param.baseline,
         max_width: param.max_width,
+        line_height_percent: param.style.line_height_percent,
     })
 }
 fn draw_border(param: &TextParam, font: Arc<Font>) -> Option<DrawCommand> {
@@ -153,6 +167,7 @@ fn draw_border(param: &TextParam, font: Arc<Font>) -> Option<DrawCommand> {
         align: param.align,
         baseline: param.baseline,
         max_width: param.max_width,
+        line_height_percent: param.style.line_height_percent,
     }))
 }
 
@@ -173,7 +188,7 @@ fn draw_background(param: &TextParam, font: &Font) -> RenderingTree {
 
     let font_metrics = font.metrics;
 
-    let height = get_line_height(param.font_type.size);
+    let height = param.line_height_px();
     let bottom_of_baseline = get_bottom_of_baseline(param.baseline, font_metrics);
     let top = param.y + bottom_of_baseline + font_metrics.descent + font_metrics.ascent;
 
@@ -214,4 +229,10 @@ pub fn get_text_width(text: &str, font_type: FontType, drop_shadow_x: Option<Px>
         let glyph_widths = font.get_glyph_widths(glyph_ids, Option::None);
         glyph_widths.iter().fold(px(0.0), |acc, cur| acc + cur) + drop_shadow_x.unwrap_or(px(0.0))
     })
+}
+
+impl TextParam {
+    pub fn line_height_px(&self) -> Px {
+        self.font_type.size.into_px() * self.style.line_height_percent
+    }
 }

--- a/namui/src/namui/render/text_input/draw_caret.rs
+++ b/namui/src/namui/render/text_input/draw_caret.rs
@@ -15,7 +15,7 @@ impl TextInput {
         let selection = selection.as_ref().unwrap();
         let caret = line_texts.get_multiline_caret(selection.end);
 
-        let line_height = get_line_height(props.font_type.size);
+        let line_height = props.line_height_px();
 
         let multiline_y_baseline_offset = get_multiline_y_baseline_offset(
             props.text_baseline,

--- a/namui/src/namui/render/text_input/draw_texts_divided_by_selection.rs
+++ b/namui/src/namui/render/text_input/draw_texts_divided_by_selection.rs
@@ -36,7 +36,7 @@ impl TextInput {
         let right_caret = line_texts.get_multiline_caret(right_selection_index);
 
         let y_of_line = |line_index: usize| {
-            let line_height = get_line_height(props.font_type.size);
+            let line_height = props.line_height_px();
 
             let multiline_y_baseline_offset = get_multiline_y_baseline_offset(
                 props.text_baseline,
@@ -208,7 +208,7 @@ impl TextInput {
         );
 
         if render_only_selection_background {
-            let line_height = get_line_height(props.font_type.size);
+            let line_height = props.line_height_px();
             let left = selected_text_left;
             let top = y - match props.text_baseline {
                 TextBaseline::Top => 0.px(),

--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -177,4 +177,7 @@ impl Props {
             TextBaseline::Bottom => self.rect.bottom(),
         }
     }
+    pub fn line_height_px(&self) -> Px {
+        self.font_type.size.into_px() * self.text_style.line_height_percent
+    }
 }

--- a/namui/src/namui/system/text_input/mouse_event.rs
+++ b/namui/src/namui/system/text_input/mouse_event.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::text::{get_fallback_fonts, get_line_height, LineTexts};
+use crate::text::{get_fallback_fonts, LineTexts};
 use std::ops::Range;
 
 pub(crate) fn on_mouse_down_in_before_attach_event_calls() {
@@ -161,8 +161,7 @@ fn get_selection_on_mouse_movement(
     let selection = super::get_input_element_selection(input_element);
 
     Some(get_one_click_selection(
-        props.text_align,
-        props.text_baseline,
+        props,
         &font,
         &line_texts,
         click_local_xy,
@@ -172,8 +171,7 @@ fn get_selection_on_mouse_movement(
 }
 
 fn get_one_click_selection(
-    text_align: TextAlign,
-    text_baseline: TextBaseline,
+    text_input_props: &Props,
     font: &Font,
     line_texts: &LineTexts,
     click_local_xy: Xy<Px>,
@@ -181,7 +179,7 @@ fn get_one_click_selection(
     last_selection: &Option<Range<usize>>,
 ) -> Range<usize> {
     let selection_index_of_xy =
-        get_selection_index_of_xy(text_align, text_baseline, font, line_texts, click_local_xy);
+        get_selection_index_of_xy(text_input_props, font, line_texts, click_local_xy);
 
     let start = match last_selection {
         Some(last_selection) => {
@@ -198,8 +196,7 @@ fn get_one_click_selection(
 }
 
 fn get_selection_index_of_xy(
-    text_align: TextAlign,
-    text_baseline: TextBaseline,
+    text_input_props: &Props,
     font: &Font,
     line_texts: &LineTexts,
     click_local_xy: Xy<Px>,
@@ -210,11 +207,11 @@ fn get_selection_index_of_xy(
     }
 
     let line_index = {
-        let line_height = get_line_height(font.size);
+        let line_height = text_input_props.line_height_px();
 
         let top_y = click_local_xy.y
             + line_height
-                * match text_baseline {
+                * match text_input_props.text_baseline {
                     TextBaseline::Top => 0.0,
                     TextBaseline::Middle => line_len as f32 / 2.0,
                     TextBaseline::Bottom => line_len as f32,
@@ -239,7 +236,7 @@ fn get_selection_index_of_xy(
 
     let line_width = glyph_widths.iter().sum::<Px>();
 
-    let aligned_x = match text_align {
+    let aligned_x = match text_input_props.text_align {
         TextAlign::Left => click_local_xy.x,
         TextAlign::Center => click_local_xy.x + line_width / 2.0,
         TextAlign::Right => click_local_xy.x + line_width,


### PR DESCRIPTION
- Support line_height_percent for namui::text() and namui::text_input.
- put 150.percent line height for luda-editor's text boxes

Before
![image](https://user-images.githubusercontent.com/3580430/199230053-0979974b-f82b-4c98-b2e3-4ced21069d3e.png)

After
![image](https://user-images.githubusercontent.com/3580430/199229988-26a5836d-753f-4839-b7fb-0b112a641b75.png)
