### PR TITLE
Upload images at once

### DIFF
--- a/luda-editor/client/Cargo.lock
+++ b/luda-editor/client/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
 name = "luda-editor-client"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "mockall",
  "namui",
  "namui-prebuilt",

--- a/luda-editor/client/Cargo.toml
+++ b/luda-editor/client/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 web-sys = { version = "0.3", features = ["Location"] }
 once_cell = "1.13"
 revert-json-patch = { path = "../revert-json-patch" }
+futures = "0.3.17"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
@@ -28,6 +28,19 @@ impl ImageSelectModal {
                 table::vertical([
                     table::fixed(20.px(), |wh| {
                         table::horizontal([
+                            table::fit(
+                                table::FitAlign::RightBottom,
+                                button::text_button_fit(
+                                    wh.height,
+                                    "Upload Bulk Images using zip",
+                                    Color::WHITE,
+                                    Color::WHITE,
+                                    2.px(),
+                                    Color::BLACK,
+                                    12.px(),
+                                    || namui::event::send(InternalEvent::RequestUploadBulkImages),
+                                ),
+                            ),
                             table::ratio(1, |_| RenderingTree::Empty),
                             table::fit(
                                 table::FitAlign::RightBottom,

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
@@ -32,7 +32,7 @@ impl ImageSelectModal {
                                 table::FitAlign::RightBottom,
                                 button::text_button_fit(
                                     wh.height,
-                                    "Upload Bulk Images using zip",
+                                    "Upload Bulk Images",
                                     Color::WHITE,
                                     Color::WHITE,
                                     2.px(),

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/update/upload_images.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/update/upload_images.rs
@@ -1,0 +1,37 @@
+use super::super::super::image_upload::create_image;
+use namui::Uuid;
+use rpc::data::Label;
+use std::path::Path;
+
+pub async fn upload_images(project_id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
+    let files = namui::file::picker::open().await;
+
+    let futures = files.into_iter().map(|file| async move {
+        let filename = file.name();
+        let filename = Path::new(&filename)
+            .with_extension("")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let labels: Vec<Label> = filename
+            .split('-')
+            .map(|splitted| {
+                let (key, value_with_sign) = splitted.split_at(splitted.find('=').unwrap());
+                let value = value_with_sign.split_at(1).1;
+                Label {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                }
+            })
+            .collect();
+
+        let data = file.content().await;
+
+        create_image(project_id, labels, Some(data)).await
+    });
+
+    futures::future::try_join_all(futures).await?;
+
+    Ok(())
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_upload/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_upload/mod.rs
@@ -1,0 +1,60 @@
+use namui::file::picker::File;
+use rpc::data::*;
+
+pub async fn create_image(
+    project_id: namui::Uuid,
+    labels: Vec<Label>,
+    image: Option<Box<[u8]>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let image_id = namui::uuid();
+
+    crate::RPC
+        .put_image_meta_data(rpc::put_image_meta_data::Request {
+            project_id,
+            image_id,
+            labels,
+        })
+        .await?;
+
+    let response = crate::RPC
+        .prepare_upload_image(rpc::prepare_upload_image::Request {
+            project_id,
+            image_id,
+        })
+        .await?;
+
+    let body = match image {
+        Some(buffer) => buffer,
+        None => [].into(),
+    };
+
+    namui::network::http::fetch(
+        response.upload_url,
+        namui::network::http::Method::PUT,
+        |builder| builder.body(body.to_vec()),
+    )
+    .await?
+    .error_for_400599()
+    .await?;
+
+    Ok(())
+}
+
+pub async fn update_image(
+    _prev_label_list: Vec<Label>,
+    _new_label_list: Vec<Label>,
+    _image: Option<File>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    /*
+    1) 이미지를 수정할 경우
+    -> 그냥 put 하면 돼
+    2) 레이블을 수정할 경우
+    -> move 하면 돼
+        -> 근데 move는 Copy & Delete야.
+    3) 이미지와 레이블 둘 다 수정할 경우
+    -> put & Delete
+
+    실패할 수 있다. 실패했다고 알려주면 된다. Delete를 먼저 하진 않는다.
+     */
+    todo!()
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/mod.rs
@@ -5,6 +5,7 @@
 pub mod character_edit_modal;
 pub mod image_edit_modal;
 pub mod image_select_modal;
+pub mod image_upload;
 pub mod screen_editor;
 pub mod screen_image_list;
 pub mod wysiwyg_editor;

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -341,7 +341,9 @@ impl LoadedSequenceEditorPage {
         } else if let Some(event) = event.downcast_ref::<image_select_modal::Event>() {
             match event {
                 image_select_modal::Event::Close => self.image_select_modal = None,
-                image_select_modal::Event::Error(_) => todo!(),
+                image_select_modal::Event::Error(error) => {
+                    namui::log!("image_select_modal::Event::Error: {error}")
+                }
             }
         } else if let Some(event) = event.downcast_ref::<crate::components::sync::Event>() {
             match event {


### PR DESCRIPTION
# What Changed
-  User can upload multiple images at once using "Upload Bulk Images" button.
![image](https://user-images.githubusercontent.com/3580430/200780675-99d42085-ac34-496b-9ec2-fef51cfe5f22.png)
- To upload images using that button, user should rename image file with pattern `{label_key}={label_value}-{label_key}={label_value}.{extension}`. For example, `캐릭터=오하연-의상=평상복.png`
