### PR TITLE
Advance text input

### DIFF
--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -92,7 +92,6 @@ pub struct TextInputCustomData {
 pub enum Event {
     Focus {
         id: crate::Uuid,
-        selection: Selection,
     },
     Blur {
         id: crate::Uuid,

--- a/namui/src/namui/system/text_input/mod.rs
+++ b/namui/src/namui/system/text_input/mod.rs
@@ -123,6 +123,21 @@ pub fn is_focused(text_input_id: crate::Uuid) -> bool {
         .map(|text_input| text_input.id == (text_input_id))
         .unwrap_or(false)
 }
+pub fn focused_text_input_id() -> Option<Uuid> {
+    TEXT_INPUT_SYSTEM
+        .last_focused_text_input
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|text_input| text_input.id)
+}
+pub fn last_focus_requested_text_input_id() -> Option<Uuid> {
+    TEXT_INPUT_SYSTEM
+        .focus_requested_text_input_id
+        .lock()
+        .unwrap()
+        .clone()
+}
 fn get_text_input_xy(rendering_tree: &RenderingTree, id: crate::Uuid) -> Option<Xy<Px>> {
     let mut return_value = None;
 

--- a/namui/src/namui/system/text_input/mouse_event.rs
+++ b/namui/src/namui/system/text_input/mouse_event.rs
@@ -116,11 +116,9 @@ fn update_focus_with_mouse_movement(
         .unwrap();
 
     input_element.focus().unwrap();
-    let event = text_input::Event::Focus {
+    crate::event::send(text_input::Event::Focus {
         id: custom_data.id.clone(),
-        selection,
-    };
-    crate::event::send(event);
+    });
 }
 
 fn get_selection_on_mouse_movement(

--- a/namui/src/namui/system/text_input/post_render.rs
+++ b/namui/src/namui/system/text_input/post_render.rs
@@ -6,20 +6,20 @@ pub(crate) fn post_render(root_rendering_tree: &RenderingTree) {
 }
 
 fn update_focused_text_input(root_rendering_tree: &RenderingTree) {
+    let last_focused_text_input_id = TEXT_INPUT_SYSTEM
+        .last_focused_text_input
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|text_input| text_input.id.clone());
+
     let next_focused_text_input_id = {
         TEXT_INPUT_SYSTEM
             .focus_requested_text_input_id
             .lock()
             .unwrap()
             .take()
-            .or_else(|| {
-                TEXT_INPUT_SYSTEM
-                    .last_focused_text_input
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .map(|text_input| text_input.id.clone())
-            })
+            .or_else(|| last_focused_text_input_id)
     };
 
     if next_focused_text_input_id.is_none() {
@@ -28,6 +28,23 @@ fn update_focused_text_input(root_rendering_tree: &RenderingTree) {
     let next_focused_text_input_id = next_focused_text_input_id.unwrap();
 
     let custom_data = find_text_input_by_id(root_rendering_tree, next_focused_text_input_id);
+
+    let is_focused_text_input_id_changed =
+        last_focused_text_input_id != Some(next_focused_text_input_id);
+    if is_focused_text_input_id_changed {
+        if let Some(last_focused_text_input_id) = last_focused_text_input_id {
+            crate::event::send(text_input::Event::Blur {
+                id: last_focused_text_input_id,
+            });
+        }
+
+        let next_focused_text_input_exists = custom_data.is_some();
+        if next_focused_text_input_exists {
+            crate::event::send(text_input::Event::Focus {
+                id: next_focused_text_input_id,
+            });
+        }
+    }
 
     *TEXT_INPUT_SYSTEM.last_focused_text_input.lock().unwrap() = custom_data;
 }


### PR DESCRIPTION
I think text_input is very unstable so I will make updates with PRs more.

- Support pub fn `focused_text_input_id(id)` and `last_focus_requested_text_input_id()`
- Remove `selection` from `Focus` event
- Call `Blur` and `Focus` on focus changed by Api