### PR TITLE
Trap events for modal

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_edit_modal/render/mod.rs
@@ -21,16 +21,14 @@ impl CharacterEditModal {
         on_top(absolute(
             self.global_xy.x,
             self.global_xy.y,
-            render([character_list_view, context_menu]).attach_event(|builder| {
-                builder
-                    .on_mouse_down_in(|event| {
-                        event.stop_propagation();
-                    })
-                    .on_mouse_down_out(|event| {
+            event_trap(
+                render([character_list_view, context_menu]).attach_event(|builder| {
+                    builder.on_mouse_down_out(|event| {
                         event.stop_propagation();
                         namui::event::send(Event::Close)
                     });
-            }),
+                }),
+            ),
         ))
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_edit_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_edit_modal/render/mod.rs
@@ -7,7 +7,7 @@ use super::*;
 
 impl ImageEditModal {
     pub fn render(&self, props: Props) -> namui::RenderingTree {
-        on_top(
+        on_top(event_trap(
             render([
                 simple_rect(props.wh, Color::WHITE, 1.px(), Color::BLACK),
                 table::horizontal([
@@ -31,15 +31,11 @@ impl ImageEditModal {
                 ])(props.wh),
             ])
             .attach_event(|builder| {
-                builder
-                    .on_mouse_down_in(|event| {
-                        event.stop_propagation();
-                    })
-                    .on_mouse_down_out(|event| {
-                        event.stop_propagation();
-                        namui::event::send(Event::Close)
-                    });
+                builder.on_mouse_down_out(|event| {
+                    event.stop_propagation();
+                    namui::event::send(Event::Close)
+                });
             }),
-        )
+        ))
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
@@ -13,16 +13,16 @@ impl ImageSelectModal {
             return image_edit_modal.render(image_edit_modal::Props { wh: props.wh });
         }
         if let Some(screen_editor) = &self.screen_editor {
-            return screen_editor.render(screen_editor::Props {
+            return event_trap(screen_editor.render(screen_editor::Props {
                 wh: props.wh,
                 project_shared_data: props.project_shared_data,
                 cut: props.cut,
-            });
+            }));
         }
 
         let screen_images = props.cut.screen_images.clone();
 
-        on_top(
+        on_top(event_trap(
             render([
                 simple_rect(props.wh, Color::WHITE, 1.px(), Color::BLACK),
                 table::vertical([
@@ -133,15 +133,11 @@ impl ImageSelectModal {
                 ])(props.wh),
             ])
             .attach_event(|builder| {
-                builder
-                    .on_mouse_down_in(|event| {
-                        event.stop_propagation();
-                    })
-                    .on_mouse_down_out(|event| {
-                        event.stop_propagation();
-                        namui::event::send(Event::Close)
-                    });
+                builder.on_mouse_down_out(|event| {
+                    event.stop_propagation();
+                    namui::event::send(Event::Close)
+                });
             }),
-        )
+        ))
     }
 }

--- a/namui-prebuilt/src/event_trap.rs
+++ b/namui-prebuilt/src/event_trap.rs
@@ -1,0 +1,61 @@
+use namui::prelude::*;
+
+pub fn event_trap(content: RenderingTree) -> RenderingTree {
+    content.attach_event(move |builder| {
+        builder
+            .on_mouse_move_in(|event| {
+                namui::log!("on_mouse_move_in");
+                event.stop_propagation()
+            })
+            .on_mouse_move_out(|event| {
+                namui::log!("on_mouse_move_out");
+                event.stop_propagation()
+            })
+            .on_mouse_down_in(|event| {
+                namui::log!("on_mouse_down_in");
+                event.stop_propagation()
+            })
+            .on_mouse_down_out(|event| {
+                namui::log!("on_mouse_down_out");
+                event.stop_propagation()
+            })
+            .on_mouse_up_in(|event| {
+                namui::log!("on_mouse_up_in");
+                event.stop_propagation()
+            })
+            .on_mouse_up_out(|event| {
+                namui::log!("on_mouse_up_out");
+                event.stop_propagation()
+            })
+            .on_wheel(|event| {
+                namui::log!("on_wheel");
+                event.stop_propagation()
+            });
+        // below don't support stop_propagation
+        // .on_key_down(|event| event.stop_propagation())
+        // .on_key_up(|event| event.stop_propagation())
+    })
+}
+
+pub fn event_trap_mouse(content: RenderingTree) -> RenderingTree {
+    content.attach_event(|builder| {
+        builder
+            .on_mouse_down_in(|event| {
+                event.stop_propagation();
+            })
+            .on_mouse_move_in(|event| {
+                event.stop_propagation();
+            })
+            .on_wheel(|event| {
+                let xy = event.namui_context.get_rendering_tree_xy(event.target);
+                if let Some(xy) = xy {
+                    if let Some(bounding_box) = event.target.get_bounding_box() {
+                        let bounding_box = bounding_box + xy;
+                        if bounding_box.is_xy_inside(system::mouse::position()) {
+                            event.stop_propagation();
+                        }
+                    }
+                }
+            });
+    })
+}

--- a/namui-prebuilt/src/lib.rs
+++ b/namui-prebuilt/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod button;
 pub mod dropdown;
+mod event_trap;
 pub mod list_view;
 pub mod scroll_view;
 mod simple_rect;
 pub mod table;
 pub mod typography;
 
+pub use event_trap::*;
 pub use simple_rect::simple_rect;
 
 #[cfg(test)]


### PR DESCRIPTION
`namui_prebuilt::event_trap` traps event's propagation.
This block event propagation for below rendering tree, so it's especially useful for modal.