### PR TITLE
Image manager

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/mod.rs
@@ -2,10 +2,8 @@ mod render;
 mod update;
 
 use super::*;
-use crate::components::*;
 use namui::prelude::*;
 use namui_prebuilt::*;
-use rpc::data::*;
 
 pub struct ImageManagerModal {
     image_table: image_table::ImageTable,

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/mod.rs
@@ -1,0 +1,29 @@
+mod render;
+mod update;
+
+use super::*;
+use crate::components::*;
+use namui::prelude::*;
+use namui_prebuilt::*;
+use rpc::data::*;
+
+pub struct ImageManagerModal {
+    image_table: image_table::ImageTable,
+}
+
+pub struct Props {
+    pub wh: Wh<Px>,
+}
+
+pub enum Event {
+    Close,
+    Error(String),
+}
+
+impl ImageManagerModal {
+    pub fn new(project_id: Uuid) -> ImageManagerModal {
+        ImageManagerModal {
+            image_table: image_table::ImageTable::new(project_id),
+        }
+    }
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/render/mod.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+impl ImageManagerModal {
+    pub fn render(&self, props: Props) -> namui::RenderingTree {
+        on_top(event_trap(
+            render([
+                simple_rect(props.wh, Color::WHITE, 1.px(), Color::BLACK),
+                table::vertical([
+                    table::fixed(36.px(), |wh| {
+                        table::horizontal([
+                            table::ratio(1, |_| RenderingTree::Empty),
+                            table::fit(
+                                table::FitAlign::RightBottom,
+                                button::text_button_fit(
+                                    wh.height,
+                                    "Exit",
+                                    Color::WHITE,
+                                    Color::WHITE,
+                                    2.px(),
+                                    Color::BLACK,
+                                    12.px(),
+                                    || namui::event::send(Event::Close),
+                                ),
+                            ),
+                        ])(wh)
+                    }),
+                    table::ratio(1, |wh| self.image_table.render(image_table::Props { wh })),
+                ])(props.wh),
+            ])
+            .attach_event(|builder| {
+                builder.on_mouse_down_out(|event| {
+                    event.stop_propagation();
+                    namui::event::send(Event::Close)
+                });
+            }),
+        ))
+    }
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/render/mod.rs
@@ -1,7 +1,9 @@
 use super::*;
+use namui_prebuilt::typography::text_fit;
 
 impl ImageManagerModal {
     pub fn render(&self, props: Props) -> namui::RenderingTree {
+        let saving_count = self.image_table.saving_count;
         on_top(event_trap(
             render([
                 simple_rect(props.wh, Color::WHITE, 1.px(), Color::BLACK),
@@ -9,6 +11,22 @@ impl ImageManagerModal {
                     table::fixed(36.px(), |wh| {
                         table::horizontal([
                             table::ratio(1, |_| RenderingTree::Empty),
+                            table::fit(
+                                table::FitAlign::LeftTop,
+                                text_fit(
+                                    wh.height,
+                                    format!(
+                                        "Save Status: {}",
+                                        if saving_count == 0 {
+                                            format!("All data saved")
+                                        } else {
+                                            format!("Saving...(Please wait for it)")
+                                        }
+                                    ),
+                                    Color::WHITE,
+                                    100.px(),
+                                ),
+                            ),
                             table::fit(
                                 table::FitAlign::RightBottom,
                                 button::text_button_fit(
@@ -19,7 +37,11 @@ impl ImageManagerModal {
                                     2.px(),
                                     Color::BLACK,
                                     12.px(),
-                                    || namui::event::send(Event::Close),
+                                    move || {
+                                        if saving_count == 0 {
+                                            namui::event::send(Event::Close)
+                                        }
+                                    },
                                 ),
                             ),
                         ])(wh)
@@ -27,10 +49,12 @@ impl ImageManagerModal {
                     table::ratio(1, |wh| self.image_table.render(image_table::Props { wh })),
                 ])(props.wh),
             ])
-            .attach_event(|builder| {
-                builder.on_mouse_down_out(|event| {
+            .attach_event(move |builder| {
+                builder.on_mouse_down_out(move |event| {
                     event.stop_propagation();
-                    namui::event::send(Event::Close)
+                    if saving_count == 0 {
+                        namui::event::send(Event::Close)
+                    }
                 });
             }),
         ))

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/update/mod.rs
@@ -2,6 +2,13 @@ use super::*;
 
 impl ImageManagerModal {
     pub fn update(&mut self, event: &dyn std::any::Any) {
+        if let Some(event) = event.downcast_ref::<image_table::Event>() {
+            match event {
+                image_table::Event::Error(error) => {
+                    namui::event::send(Event::Error(error.clone()));
+                }
+            }
+        }
         self.image_table.update(event);
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_manager_modal/update/mod.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+impl ImageManagerModal {
+    pub fn update(&mut self, event: &dyn std::any::Any) {
+        self.image_table.update(event);
+    }
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
@@ -1,0 +1,53 @@
+mod render;
+mod update;
+
+use namui::prelude::*;
+use namui_prebuilt::*;
+use rpc::data::*;
+
+pub struct ImageTable {
+    project_id: Uuid,
+    list_view: list_view::ListView,
+    images: Vec<ImageWithLabels>,
+}
+
+pub struct Props {
+    pub wh: Wh<Px>,
+}
+
+pub enum Event {
+    Error(String),
+}
+
+enum InternalEvent {
+    LoadImages(Vec<ImageWithLabels>),
+}
+
+impl ImageTable {
+    pub fn new(project_id: Uuid) -> ImageTable {
+        request_reload_images(project_id);
+        ImageTable {
+            project_id,
+            list_view: list_view::ListView::new(),
+            images: vec![],
+        }
+    }
+}
+pub fn request_reload_images(project_id: Uuid) {
+    spawn_local({
+        async move {
+            let result = crate::RPC
+                .list_images(rpc::list_images::Request { project_id })
+                .await;
+
+            match result {
+                Ok(response) => {
+                    namui::event::send(InternalEvent::LoadImages(response.images));
+                }
+                Err(error) => {
+                    namui::event::send(Event::Error(error.to_string()));
+                }
+            }
+        }
+    });
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
@@ -12,6 +12,7 @@ pub struct ImageTable {
     sort_order_by: Option<SortOrderBy>,
     text_input: text_input::TextInput,
     editing_target: Option<EditingTarget>,
+    pub saving_count: usize,
 }
 
 pub struct Props {
@@ -26,6 +27,7 @@ enum InternalEvent {
     LoadImages(Vec<ImageWithLabels>),
     LeftClickOnLabelHeader { key: String },
     LeftClickOnLabelCell { image_id: Uuid, label_key: String },
+    PutImageMetaDataSuccess,
 }
 
 enum SortOrderBy {
@@ -48,6 +50,7 @@ impl ImageTable {
             sort_order_by: None,
             text_input: text_input::TextInput::new(),
             editing_target: None,
+            saving_count: 0,
         }
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
@@ -10,6 +10,8 @@ pub struct ImageTable {
     list_view: list_view::ListView,
     images: Vec<ImageWithLabels>,
     sort_order_by: Option<SortOrderBy>,
+    text_input: text_input::TextInput,
+    editing_target: Option<EditingTarget>,
 }
 
 pub struct Props {
@@ -23,11 +25,17 @@ pub enum Event {
 enum InternalEvent {
     LoadImages(Vec<ImageWithLabels>),
     LeftClickOnLabelHeader { key: String },
+    LeftClickOnLabelCell { image_id: Uuid, label_key: String },
 }
 
 enum SortOrderBy {
     Ascending { key: String },
     Descending { key: String },
+}
+
+struct EditingTarget {
+    image_id: Uuid,
+    label_key: String,
 }
 
 impl ImageTable {
@@ -38,6 +46,8 @@ impl ImageTable {
             list_view: list_view::ListView::new(),
             images: vec![],
             sort_order_by: None,
+            text_input: text_input::TextInput::new(),
+            editing_target: None,
         }
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/mod.rs
@@ -9,6 +9,7 @@ pub struct ImageTable {
     project_id: Uuid,
     list_view: list_view::ListView,
     images: Vec<ImageWithLabels>,
+    sort_order_by: Option<SortOrderBy>,
 }
 
 pub struct Props {
@@ -21,6 +22,12 @@ pub enum Event {
 
 enum InternalEvent {
     LoadImages(Vec<ImageWithLabels>),
+    LeftClickOnLabelHeader { key: String },
+}
+
+enum SortOrderBy {
+    Ascending { key: String },
+    Descending { key: String },
 }
 
 impl ImageTable {
@@ -30,6 +37,7 @@ impl ImageTable {
             project_id,
             list_view: list_view::ListView::new(),
             images: vec![],
+            sort_order_by: None,
         }
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/render/mod.rs
@@ -1,0 +1,85 @@
+use super::*;
+use crate::storage::get_project_image_url;
+use namui_prebuilt::typography::center_text;
+use std::collections::BTreeSet;
+
+const ROW_HEIGHT: Px = px(280.0);
+const COLUMN_WIDTH: Px = px(200.0);
+
+impl ImageTable {
+    pub fn render(&self, props: Props) -> RenderingTree {
+        let project_id = self.project_id;
+        let label_keys: BTreeSet<_> = self
+            .images
+            .iter()
+            .flat_map(|image| image.labels.iter().map(|label| label.key.clone()))
+            .collect();
+
+        let rows = self.images.iter().map(|image| Row {
+            image_id: image.id,
+            label_values: label_keys
+                .iter()
+                .map(|key| {
+                    image
+                        .labels
+                        .iter()
+                        .find(|label| &label.key == key)
+                        .map(|label| label.value.clone())
+                })
+                .collect(),
+        });
+
+        self.list_view.render(list_view::Props {
+            xy: Xy::zero(),
+            height: props.wh.height,
+            scroll_bar_width: 10.px(),
+            item_wh: Wh::new(props.wh.width, ROW_HEIGHT),
+            items: rows,
+            item_render: |_wh, row| row.render(project_id),
+        })
+    }
+}
+
+struct Row {
+    image_id: Uuid,
+    label_values: Vec<Option<String>>,
+}
+
+impl Row {
+    fn render(&self, project_id: Uuid) -> RenderingTree {
+        let cell_wh = Wh::new(COLUMN_WIDTH, ROW_HEIGHT);
+        let image = namui::try_render(|| {
+            let url = get_project_image_url(project_id, self.image_id).unwrap();
+            let image = namui::image::try_load_url(&url)?;
+
+            Some(namui::image(ImageParam {
+                rect: Rect::from_xy_wh(Xy::zero(), cell_wh),
+                source: ImageSource::Image(image),
+                style: ImageStyle {
+                    fit: ImageFit::Fill,
+                    paint_builder: None,
+                },
+            }))
+        });
+
+        render(
+            [image]
+                .into_iter()
+                .chain(self.label_values.iter().map(|label_value| {
+                    let border = simple_rect(cell_wh, Color::WHITE, 1.px(), Color::TRANSPARENT);
+                    let text = label_value
+                        .as_ref()
+                        .map(|label_value| {
+                            center_text(cell_wh, label_value, Color::WHITE, 18.int_px())
+                        })
+                        .unwrap_or(RenderingTree::Empty);
+
+                    render([border, text])
+                }))
+                .enumerate()
+                .map(|(index, rendering_tree)| {
+                    translate(COLUMN_WIDTH * index, 0.px(), rendering_tree)
+                }),
+        )
+    }
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/render/row.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/render/row.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+pub struct Row {
+    pub image_id: Uuid,
+    pub labels: Vec<Label>,
+}
+
+impl Row {
+    pub fn render(&self, image_table: &ImageTable) -> RenderingTree {
+        let project_id = image_table.project_id;
+        let cell_wh = Wh::new(COLUMN_WIDTH, ROW_HEIGHT);
+        let image_id = self.image_id;
+
+        let image = render([
+            border(cell_wh),
+            namui::try_render(|| {
+                let url = get_project_image_url(project_id, self.image_id).unwrap();
+                let image = namui::image::try_load_url(&url)?;
+
+                Some(namui::image(ImageParam {
+                    rect: Rect::from_xy_wh(Xy::zero(), cell_wh),
+                    source: ImageSource::Image(image),
+                    style: ImageStyle {
+                        fit: ImageFit::Contain,
+                        paint_builder: None,
+                    },
+                }))
+            }),
+        ]);
+
+        render(
+            [image]
+                .into_iter()
+                .chain(self.labels.iter().map(|label| {
+                    let text = {
+                        match image_table.editing_target.as_ref() {
+                            Some(editing_target)
+                                if editing_target.image_id == self.image_id
+                                    && editing_target.label_key == label.key =>
+                            {
+                                image_table.text_input.render(text_input::Props {
+                                    rect: Rect::from_xy_wh(Xy::zero(), cell_wh),
+                                    text: label.value.clone(),
+                                    text_align: TextAlign::Center,
+                                    text_baseline: TextBaseline::Middle,
+                                    font_type: FontType {
+                                        serif: false,
+                                        size: FONT_SIZE,
+                                        language: Language::Ko,
+                                        font_weight: FontWeight::REGULAR,
+                                    },
+                                    style: text_input::Style {
+                                        text: TextStyle {
+                                            color: Color::WHITE,
+                                            ..Default::default()
+                                        },
+                                        rect: RectStyle {
+                                            ..Default::default()
+                                        },
+                                        ..Default::default()
+                                    },
+                                    event_handler: None,
+                                })
+                            }
+                            _ => center_text(cell_wh, &label.value, Color::WHITE, FONT_SIZE),
+                        }
+                    };
+
+                    render([border(cell_wh), text]).attach_event(move |builder| {
+                        let label_key = label.key.clone();
+                        builder.on_mouse_down_in(move |event| {
+                            if event.button == Some(MouseButton::Left) {
+                                namui::event::send(InternalEvent::LeftClickOnLabelCell {
+                                    image_id,
+                                    label_key: label_key.clone(),
+                                });
+                            }
+                        });
+                    })
+                }))
+                .enumerate()
+                .map(|(index, rendering_tree)| {
+                    translate(COLUMN_WIDTH * index, 0.px(), rendering_tree)
+                }),
+        )
+    }
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+impl ImageTable {
+    pub fn update(&mut self, event: &dyn std::any::Any) {
+        if let Some(event) = event.downcast_ref::<InternalEvent>() {
+            match event {
+                InternalEvent::LoadImages(images) => {
+                    self.images = images.clone();
+                }
+            }
+        }
+        self.list_view.update(event);
+    }
+}

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
@@ -26,6 +26,41 @@ impl ImageTable {
                         },
                     };
                 }
+                &InternalEvent::LeftClickOnLabelCell {
+                    image_id,
+                    ref label_key,
+                } => {
+                    self.editing_target = Some(EditingTarget {
+                        image_id,
+                        label_key: label_key.clone(),
+                    });
+                    self.text_input.focus();
+                }
+            }
+        } else if let Some(event) = event.downcast_ref::<text_input::Event>() {
+            match event {
+                text_input::Event::Focus { id } => {}
+                text_input::Event::Blur { id } => {}
+                text_input::Event::TextUpdated { id, text } => {
+                    if id == self.text_input.get_id() {
+                        let editing_target = self.editing_target.as_ref().unwrap();
+                        if let Some(image) = self
+                            .images
+                            .iter_mut()
+                            .find(|image| image.id.eq(&editing_target.image_id))
+                        {
+                            if let Some(label) = image
+                                .labels
+                                .iter_mut()
+                                .find(|label| label.key.eq(&editing_target.label_key))
+                            {
+                                label.value = text.clone();
+                            }
+                        }
+                    }
+                }
+                text_input::Event::SelectionUpdated { id, selection } => {}
+                text_input::Event::KeyDown { id, code } => {}
             }
         }
         self.list_view.update(event);

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
@@ -66,10 +66,7 @@ impl ImageTable {
                         }
                     }
                 }
-                text_input::Event::Focus { id } => {}
-                text_input::Event::Blur { id } => {}
-                text_input::Event::SelectionUpdated { id, selection } => {}
-                text_input::Event::KeyDown { id, code } => {}
+                _ => {}
             }
         }
         self.list_view.update(event);

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_table/update/mod.rs
@@ -7,6 +7,25 @@ impl ImageTable {
                 InternalEvent::LoadImages(images) => {
                     self.images = images.clone();
                 }
+                InternalEvent::LeftClickOnLabelHeader { key } => {
+                    self.sort_order_by = match self.sort_order_by.as_ref() {
+                        None => Some(SortOrderBy::Ascending { key: key.clone() }),
+                        Some(sort_order_by) => match sort_order_by {
+                            SortOrderBy::Ascending { key: current_key }
+                            | SortOrderBy::Descending { key: current_key }
+                                if current_key.ne(key) =>
+                            {
+                                Some(SortOrderBy::Ascending { key: key.clone() })
+                            }
+                            SortOrderBy::Ascending { key: current_key } => {
+                                Some(SortOrderBy::Descending {
+                                    key: current_key.clone(),
+                                })
+                            }
+                            SortOrderBy::Descending { key: _ } => None,
+                        },
+                    };
+                }
             }
         }
         self.list_view.update(event);

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/mod.rs
@@ -4,7 +4,9 @@
 // pub mod character_image_select_modal;
 pub mod character_edit_modal;
 pub mod image_edit_modal;
+pub mod image_manager_modal;
 pub mod image_select_modal;
+pub mod image_table;
 pub mod image_upload;
 pub mod screen_editor;
 pub mod screen_image_list;

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
@@ -30,6 +30,7 @@ pub struct LoadedSequenceEditorPage {
     text_input_selected_cut_id: Option<Uuid>,
     cut_clipboard: Option<Cut>,
     images_clipboard: Option<ScreenImages>,
+    image_manager_modal: Option<image_manager_modal::ImageManagerModal>,
 }
 
 enum Event {
@@ -85,6 +86,7 @@ enum Event {
     PasteImages {
         cut_id: Uuid,
     },
+    ImageManagerButtonClicked,
 }
 
 #[derive(Clone, Copy)]
@@ -124,6 +126,7 @@ impl LoadedSequenceEditorPage {
             text_input_selected_cut_id: None,
             cut_clipboard: None,
             images_clipboard: None,
+            image_manager_modal: None,
         }
     }
     fn project_id(&self) -> Uuid {

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/mod.rs
@@ -45,21 +45,21 @@ impl LoadedSequenceEditorPage {
                         .iter()
                         .find(|cut| cut.id() == image_select_modal.cut_id)
                     {
-                        let modal_wh = props.wh;
-                        let xy = ((props.wh - modal_wh) / 2.0).as_xy();
-                        translate(
-                            xy.x,
-                            xy.y,
-                            image_select_modal.render(image_select_modal::Props {
-                                wh: modal_wh,
-                                recent_selected_image_ids: &self.recent_selected_image_ids,
-                                cut,
-                                project_shared_data: &self.project_shared_data,
-                            }),
-                        )
+                        image_select_modal.render(image_select_modal::Props {
+                            wh: props.wh,
+                            recent_selected_image_ids: &self.recent_selected_image_ids,
+                            cut,
+                            project_shared_data: &self.project_shared_data,
+                        })
                     } else {
                         RenderingTree::Empty
                     }
+                }
+                None => RenderingTree::Empty,
+            },
+            match &self.image_manager_modal {
+                Some(image_manager_modal) => {
+                    image_manager_modal.render(image_manager_modal::Props { wh: props.wh })
                 }
                 None => RenderingTree::Empty,
             },

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
@@ -74,6 +74,19 @@ impl LoadedSequenceEditorPage {
             };
             typography::body::left(wh.height, text, Color::WHITE)
         });
+        let image_manager_button = table::fit(
+            table::FitAlign::CenterMiddle,
+            text_button_fit(
+                wh.height,
+                "Image Manager",
+                Color::WHITE,
+                Color::WHITE,
+                1.px(),
+                Color::BLACK,
+                8.px(),
+                || namui::event::send(Event::ImageManagerButtonClicked),
+            ),
+        );
         let download_button = table::fit(
             table::FitAlign::CenterMiddle,
             text_button_fit(
@@ -111,6 +124,7 @@ impl LoadedSequenceEditorPage {
                 sequence_name_label,
                 margin(),
                 sync_status,
+                image_manager_button,
                 download_button,
                 preview_button,
             ])(wh),

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -310,6 +310,11 @@ impl LoadedSequenceEditorPage {
                         })
                     }
                 }
+                Event::ImageManagerButtonClicked => {
+                    self.image_manager_modal = Some(image_manager_modal::ImageManagerModal::new(
+                        self.project_shared_data.id(),
+                    ));
+                }
             }
         } else if let Some(event) = event.downcast_ref::<text_input::Event>() {
             if let text_input::Event::TextUpdated { id, text } = event {
@@ -496,6 +501,9 @@ impl LoadedSequenceEditorPage {
         self.context_menu
             .as_mut()
             .map(|context_menu| context_menu.update(event));
+        self.image_manager_modal
+            .as_mut()
+            .map(|image_manager_modal| image_manager_modal.update(event));
     }
     fn on_sequence_updated_by_server(&mut self) {
         self.renew_line_text_inputs();

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -486,6 +486,13 @@ impl LoadedSequenceEditorPage {
                     })
                 }
             }
+        } else if let Some(event) = event.downcast_ref::<image_manager_modal::Event>() {
+            match event {
+                image_manager_modal::Event::Close => {
+                    self.image_manager_modal = None;
+                }
+                image_manager_modal::Event::Error(error) => todo!("{}", error),
+            }
         }
 
         self.cut_list_view.update(event);


### PR DESCRIPTION
This Pr makes image manager for luda editor.

Image manager modal has big table or spreadsheet.
1. User can sort images using label key
2. User can update image's label value

I will put more functions, like (1) upload image, (2) delete image, (3) add new label key, (4) horizontal scroll, etc.

Demo

https://user-images.githubusercontent.com/3580430/202181629-4a56421b-f811-44fb-b386-c5110a4ea028.mp4

