### PR TITLE
Open character edit modal on next to mouse cursor

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/mod.rs
@@ -13,6 +13,7 @@ pub struct CharacterEditModal {
     context_menu: Option<context_menu::ContextMenu>,
     editing_text_mode: Option<EditingTextMode>,
     text_input: TextInput,
+    global_xy: Xy<Px>,
 }
 
 pub struct Props<'a> {
@@ -53,7 +54,11 @@ enum EditingTextMode {
 }
 
 impl CharacterEditModal {
-    pub fn new(cut_id: namui::Uuid, character_id: Option<Uuid>) -> CharacterEditModal {
+    pub fn new(
+        cut_id: namui::Uuid,
+        character_id: Option<Uuid>,
+        global_xy: Xy<Px>,
+    ) -> CharacterEditModal {
         CharacterEditModal {
             cut_id,
             character_list_view: list_view::ListView::new(),
@@ -61,6 +66,7 @@ impl CharacterEditModal {
             context_menu: None,
             editing_text_mode: None,
             text_input: TextInput::new(),
+            global_xy,
         }
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/mod.rs
@@ -18,7 +18,9 @@ impl CharacterEditModal {
             None => RenderingTree::Empty,
         };
 
-        on_top(
+        on_top(absolute(
+            self.global_xy.x,
+            self.global_xy.y,
             render([character_list_view, context_menu]).attach_event(|builder| {
                 builder
                     .on_mouse_down_in(|event| {
@@ -29,6 +31,6 @@ impl CharacterEditModal {
                         namui::event::send(Event::Close)
                     });
             }),
-        )
+        ))
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
@@ -35,6 +35,7 @@ enum Event {
     Error(String),
     CharacterCellClicked {
         cut_id: namui::Uuid,
+        global_xy: Xy<Px>,
     },
     ScreenEditorCellClicked {
         index: usize,

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/character_cell.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/character_cell.rs
@@ -43,8 +43,11 @@ impl LoadedSequenceEditorPage {
         ])
         .attach_event(move |builder| {
             let cut_id = cut.id();
-            builder.on_mouse_down_in(move |_event| {
-                namui::event::send(Event::CharacterCellClicked { cut_id: cut_id });
+            builder.on_mouse_down_in(move |event| {
+                namui::event::send(Event::CharacterCellClicked {
+                    cut_id,
+                    global_xy: event.global_xy,
+                });
             });
         })
     }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -23,13 +23,14 @@ impl LoadedSequenceEditorPage {
                 Event::Error(error) => {
                     todo!("error: {error}")
                 }
-                &Event::CharacterCellClicked { cut_id } => {
+                &Event::CharacterCellClicked { cut_id, global_xy } => {
                     match self.sequence.cuts.iter().find(|cut| cut.id() == cut_id) {
                         Some(cut) => {
                             self.character_edit_modal =
                                 Some(character_edit_modal::CharacterEditModal::new(
                                     cut_id,
                                     cut.character_id,
+                                    global_xy,
                                 ));
                         }
                         None => {


### PR DESCRIPTION
Previously character edit modal opened in y:0, and I changed it to mouse's global_xy.
local tested.
