### PR TITLE
Keep side-padding

### DIFF
--- a/namui-prebuilt/src/typography/mod.rs
+++ b/namui-prebuilt/src/typography/mod.rs
@@ -1,6 +1,7 @@
 pub mod body;
 pub mod title;
 
+use crate::*;
 use namui::prelude::*;
 
 pub fn center_text(
@@ -80,7 +81,15 @@ pub fn text_fit(
         None => return RenderingTree::Empty,
     };
 
-    translate(width / 2 + side_padding, 0.px(), center_text)
+    render([
+        simple_rect(
+            Wh::new(width + side_padding * 2, height),
+            Color::TRANSPARENT,
+            0.px(),
+            Color::TRANSPARENT,
+        ),
+        translate(width / 2 + side_padding, 0.px(), center_text),
+    ])
 }
 
 fn adjust_font_size(height: Px) -> IntPx {


### PR DESCRIPTION
I put side padding 100.px(), but,

Before
![image](https://user-images.githubusercontent.com/3580430/202161395-58246452-e216-42c3-a2d7-da65171b8abd.png)

No side padding there, So I put transparent rect for it.

![image](https://user-images.githubusercontent.com/3580430/202161444-5e5df8ba-be6e-43fb-8c0b-d8dedae78463.png)

It's red on screenshot, I changed it transparent color.