### PR TITLE
Feature/image select optimization

### DIFF
--- a/namui/Cargo.toml
+++ b/namui/Cargo.toml
@@ -73,4 +73,5 @@ features = [
     "Url",
     "ErrorEvent",
     "HtmlAnchorElement",
+    "ImageBitmap",
 ]

--- a/namui/src/namui/skia/web/canvas_kit/surface.rs
+++ b/namui/src/namui/skia/web/canvas_kit/surface.rs
@@ -60,8 +60,8 @@ extern "C" {
     #[wasm_bindgen(structural, method)]
     pub(crate) fn makeImageFromTextureSource(
         this: &CanvasKitSurface,
-        src: web_sys::HtmlImageElement, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
-        info: Option<js_sys::Object>,   // ImageInfo | PartialImageInfo
+        src: JsValue, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
+        info: Option<js_sys::Object>, // ImageInfo | PartialImageInfo
         srcIsPremul: Option<bool>,
     ) -> CanvasKitImage;
 

--- a/namui/src/namui/skia/web/surface.rs
+++ b/namui/src/namui/skia/web/surface.rs
@@ -1,4 +1,5 @@
 use super::*;
+use wasm_bindgen::JsValue;
 
 pub(crate) struct Surface {
     canvas_kit_surface: CanvasKitSurface,
@@ -22,7 +23,7 @@ impl Surface {
     }
     pub fn make_image_from_texture_source(
         &self,
-        src: web_sys::HtmlImageElement, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
+        src: JsValue, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
         info: Option<PartialImageInfo>,
         src_is_premul: Option<bool>,
     ) -> Image {


### PR DESCRIPTION
I had a problem with HtmlImageElement, they seems decoding image in main thread.
I fixed it with [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap).
I found the note from chromium issue tracker that HtmlImageElement has a lot of legacy so they are not sure how they are decoding the image.

