### PR TITLE
Support download file

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
@@ -60,6 +60,7 @@ enum Event {
     InsertCut {
         position: AddCutPosition,
     },
+    DownloadButtonClicked,
 }
 
 #[derive(Clone, Copy)]

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
@@ -74,6 +74,19 @@ impl LoadedSequenceEditorPage {
             };
             typography::body::left(wh.height, text, Color::WHITE)
         });
+        let download_button = table::fit(
+            table::FitAlign::CenterMiddle,
+            text_button_fit(
+                wh.height,
+                "Download",
+                Color::WHITE,
+                Color::WHITE,
+                1.px(),
+                Color::BLACK,
+                8.px(),
+                || namui::event::send(Event::DownloadButtonClicked),
+            ),
+        );
         let preview_button = table::fit(
             table::FitAlign::CenterMiddle,
             text_button_fit(
@@ -98,6 +111,7 @@ impl LoadedSequenceEditorPage {
                 sequence_name_label,
                 margin(),
                 sync_status,
+                download_button,
                 preview_button,
             ])(wh),
         ])

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -144,6 +144,28 @@ impl LoadedSequenceEditorPage {
                         }
                     }
                 },
+                Event::DownloadButtonClicked => {
+                    let project_shared_data_json =
+                        serde_json::to_string(&self.project_shared_data).unwrap();
+                    let sequence_json = serde_json::to_string(&self.sequence).unwrap();
+                    let project_id = self.project_id();
+                    let sequence_name = self.sequence.name.clone();
+                    spawn_local(async move {
+                        namui::system::file::download(
+                            format!("project_{project_id}.json"),
+                            project_shared_data_json,
+                        )
+                        .await
+                        .unwrap();
+
+                        namui::system::file::download(
+                            format!("sequence_{sequence_name}_{project_id}.json"),
+                            sequence_json,
+                        )
+                        .await
+                        .unwrap();
+                    });
+                }
             }
         } else if let Some(event) = event.downcast_ref::<text_input::Event>() {
             if let text_input::Event::TextUpdated { id, text } = event {

--- a/namui/Cargo.toml
+++ b/namui/Cargo.toml
@@ -71,4 +71,5 @@ features = [
     "HtmlImageElement",
     "Url",
     "ErrorEvent",
+    "HtmlAnchorElement",
 ]

--- a/namui/src/namui/system/file/download.rs
+++ b/namui/src/namui/system/file/download.rs
@@ -1,0 +1,52 @@
+use crate::system::platform_utils::web::document;
+use wasm_bindgen::JsCast;
+use web_sys::Blob;
+
+pub trait Downloadable {
+    fn to_blob(&self) -> Result<Blob, Box<dyn std::error::Error>>;
+}
+
+impl Downloadable for String {
+    fn to_blob(&self) -> Result<Blob, Box<dyn std::error::Error>> {
+        let array_sequence = {
+            let array = js_sys::Array::new();
+            array.push(&self.into());
+            array
+        };
+        let blob = web_sys::Blob::new_with_str_sequence(&array_sequence.into())
+            .map_err(|e| format!("Failed to create blob from string sequence, {:?}", e))?;
+        Ok(blob)
+    }
+}
+
+pub async fn download(
+    filename: impl AsRef<str>,
+    file: impl Downloadable,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let blob = file.to_blob()?;
+    let object_url = web_sys::Url::create_object_url_with_blob(&blob)
+        .map_err(|e| format!("Failed to create object URL for blob: {:?}", e))?;
+
+    let a_tag = document()
+        .create_element("a")
+        .map_err(|e| format!("Failed to create <a> tag: {:?}", e))?
+        .dyn_into::<web_sys::HtmlAnchorElement>()
+        .map_err(|e| format!("Failed to cast <a> tag to HtmlAnchorElement: {:?}", e))?;
+
+    a_tag.set_href(&object_url);
+    a_tag.set_download(filename.as_ref());
+
+    document()
+        .body()
+        .unwrap()
+        .append_child(&a_tag)
+        .map_err(|e| format!("Failed to append <a> tag to body: {:?}", e))?;
+
+    a_tag.click();
+
+    a_tag.remove();
+    web_sys::Url::revoke_object_url(&object_url)
+        .map_err(|e| format!("Failed to revoke object URL: {:?}", e))?;
+
+    Ok(())
+}

--- a/namui/src/namui/system/file/mod.rs
+++ b/namui/src/namui/system/file/mod.rs
@@ -1,8 +1,10 @@
 pub mod bundle;
+pub mod download;
 mod electron;
 mod init;
 pub mod picker;
 pub mod system_drive;
 pub mod types;
 
+pub use download::*;
 pub(super) use init::init;


### PR DESCRIPTION
- currently only string file download supported
- user can download luda-editor sequence in editor

![image](https://user-images.githubusercontent.com/3580430/199303482-4dcc29eb-42d1-49cd-a747-659572fbb265.png)
![image](https://user-images.githubusercontent.com/3580430/199303512-e19cdac9-e60d-45d3-abb3-dbc68d9c8468.png)

local tested