### PR TITLE
Add text_input padding

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/character.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/character.rs
@@ -75,15 +75,6 @@ impl CharacterEditModal {
                                         true => self.text_input.render(text_input::Props {
                                             text: editing_text.unwrap().clone(),
                                             rect: Rect::from_xy_wh(Xy::zero(), wh),
-                                            rect_style: RectStyle {
-                                                stroke: Some(RectStroke {
-                                                    color: stroke_color,
-                                                    width: 1.px(),
-                                                    border_position: BorderPosition::Inside,
-                                                }),
-                                                fill: Some(RectFill { color: fill_color }),
-                                                round: None,
-                                            },
                                             text_align: TextAlign::Left,
                                             text_baseline: TextBaseline::Middle,
                                             font_type: FontType {
@@ -92,8 +83,20 @@ impl CharacterEditModal {
                                                 language: Language::Ko,
                                                 font_weight: FontWeight::MEDIUM,
                                             },
-                                            text_style: TextStyle {
-                                                color: stroke_color,
+                                            style: text_input::Style {
+                                                rect: RectStyle {
+                                                    stroke: Some(RectStroke {
+                                                        color: stroke_color,
+                                                        width: 1.px(),
+                                                        border_position: BorderPosition::Inside,
+                                                    }),
+                                                    fill: Some(RectFill { color: fill_color }),
+                                                    ..Default::default()
+                                                },
+                                                text: TextStyle {
+                                                    color: stroke_color,
+                                                    ..Default::default()
+                                                },
                                                 ..Default::default()
                                             },
                                             event_handler: None,

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_edit_modal/render/label_input.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_edit_modal/render/label_input.rs
@@ -23,17 +23,6 @@ impl ImageEditModal {
                         table::ratio(1, |wh| {
                             self.label_text_input.render(text_input::Props {
                                 rect: Rect::from_xy_wh(Xy::zero(), wh),
-                                rect_style: RectStyle {
-                                    stroke: Some(RectStroke {
-                                        color: Color::WHITE,
-                                        width: 1.px(),
-                                        border_position: BorderPosition::Inside,
-                                    }),
-                                    fill: Some(RectFill {
-                                        color: Color::BLACK,
-                                    }),
-                                    round: None,
-                                },
                                 text: self.label_text.clone(),
                                 text_align: TextAlign::Left,
                                 text_baseline: TextBaseline::Middle,
@@ -43,8 +32,22 @@ impl ImageEditModal {
                                     language: Language::Ko,
                                     font_weight: FontWeight::REGULAR,
                                 },
-                                text_style: TextStyle {
-                                    color: Color::WHITE,
+                                style: text_input::Style {
+                                    rect: RectStyle {
+                                        stroke: Some(RectStroke {
+                                            color: Color::WHITE,
+                                            width: 1.px(),
+                                            border_position: BorderPosition::Inside,
+                                        }),
+                                        fill: Some(RectFill {
+                                            color: Color::BLACK,
+                                        }),
+                                        ..Default::default()
+                                    },
+                                    text: TextStyle {
+                                        color: Color::WHITE,
+                                        ..Default::default()
+                                    },
                                     ..Default::default()
                                 },
                                 event_handler: Some(text_input::EventHandler::new().on_key_down(

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/mod.rs
@@ -51,27 +51,6 @@ impl LoadedSequenceEditorPage {
                                 line_text_input
                                     .render(text_input::Props {
                                         rect: Rect::from_xy_wh(Xy::zero(), wh),
-                                        rect_style: RectStyle {
-                                            stroke: Some(match is_selected {
-                                                true => RectStroke {
-                                                    color: Color::BLUE,
-                                                    width: 2.px(),
-                                                    border_position: BorderPosition::Inside,
-                                                },
-                                                false => RectStroke {
-                                                    color: Color::WHITE,
-                                                    width: 1.px(),
-                                                    border_position: BorderPosition::Inside,
-                                                },
-                                            }),
-                                            fill: Some(RectFill {
-                                                color: match is_selected {
-                                                    true => Color::WHITE,
-                                                    false => Color::BLACK,
-                                                },
-                                            }),
-                                            round: None,
-                                        },
                                         text: cut.line.clone(),
                                         text_align: TextAlign::Left,
                                         text_baseline: TextBaseline::Middle,
@@ -81,12 +60,35 @@ impl LoadedSequenceEditorPage {
                                             language: Language::Ko,
                                             font_weight: FontWeight::REGULAR,
                                         },
-                                        text_style: TextStyle {
-                                            color: match is_selected {
-                                                true => Color::BLUE,
-                                                false => Color::WHITE,
+                                        style: text_input::Style {
+                                            rect: RectStyle {
+                                                stroke: Some(match is_selected {
+                                                    true => RectStroke {
+                                                        color: Color::BLUE,
+                                                        width: 2.px(),
+                                                        border_position: BorderPosition::Inside,
+                                                    },
+                                                    false => RectStroke {
+                                                        color: Color::WHITE,
+                                                        width: 1.px(),
+                                                        border_position: BorderPosition::Inside,
+                                                    },
+                                                }),
+                                                fill: Some(RectFill {
+                                                    color: match is_selected {
+                                                        true => Color::WHITE,
+                                                        false => Color::BLACK,
+                                                    },
+                                                }),
+                                                ..Default::default()
                                             },
-                                            line_height_percent: 150.percent(),
+                                            text: TextStyle {
+                                                color: match is_selected {
+                                                    true => Color::BLUE,
+                                                    false => Color::WHITE,
+                                                },
+                                                ..Default::default()
+                                            },
                                             ..Default::default()
                                         },
                                         event_handler: None,

--- a/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
@@ -76,17 +76,6 @@ impl RenameModal {
                         ),
                         self.text_input.render(text_input::Props {
                             rect: text_input_rect_in_modal,
-                            rect_style: RectStyle {
-                                stroke: Some(RectStroke {
-                                    color: Color::BLACK,
-                                    width: 1.px(),
-                                    border_position: BorderPosition::Outside,
-                                }),
-                                fill: Some(RectFill {
-                                    color: Color::WHITE,
-                                }),
-                                round: None,
-                            },
                             text: self.sequence_name.clone(),
                             text_align: TextAlign::Left,
                             text_baseline: TextBaseline::Top,
@@ -96,8 +85,22 @@ impl RenameModal {
                                 language: Language::Ko,
                                 font_weight: FontWeight::REGULAR,
                             },
-                            text_style: TextStyle {
-                                color: Color::BLACK,
+                            style: text_input::Style {
+                                rect: RectStyle {
+                                    stroke: Some(RectStroke {
+                                        color: Color::BLACK,
+                                        width: 1.px(),
+                                        border_position: BorderPosition::Outside,
+                                    }),
+                                    fill: Some(RectFill {
+                                        color: Color::WHITE,
+                                    }),
+                                    ..Default::default()
+                                },
+                                text: TextStyle {
+                                    color: Color::BLACK,
+                                    ..Default::default()
+                                },
                                 ..Default::default()
                             },
                             event_handler: None,

--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -68,14 +68,6 @@ impl Entity for TextInputExample {
                         width: px(200.0),
                         height: px(200.0),
                     },
-                    rect_style: RectStyle {
-                        stroke: Some(RectStroke {
-                            border_position: BorderPosition::Inside,
-                            color: Color::BLACK,
-                            width: px(1.0),
-                        }),
-                        ..Default::default()
-                    },
                     text_align: match x {
                         x if x == 0 => TextAlign::Left,
                         x if x == 1 => TextAlign::Center,
@@ -95,8 +87,19 @@ impl Entity for TextInputExample {
                         serif: false,
                         size: int_px(20),
                     },
-                    text_style: namui::TextStyle {
-                        color: namui::Color::BLACK,
+                    style: text_input::Style {
+                        rect: RectStyle {
+                            stroke: Some(RectStroke {
+                                border_position: BorderPosition::Inside,
+                                color: Color::BLACK,
+                                width: px(1.0),
+                            }),
+                            ..Default::default()
+                        },
+                        text: namui::TextStyle {
+                            color: namui::Color::BLACK,
+                            ..Default::default()
+                        },
                         ..Default::default()
                     },
                     event_handler: None,

--- a/namui/src/namui/render/text_input/draw_caret.rs
+++ b/namui/src/namui/render/text_input/draw_caret.rs
@@ -52,7 +52,7 @@ impl TextInput {
         }
         let font = font.unwrap();
 
-        let drop_shadow_x = props.text_style.drop_shadow.map(|shadow| shadow.x);
+        let drop_shadow_x = props.style.text.drop_shadow.map(|shadow| shadow.x);
 
         let left_text_width = get_text_width_internal(&font, &left_text_string, drop_shadow_x);
         let right_text_width = get_text_width_internal(&font, &right_text_string, drop_shadow_x);

--- a/namui/src/namui/system/text_input/key_down.rs
+++ b/namui/src/namui/system/text_input/key_down.rs
@@ -116,7 +116,7 @@ fn get_selection_on_keyboard_down(
         .chain(std::iter::once_with(|| get_fallback_fonts(font.size)).flatten())
         .collect::<Vec<_>>();
 
-    let paint = get_text_paint(props.text_style.color).build();
+    let paint = get_text_paint(props.style.text.color).build();
 
     let line_texts = LineTexts::new(&props.text, &fonts, &paint, Some(props.rect.width()));
 

--- a/namui/src/namui/system/text_input/mouse_event.rs
+++ b/namui/src/namui/system/text_input/mouse_event.rs
@@ -143,7 +143,7 @@ fn get_selection_on_mouse_movement(
         .chain(std::iter::once_with(|| get_fallback_fonts(font.size)).flatten())
         .collect::<Vec<_>>();
 
-    let paint = get_text_paint(props.text_style.color).build();
+    let paint = get_text_paint(props.style.text.color).build();
 
     let line_texts = LineTexts::new(&props.text, &fonts, &paint, Some(props.rect.width()));
 


### PR DESCRIPTION
Add padding for text_input

Tested in local with sample

https://user-images.githubusercontent.com/3580430/199461841-68d15482-4478-4dd0-b247-6883c7e34bfa.mp4

(padding was 10.px() in this test. now it become 4.px() as default)