### PR TITLE
Fix wrong fit unit

### DIFF
--- a/namui-prebuilt/src/table/mod.rs
+++ b/namui-prebuilt/src/table/mod.rs
@@ -234,8 +234,8 @@ pub fn fit<'a>(align: FitAlign, rendering_tree: RenderingTree) -> TableCell<'a> 
     match rendering_tree.get_bounding_box() {
         Some(bounding_box) => TableCell {
             unit: Unit::Responsive(Box::new(move |direction| match direction {
-                Direction::Vertical => bounding_box.height(),
-                Direction::Horizontal => bounding_box.width(),
+                Direction::Vertical => bounding_box.y() + bounding_box.height(),
+                Direction::Horizontal => bounding_box.x() + bounding_box.width(),
             })),
             render: Box::new(move |direction, wh| {
                 let x = match direction {


### PR DESCRIPTION
`table::fit` didn't calculate the x or y for target rendering tree.

Check left-bottom labels.

Before

![image](https://user-images.githubusercontent.com/3580430/201630039-1167c944-16a2-4f78-bb9a-a32ac47e891a.png)

After

![image](https://user-images.githubusercontent.com/3580430/201630052-319c78ff-031f-422f-adb8-861e6268553f.png)
