### PR TITLE
Throttle and retry upload image request

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/update/upload_images.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/update/upload_images.rs
@@ -6,30 +6,40 @@ use std::path::Path;
 pub async fn upload_images(project_id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
     let files = namui::file::picker::open().await;
 
-    let futures = files.into_iter().map(|file| async move {
-        let filename = file.name();
-        let filename = Path::new(&filename)
-            .with_extension("")
-            .to_str()
-            .unwrap()
-            .to_string();
+    let concurrency = 10;
+    let file_count_per_channel = (files.len() as f32 / concurrency as f32).ceil() as usize;
 
-        let labels: Vec<Label> = filename
-            .split('-')
-            .map(|splitted| {
-                let (key, value_with_sign) = splitted.split_at(splitted.find('=').unwrap());
-                let value = value_with_sign.split_at(1).1;
-                Label {
-                    key: key.to_string(),
-                    value: value.to_string(),
+    let futures = files
+        .chunks(file_count_per_channel)
+        .map(|files_in_channel| async move {
+            for file in files_in_channel.into_iter() {
+                let filename = file.name();
+                let filename = Path::new(&filename)
+                    .with_extension("")
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+
+                let labels: Vec<Label> = filename
+                    .split('-')
+                    .map(|splitted| {
+                        let (key, value_with_sign) = splitted.split_at(splitted.find('=').unwrap());
+                        let value = value_with_sign.split_at(1).1;
+                        Label {
+                            key: key.to_string(),
+                            value: value.to_string(),
+                        }
+                    })
+                    .collect();
+
+                let data = file.content().await;
+
+                if let Err(error) = create_image(project_id, labels, Some(data)).await {
+                    return Err(error);
                 }
-            })
-            .collect();
-
-        let data = file.content().await;
-
-        create_image(project_id, labels, Some(data)).await
-    });
+            }
+            Ok(())
+        });
 
     futures::future::try_join_all(futures).await?;
 

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_upload/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_upload/mod.rs
@@ -1,4 +1,5 @@
 use namui::file::picker::File;
+use namui::prelude::*;
 use rpc::data::*;
 
 pub async fn create_image(
@@ -8,36 +9,89 @@ pub async fn create_image(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let image_id = namui::uuid();
 
-    crate::RPC
-        .put_image_meta_data(rpc::put_image_meta_data::Request {
-            project_id,
-            image_id,
-            labels,
-        })
-        .await?;
+    retry_on_error(
+        move || {
+            crate::RPC.put_image_meta_data(rpc::put_image_meta_data::Request {
+                project_id,
+                image_id,
+                labels: labels.clone(),
+            })
+        },
+        10,
+    )
+    .await?;
 
-    let response = crate::RPC
-        .prepare_upload_image(rpc::prepare_upload_image::Request {
-            project_id,
-            image_id,
-        })
-        .await?;
+    let response = retry_on_error(
+        move || {
+            crate::RPC.prepare_upload_image(rpc::prepare_upload_image::Request {
+                project_id,
+                image_id,
+            })
+        },
+        10,
+    )
+    .await?;
 
     let body = match image {
         Some(buffer) => buffer,
         None => [].into(),
     };
 
-    namui::network::http::fetch(
-        response.upload_url,
-        namui::network::http::Method::PUT,
-        |builder| builder.body(body.to_vec()),
+    retry_on_error(
+        move || {
+            let body = body.clone();
+            let upload_url = response.upload_url.clone();
+            async move {
+                namui::network::http::fetch(
+                    upload_url,
+                    namui::network::http::Method::PUT,
+                    |builder| builder.body(body.to_vec()),
+                )
+                .await?
+                .error_for_400599()
+                .await
+            }
+        },
+        10,
     )
-    .await?
-    .error_for_400599()
     .await?;
 
     Ok(())
+}
+
+async fn retry_on_error<FuncFuture, FuncOk, FuncErr>(
+    func: impl Fn() -> FuncFuture,
+    max_retry_count: usize,
+) -> Result<FuncOk, FuncErr>
+where
+    FuncFuture: std::future::Future<Output = Result<FuncOk, FuncErr>>,
+{
+    let mut retry_count = 0;
+    let mut delay = 100.ms();
+    loop {
+        match func().await {
+            Ok(result) => return Ok(result),
+            Err(error) => {
+                if retry_count < max_retry_count {
+                    retry_count += 1;
+                    namui::time::delay(delay).await;
+                    delay = {
+                        let collision_avoidance = ((namui::random(1)[0] % 10) as f32).ms();
+                        let next_delay = delay * 2 + collision_avoidance;
+                        let max_delay = 4000.ms();
+                        if next_delay > max_delay {
+                            max_delay
+                        } else {
+                            next_delay
+                        }
+                    };
+                    continue;
+                } else {
+                    return Err(error);
+                }
+            }
+        }
+    }
 }
 
 pub async fn update_image(

--- a/luda-editor/server/src/handle/mod.rs
+++ b/luda-editor/server/src/handle/mod.rs
@@ -37,7 +37,10 @@ async fn handle(request: Request<Body>) -> Result<Response<Body>, LambdaError> {
     let response_builder = Response::builder()
         .header("Access-Control-Allow-Origin", "*")
         .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        .header("Access-Control-Allow-Headers", "Content-Type, session");
+        .header("Access-Control-Allow-Headers", "Content-Type, session")
+        .header("Cache-Control", "no-cache, no-store, must-revalidate")
+        .header("Pragma", "no-cache")
+        .header("Expires", "0");
 
     if request.method() == Method::OPTIONS {
         return Ok(response_builder


### PR DESCRIPTION
# What happened?
- Failed to upload multiple images at once because of lambda throttle
- Fail to send some request in local even I disabled cache. It worked to send same api using curl in my git bash.

# What I did
- Throttle and retry upload image request
- Add cache disable header (wink wink, small changes but I put in this PR.)

![image](https://user-images.githubusercontent.com/3580430/201168796-8adfc052-9394-4f0f-9fa3-86b1352fdde1.png)
Tested in local and test server

