### PR TITLE
Put left-right margin for sequence edit

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/mod.rs
@@ -55,20 +55,27 @@ impl LoadedSequenceEditorPage {
         ]);
 
         render([
-            table::vertical([
-                table::fixed(20.px(), |wh| {
-                    self.render_top_bar_for_editor(
-                        wh,
-                        &sequence,
-                        self.sequence_syncer.get_sync_status(),
-                    )
-                }),
+            table::horizontal([
+                table::ratio(1, |_wh| RenderingTree::Empty),
                 table::ratio(
-                    1.0,
-                    table::horizontal([table::ratio(1.0, |wh| {
-                        self.render_line_list(wh, &sequence, &characters)
-                    })]),
+                    4,
+                    table::vertical([
+                        table::fixed(20.px(), |wh| {
+                            self.render_top_bar_for_editor(
+                                wh,
+                                &sequence,
+                                self.sequence_syncer.get_sync_status(),
+                            )
+                        }),
+                        table::ratio(
+                            1.0,
+                            table::horizontal([table::ratio(1.0, |wh| {
+                                self.render_line_list(wh, &sequence, &characters)
+                            })]),
+                        ),
+                    ]),
                 ),
+                table::ratio(1, |_wh| RenderingTree::Empty),
             ])(props.wh),
             modal,
             self.context_menu


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3580430/199708325-7b960744-898a-46d4-9fa2-c998173dbd83.png)

I think we need the method to use responsive design in namui_prebuit::table.