### PR TITLE
Support callback version for rpc

### DIFF
--- a/luda-editor/rpc/src/lib.rs
+++ b/luda-editor/rpc/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod data;
 mod define_rpc;
 
+pub use define_rpc::RpcFuture;
 pub use revert_json_patch as json_patch;
 pub use uuid::{uuid, Uuid};
 


### PR DESCRIPTION
We uses `spawn_local` to call async function like rpc so many times, but I think it's not necessary. I thought it can be done with callback. the good point of callback is we don't have to clone parameter of self from outside.

Before

![image](https://user-images.githubusercontent.com/3580430/202196584-b36fcfe6-a4ff-425d-9834-6141b9a470bd.png)


After

![image](https://user-images.githubusercontent.com/3580430/202196597-3843a27b-5762-4573-8b4e-92e17a85bd29.png)
