### PR TITLE
Improve image editor UI

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/image_preview.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/image_preview.rs
@@ -1,4 +1,5 @@
 use super::*;
+use namui_prebuilt::table::FitAlign;
 use std::str::FromStr;
 
 pub struct Props {
@@ -39,7 +40,8 @@ impl ImageSelectModal {
                         }))
                     })
                 }),
-                table::ratio(1, |wh| {
+                table::fit(
+                    FitAlign::LeftTop,
                     namui::try_render(|| {
                         let label_title = typography::body::left_top_bold("Labels", Color::WHITE);
 
@@ -70,11 +72,11 @@ impl ImageSelectModal {
                                     color: Color::WHITE,
                                     ..Default::default()
                                 },
-                                max_width: Some(wh.width - 24.px()),
+                                max_width: Some(props.wh.width - 24.px()),
                             }),
                         ]))
-                    })
-                }),
+                    }),
+                ),
                 table::fixed(64.px(), |wh| {
                     let padding = 12.px();
                     let button_height = wh.height - padding * 2;

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
@@ -5,7 +5,7 @@ mod recent_images;
 
 use super::*;
 use crate::pages::sequence_edit_page::loaded::components::screen_image_list;
-use namui_prebuilt::button::body_text_button;
+use namui_prebuilt::{button::body_text_button, typography::*};
 
 impl ImageSelectModal {
     pub fn render(&self, props: Props) -> namui::RenderingTree {
@@ -26,10 +26,10 @@ impl ImageSelectModal {
             render([
                 simple_rect(props.wh, Color::WHITE, 1.px(), Color::BLACK),
                 table::vertical([
-                    table::fixed(20.px(), |wh| {
+                    table::fixed(36.px(), |wh| {
                         table::horizontal([
                             table::fit(
-                                table::FitAlign::RightBottom,
+                                table::FitAlign::LeftTop,
                                 button::text_button_fit(
                                     wh.height,
                                     "Upload Bulk Images",
@@ -39,6 +39,15 @@ impl ImageSelectModal {
                                     Color::BLACK,
                                     12.px(),
                                     || namui::event::send(InternalEvent::RequestUploadBulkImages),
+                                ),
+                            ),
+                            table::fit(
+                                table::FitAlign::LeftTop,
+                                text_fit(
+                                    wh.height,
+                                    format!("Text: \"{}\"", props.cut.line.replace("\n", " ")),
+                                    Color::WHITE,
+                                    12.px(),
                                 ),
                             ),
                             table::ratio(1, |_| RenderingTree::Empty),

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/mod.rs
@@ -45,7 +45,7 @@ impl LoadedSequenceEditorPage {
                         .iter()
                         .find(|cut| cut.id() == image_select_modal.cut_id)
                     {
-                        let modal_wh = props.wh * 2.0 / 3.0;
+                        let modal_wh = props.wh;
                         let xy = ((props.wh - modal_wh) / 2.0).as_xy();
                         translate(
                             xy.x,

--- a/namui-prebuilt/src/table/mod.rs
+++ b/namui-prebuilt/src/table/mod.rs
@@ -234,8 +234,8 @@ pub fn fit<'a>(align: FitAlign, rendering_tree: RenderingTree) -> TableCell<'a> 
     match rendering_tree.get_bounding_box() {
         Some(bounding_box) => TableCell {
             unit: Unit::Responsive(Box::new(move |direction| match direction {
-                Direction::Vertical => bounding_box.height(),
-                Direction::Horizontal => bounding_box.width(),
+                Direction::Vertical => bounding_box.y() + bounding_box.height(),
+                Direction::Horizontal => bounding_box.x() + bounding_box.width(),
             })),
             render: Box::new(move |direction, wh| {
                 let x = match direction {

--- a/namui-prebuilt/src/typography/mod.rs
+++ b/namui-prebuilt/src/typography/mod.rs
@@ -24,6 +24,39 @@ pub fn center_text(wh: Wh<Px>, text: impl AsRef<str>, color: Color) -> Rendering
     })
 }
 
+pub fn text_fit(
+    height: Px,
+    text: impl AsRef<str>,
+    color: Color,
+    side_padding: Px,
+) -> namui::RenderingTree {
+    let center_text = namui::text(TextParam {
+        text: String::from(text.as_ref()),
+        x: 0.px(),
+        y: height / 2.0,
+        align: TextAlign::Center,
+        baseline: TextBaseline::Middle,
+        font_type: FontType {
+            font_weight: FontWeight::REGULAR,
+            language: Language::Ko,
+            serif: false,
+            size: adjust_font_size(height),
+        },
+        style: TextStyle {
+            color,
+            ..Default::default()
+        },
+        max_width: None,
+    });
+
+    let width = match center_text.get_bounding_box() {
+        Some(bounding_box) => bounding_box.width(),
+        None => return RenderingTree::Empty,
+    };
+
+    translate(width / 2 + side_padding, 0.px(), center_text)
+}
+
 fn adjust_font_size(height: Px) -> IntPx {
     // 0, 4, 8, 16, 20, ...
     let mut font_size: Px = height * 0.7;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3580430/201636894-fc1ad05d-e05a-41e3-9587-40d192b6f624.png)

Changes
1. Put text of cut in image editor
2. Bigger preview
3. Full-width image editor