### PR TITLE
Query components without refcell

### DIFF
--- a/luda-adventure/ecs-macro/src/lib.rs
+++ b/luda-adventure/ecs-macro/src/lib.rs
@@ -58,6 +58,58 @@ pub fn component(input: TokenStream) -> TokenStream {
                 )
             }
         }
+
+        impl<'component> crate::ecs::ComponentQueryArgument<'component> for Option<#name> {
+            type Output = Option<&'component #name>;
+            fn filter(
+                contained_component: &Box<dyn crate::ecs::ContainedComponent>,
+                filtered: &Option<&'component Box<dyn crate::ecs::ContainedComponent>>,
+            ) -> bool {
+                if filtered.is_some() {
+                    return false;
+                }
+                if contained_component.as_any().is::<crate::ecs::ComponentContainer<#name>>() {
+                    return true;
+                }
+                false
+            }
+            fn output(filtered: Option<&'component Box<dyn crate::ecs::ContainedComponent>>) -> Option<Self::Output> {
+                Some(filtered.and_then(|filtered| {
+                    Some(
+                        filtered
+                            .as_any()
+                            .downcast_ref::<crate::ecs::ComponentContainer<#name>>()?
+                            .as_ref(),
+                    )
+                }))
+            }
+        }
+
+        impl<'component> crate::ecs::ComponentQueryArgumentMut<'component> for Option<#name> {
+            type Output = Option<&'component mut #name>;
+            fn filter(
+                contained_component: &Box<dyn crate::ecs::ContainedComponent>,
+                filtered: &Option<&'component mut Box<dyn crate::ecs::ContainedComponent>>,
+            ) -> bool {
+                if filtered.is_some() {
+                    return false;
+                }
+                if contained_component.as_any().is::<crate::ecs::ComponentContainer<#name>>() {
+                    return true;
+                }
+                false
+            }
+            fn output(filtered: Option<&'component mut Box<dyn crate::ecs::ContainedComponent>>) -> Option<Self::Output> {
+                Some(filtered.and_then(|filtered| {
+                    Some(
+                        filtered
+                            .as_any_mut()
+                            .downcast_mut::<crate::ecs::ComponentContainer<#name>>()?
+                            .as_ref_mut(),
+                    )
+                }))
+            }
+        }
     };
 
     TokenStream::from(expanded)

--- a/luda-adventure/src/app/game/render/create_rendering_context.rs
+++ b/luda-adventure/src/app/game/render/create_rendering_context.rs
@@ -45,7 +45,7 @@ impl Game {
                 .entities()
                 .find(|entity| entity.id() == id)
                 .expect("failed to find entity")
-                .get_component::<&Positioner>()
+                .get_component::<Positioner>()
                 .unwrap()
                 .xy_with_interpolation(interpolation_progress),
             CameraSubject::Xy { xy } => xy.clone(),

--- a/luda-adventure/src/app/game/render/render_guide_icon.rs
+++ b/luda-adventure/src/app/game/render/render_guide_icon.rs
@@ -10,8 +10,8 @@ impl Game {
                 .get_quest_object_list(&self.ecs_app)
                 .iter()
                 .map(|entity| {
-                    let (renderer, positioner) =
-                        entity.get_component::<(&Renderer, &Positioner)>().unwrap();
+                    let renderer = entity.get_component::<Renderer>().unwrap();
+                    let positioner = entity.get_component::<Positioner>().unwrap();
                     let visual_area = renderer.visual_rect + positioner.xy;
                     render([
                         translate(

--- a/luda-adventure/src/app/game/render/render_guide_icon.rs
+++ b/luda-adventure/src/app/game/render/render_guide_icon.rs
@@ -10,8 +10,8 @@ impl Game {
                 .get_quest_object_list(&self.ecs_app)
                 .iter()
                 .map(|entity| {
-                    let renderer = entity.get_component::<Renderer>().unwrap();
-                    let positioner = entity.get_component::<Positioner>().unwrap();
+                    let (renderer, positioner) =
+                        entity.get_component::<(Renderer, Positioner)>().unwrap();
                     let visual_area = renderer.visual_rect + positioner.xy;
                     render([
                         translate(

--- a/luda-adventure/src/app/game/render/render_in_screen_object_list.rs
+++ b/luda-adventure/src/app/game/render/render_in_screen_object_list.rs
@@ -1,6 +1,6 @@
 use crate::{app::game::*, ecs::Entity};
 use namui::prelude::*;
-use std::cmp::Ordering;
+use std::{cell::Ref, cmp::Ordering};
 
 impl Game {
     pub fn render_in_screen_object_list(
@@ -24,7 +24,7 @@ impl Game {
     fn get_in_screen_object_list(
         &self,
         rendering_context: &RenderingContext,
-    ) -> Vec<(&crate::ecs::Entity, (&Renderer, &Positioner))> {
+    ) -> Vec<(&crate::ecs::Entity, (Ref<Renderer>, Ref<Positioner>))> {
         self.ecs_app
             .query_entities::<(&Renderer, &Positioner)>()
             .into_iter()
@@ -39,7 +39,7 @@ impl Game {
 }
 
 fn sort_in_screen_object_list_with_z_index_then_sort_with_y_coordinate(
-    in_screen_object_list: &mut Vec<(&Entity, (&Renderer, &Positioner))>,
+    in_screen_object_list: &mut Vec<(&Entity, (Ref<Renderer>, Ref<Positioner>))>,
 ) {
     in_screen_object_list.sort_by(
         |(_, (a_renderer, a_positioner)), (_, (b_renderer, b_positioner))| {

--- a/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
+++ b/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
@@ -27,15 +27,17 @@ fn character_should_escape_edge_of_wall() {
 /// - x: 0 tile
 /// - y: 0 tile
 fn add_character(ecs_app: &mut ecs::App) {
-    let mut character = new_player(Xy {
+    let character = new_player(Xy {
         x: 0.tile(),
         y: 0.tile(),
     });
-    let mover = character.get_component_mut::<&mut Mover>().unwrap();
-    mover.movement = Movement::Moving(Xy {
-        x: Per::new(1.tile(), 1.sec()),
-        y: Per::new(1.tile(), 1.sec()),
-    });
+    {
+        let mut mover = character.get_component_mut::<Mover>().unwrap();
+        mover.movement = Movement::Moving(Xy {
+            x: Per::new(1.tile(), 1.sec()),
+            y: Per::new(1.tile(), 1.sec()),
+        });
+    }
     ecs_app.add_entity(character);
 }
 

--- a/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
+++ b/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
@@ -27,7 +27,7 @@ fn character_should_escape_edge_of_wall() {
 /// - x: 0 tile
 /// - y: 0 tile
 fn add_character(ecs_app: &mut ecs::App) {
-    let character = new_player(Xy {
+    let mut character = new_player(Xy {
         x: 0.tile(),
         y: 0.tile(),
     });
@@ -58,8 +58,8 @@ fn add_wall(ecs_app: &mut ecs::App) {
 }
 
 fn get_character_x(ecs_app: &ecs::App) -> Tile {
-    let (_, (_, positioner)) = ecs_app
-        .query_entities::<(&PlayerCharacter, &Positioner)>()
+    let (_, positioner) = ecs_app
+        .query_component::<(PlayerCharacter, Positioner)>()
         .into_iter()
         .next()
         .unwrap();

--- a/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
+++ b/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
@@ -31,13 +31,11 @@ fn add_character(ecs_app: &mut ecs::App) {
         x: 0.tile(),
         y: 0.tile(),
     });
-    {
-        let mut mover = character.get_component_mut::<Mover>().unwrap();
-        mover.movement = Movement::Moving(Xy {
-            x: Per::new(1.tile(), 1.sec()),
-            y: Per::new(1.tile(), 1.sec()),
-        });
-    }
+    let mut mover = character.get_component_mut::<Mover>().unwrap();
+    mover.movement = Movement::Moving(Xy {
+        x: Per::new(1.tile(), 1.sec()),
+        y: Per::new(1.tile(), 1.sec()),
+    });
     ecs_app.add_entity(character);
 }
 

--- a/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
+++ b/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
@@ -34,13 +34,11 @@ fn add_character(ecs_app: &mut ecs::App) {
         x: 2.999.tile(),
         y: 0.tile(),
     });
-    {
-        let mut mover = character.get_component_mut::<Mover>().unwrap();
-        mover.movement = Movement::Moving(Xy {
-            x: Per::new(0.tile(), 1.sec()),
-            y: Per::new(10.tile(), 1.sec()),
-        });
-    }
+    let mut mover = character.get_component_mut::<Mover>().unwrap();
+    mover.movement = Movement::Moving(Xy {
+        x: Per::new(0.tile(), 1.sec()),
+        y: Per::new(10.tile(), 1.sec()),
+    });
     ecs_app.add_entity(character);
 }
 

--- a/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
+++ b/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
@@ -30,15 +30,17 @@ fn character_should_not_move_on_cross_axis_when_collide() {
 /// - x: 2.999 tile
 /// - y: 0 tile
 fn add_character(ecs_app: &mut ecs::App) {
-    let mut character = new_player(Xy {
+    let character = new_player(Xy {
         x: 2.999.tile(),
         y: 0.tile(),
     });
-    let mover = character.get_component_mut::<&mut Mover>().unwrap();
-    mover.movement = Movement::Moving(Xy {
-        x: Per::new(0.tile(), 1.sec()),
-        y: Per::new(10.tile(), 1.sec()),
-    });
+    {
+        let mut mover = character.get_component_mut::<Mover>().unwrap();
+        mover.movement = Movement::Moving(Xy {
+            x: Per::new(0.tile(), 1.sec()),
+            y: Per::new(10.tile(), 1.sec()),
+        });
+    }
     ecs_app.add_entity(character);
 }
 

--- a/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
+++ b/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
@@ -30,7 +30,7 @@ fn character_should_not_move_on_cross_axis_when_collide() {
 /// - x: 2.999 tile
 /// - y: 0 tile
 fn add_character(ecs_app: &mut ecs::App) {
-    let character = new_player(Xy {
+    let mut character = new_player(Xy {
         x: 2.999.tile(),
         y: 0.tile(),
     });
@@ -70,8 +70,8 @@ fn add_wall(ecs_app: &mut ecs::App) {
 }
 
 fn get_character_x(ecs_app: &ecs::App) -> Tile {
-    let (_, (_, positioner)) = ecs_app
-        .query_entities::<(&PlayerCharacter, &Positioner)>()
+    let (_, positioner) = ecs_app
+        .query_component::<(PlayerCharacter, Positioner)>()
         .into_iter()
         .next()
         .unwrap();

--- a/luda-adventure/src/app/game/types/game_object/component/collider/collider.rs
+++ b/luda-adventure/src/app/game/types/game_object/component/collider/collider.rs
@@ -3,7 +3,7 @@ use crate::app::game::Tile;
 use geo::Polygon;
 use namui::prelude::*;
 
-#[derive(ecs_macro::Component)]
+#[derive(ecs_macro::Component, Debug)]
 pub struct Collider {
     rigid_body_at_origin: RigidBody,
 }

--- a/luda-adventure/src/app/game/types/game_object/component/collider/rigid_body/circle.rs
+++ b/luda-adventure/src/app/game/types/game_object/component/collider/rigid_body/circle.rs
@@ -1,5 +1,6 @@
 use geo::{Contains, Coordinate, EuclideanDistance};
 
+#[derive(Debug)]
 pub struct Circle {
     pub center: Coordinate<f64>,
     pub radius: f64,

--- a/luda-adventure/src/app/game/types/game_object/component/collider/rigid_body/rigid_body.rs
+++ b/luda-adventure/src/app/game/types/game_object/component/collider/rigid_body/rigid_body.rs
@@ -3,6 +3,7 @@ use crate::app::game::{CollisionInfo, Tile};
 use geo::{coord, polygon, Polygon, Translate};
 use namui::prelude::*;
 
+#[derive(Debug)]
 pub enum RigidBody {
     Polygon(Polygon),
     Circle(Circle),

--- a/luda-adventure/src/app/game/types/game_object/component/renderer.rs
+++ b/luda-adventure/src/app/game/types/game_object/component/renderer.rs
@@ -6,15 +6,14 @@ use std::fmt::Debug;
 pub struct Renderer {
     pub z_index: i32,
     pub visual_rect: Rect<Tile>,
-    render:
-        Box<dyn Fn(&crate::ecs::Entity, &GameState, &RenderingContext) -> RenderingTree + 'static>,
+    render: Box<dyn Fn(&GameState, &RenderingContext, Xy<Tile>) -> RenderingTree + 'static>,
 }
 
 impl Renderer {
     pub fn new(
         z_index: i32,
         visual_rect: Rect<Tile>,
-        render: impl Fn(&crate::ecs::Entity, &GameState, &RenderingContext) -> RenderingTree + 'static,
+        render: impl Fn(&GameState, &RenderingContext, Xy<Tile>) -> RenderingTree + 'static,
     ) -> Self {
         Self {
             z_index,
@@ -24,11 +23,11 @@ impl Renderer {
     }
     pub fn render(
         &self,
-        entity: &crate::ecs::Entity,
         game_state: &GameState,
         rendering_context: &RenderingContext,
+        xy: Xy<Tile>,
     ) -> RenderingTree {
-        (self.render)(entity, game_state, rendering_context)
+        (self.render)(game_state, rendering_context, xy)
     }
 }
 

--- a/luda-adventure/src/app/game/types/game_object/component/renderer.rs
+++ b/luda-adventure/src/app/game/types/game_object/component/renderer.rs
@@ -1,5 +1,6 @@
 use crate::app::game::*;
 use namui::prelude::*;
+use std::fmt::Debug;
 
 #[derive(ecs_macro::Component)]
 pub struct Renderer {
@@ -28,5 +29,14 @@ impl Renderer {
         rendering_context: &RenderingContext,
     ) -> RenderingTree {
         (self.render)(entity, game_state, rendering_context)
+    }
+}
+
+impl Debug for Renderer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Renderer")
+            .field("z_index", &self.z_index)
+            .field("visual_rect", &self.visual_rect)
+            .finish()
     }
 }

--- a/luda-adventure/src/app/game/types/game_object/floor.rs
+++ b/luda-adventure/src/app/game/types/game_object/floor.rs
@@ -41,7 +41,7 @@ pub fn new_floor(positions: Vec<Xy<Tile>>) -> crate::ecs::Entity {
                 height: VISUAL_HEIGHT + max_y - min_y,
             },
             move |entity, _game_context, rendering_context| {
-                let positioner = entity.get_component::<&Positioner>().unwrap();
+                let positioner = entity.get_component::<Positioner>().unwrap();
                 let main_position = positioner.xy;
 
                 render(

--- a/luda-adventure/src/app/game/types/game_object/floor.rs
+++ b/luda-adventure/src/app/game/types/game_object/floor.rs
@@ -40,14 +40,11 @@ pub fn new_floor(positions: Vec<Xy<Tile>>) -> crate::ecs::Entity {
                 width: VISUAL_WIDTH + max_x - min_x,
                 height: VISUAL_HEIGHT + max_y - min_y,
             },
-            move |entity, _game_context, rendering_context| {
-                let positioner = entity.get_component::<Positioner>().unwrap();
-                let main_position = positioner.xy;
-
+            move |_game_context, rendering_context, xy| {
                 render(
                     positions
                         .iter()
-                        .map(|position| position + main_position)
+                        .map(|position| position + xy)
                         .filter(|position| {
                             rendering_context
                                 .screen_rect

--- a/luda-adventure/src/app/game/types/game_object/player_character/heading.rs
+++ b/luda-adventure/src/app/game/types/game_object/player_character/heading.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Heading {
     Left,
     Right,

--- a/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
+++ b/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
@@ -7,7 +7,7 @@ const VISUAL_HEIGHT: Tile = tile(4.0);
 const VISUAL_OFFSET_X: Tile = tile(-1.5);
 const VISUAL_OFFSET_Y: Tile = tile(-2.5);
 
-#[derive(ecs_macro::Component)]
+#[derive(ecs_macro::Component, Debug)]
 pub struct PlayerCharacter {
     heading: Heading,
 }
@@ -48,8 +48,8 @@ pub fn new_player(xy: Xy<Tile>) -> crate::ecs::Entity {
                 height: VISUAL_HEIGHT,
             },
             |entity, _game_context, rendering_context| {
-                let positioner = entity.get_component::<&Positioner>().unwrap();
-                let character = entity.get_component::<&PlayerCharacter>().unwrap();
+                let positioner = entity.get_component::<Positioner>().unwrap();
+                let character = entity.get_component::<PlayerCharacter>().unwrap();
                 let position =
                     positioner.xy_with_interpolation(rendering_context.interpolation_progress);
                 translate(

--- a/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
+++ b/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
@@ -47,14 +47,11 @@ pub fn new_player(xy: Xy<Tile>) -> crate::ecs::Entity {
                 width: VISUAL_WIDTH,
                 height: VISUAL_HEIGHT,
             },
-            |entity, _game_context, rendering_context| {
-                let positioner = entity.get_component::<Positioner>().unwrap();
-                let character = entity.get_component::<PlayerCharacter>().unwrap();
-                let position =
-                    positioner.xy_with_interpolation(rendering_context.interpolation_progress);
+            |_game_context, rendering_context, xy| {
+                //TODO: Render the player character with heading
                 translate(
-                    (rendering_context.px_per_tile * (position.x + VISUAL_OFFSET_X)).floor(),
-                    (rendering_context.px_per_tile * (position.y + VISUAL_OFFSET_Y)).floor(),
+                    (rendering_context.px_per_tile * (xy.x + VISUAL_OFFSET_X)).floor(),
+                    (rendering_context.px_per_tile * (xy.y + VISUAL_OFFSET_Y)).floor(),
                     render([
                         simple_rect(
                             Wh {
@@ -70,10 +67,11 @@ pub fn new_player(xy: Xy<Tile>) -> crate::ecs::Entity {
                                 width: rendering_context.px_per_tile * VISUAL_WIDTH,
                                 height: rendering_context.px_per_tile * VISUAL_HEIGHT,
                             },
-                            match character.heading {
-                                Heading::Left => "L",
-                                Heading::Right => "R",
-                            },
+                            // match character.heading {
+                            //     Heading::Left => "L",
+                            //     Heading::Right => "R",
+                            // },
+                            "E",
                             Color::WHITE,
                         ),
                     ]),

--- a/luda-adventure/src/app/game/types/game_object/wall.rs
+++ b/luda-adventure/src/app/game/types/game_object/wall.rs
@@ -56,7 +56,7 @@ fn append_components(entity: crate::ecs::Entity, positions: Vec<Xy<Tile>>) -> cr
                 width,
                 height,
             },
-            move |_entity, _game_context, rendering_context| {
+            move |_game_context, rendering_context, _xy| {
                 render(
                     positions
                         .iter()

--- a/luda-adventure/src/app/game/update/evaluate_ticks/move_character.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/move_character.rs
@@ -3,9 +3,9 @@ use namui::prelude::*;
 
 impl Game {
     pub fn move_character(&mut self) {
-        if let Some((_entity, (_player_character, positioner, mover))) = self
+        if let Some((_player_character, positioner, mover)) = self
             .ecs_app
-            .query_entities_mut::<(&PlayerCharacter, &mut Positioner, &Mover)>()
+            .query_component_mut::<(PlayerCharacter, Positioner, Mover)>()
             .first_mut()
         {
             if let Movement::Moving(velocity) = mover.movement {

--- a/luda-adventure/src/app/game/update/evaluate_ticks/pre_evaluate_ticks/update_positioner_interpolation.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/pre_evaluate_ticks/update_positioner_interpolation.rs
@@ -2,7 +2,7 @@ use crate::app::game::{Game, Positioner};
 
 impl Game {
     pub fn save_positioner_xy(&mut self) {
-        for (_entity, mut positioner) in self.ecs_app.query_entities_mut::<&mut Positioner>() {
+        for positioner in self.ecs_app.query_component_mut::<Positioner>() {
             positioner.save_current_xy();
         }
     }

--- a/luda-adventure/src/app/game/update/evaluate_ticks/pre_evaluate_ticks/update_positioner_interpolation.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/pre_evaluate_ticks/update_positioner_interpolation.rs
@@ -2,7 +2,7 @@ use crate::app::game::{Game, Positioner};
 
 impl Game {
     pub fn save_positioner_xy(&mut self) {
-        for (_entity, positioner) in self.ecs_app.query_entities_mut::<&mut Positioner>() {
+        for (_entity, mut positioner) in self.ecs_app.query_entities_mut::<&mut Positioner>() {
             positioner.save_current_xy();
         }
     }

--- a/luda-adventure/src/app/game/update/evaluate_ticks/resolve_collision_about_character.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/resolve_collision_about_character.rs
@@ -50,10 +50,10 @@ impl Game {
 
 fn get_rigid_body_list_except_character(ecs_app: &ecs::App) -> Vec<RigidBody> {
     ecs_app
-        .query_component::<(Collider, Positioner)>()
+        .query_component::<(Collider, Positioner, Option<PlayerCharacter>)>()
         .into_iter()
-        // TODO: Filter out character
-        .map(|(collider, positioner)| collider.get_rigid_body(positioner.xy))
+        .filter(|(_, _, player_character)| player_character.is_none())
+        .map(|(collider, positioner, _)| collider.get_rigid_body(positioner.xy))
         .collect::<Vec<_>>()
 }
 

--- a/luda-adventure/src/app/game/update/evaluate_ticks/resolve_collision_about_character.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/resolve_collision_about_character.rs
@@ -1,8 +1,5 @@
 use crate::{
-    app::game::{
-        known_id::object::PLAYER_CHARACTER, Collider, CollisionInfo, Game, PlayerCharacter,
-        Positioner, RigidBody, Tile,
-    },
+    app::game::{Collider, CollisionInfo, Game, PlayerCharacter, Positioner, RigidBody, Tile},
     ecs,
 };
 use namui::prelude::*;
@@ -12,9 +9,9 @@ const MAX_COLLISION_RESOLVE_COUNT: i32 = 6;
 impl Game {
     pub fn resolve_collision_about_character(&mut self) {
         let rigid_body_list_except_character = get_rigid_body_list_except_character(&self.ecs_app);
-        if let Some((_, (_, character_collider, character_positioner))) = self
+        if let Some((_, character_collider, character_positioner)) = self
             .ecs_app
-            .query_entities_mut::<(&PlayerCharacter, &Collider, &mut Positioner)>()
+            .query_component_mut::<(PlayerCharacter, Collider, Positioner)>()
             .first_mut()
         {
             let mut character_rigid_body =
@@ -53,14 +50,10 @@ impl Game {
 
 fn get_rigid_body_list_except_character(ecs_app: &ecs::App) -> Vec<RigidBody> {
     ecs_app
-        .query_entities::<(&Collider, &Positioner)>()
+        .query_component::<(Collider, Positioner)>()
         .into_iter()
-        .filter_map(
-            |(entity, (collider, positioner))| match entity.id() == PLAYER_CHARACTER {
-                true => None,
-                false => Some(collider.get_rigid_body(positioner.xy)),
-            },
-        )
+        // TODO: Filter out character
+        .map(|(collider, positioner)| collider.get_rigid_body(positioner.xy))
         .collect::<Vec<_>>()
 }
 

--- a/luda-adventure/src/app/game/update/set_character_movement_according_to_user_input.rs
+++ b/luda-adventure/src/app/game/update/set_character_movement_according_to_user_input.rs
@@ -10,9 +10,9 @@ impl Game {
                     let movement_direction =
                         get_movement_direction_from_pressing_codes(&event.pressing_codes);
 
-                    if let Some((_entity, (player_character, mover))) = self
+                    if let Some((player_character, mover)) = self
                         .ecs_app
-                        .query_entities_mut::<(&mut PlayerCharacter, &mut Mover)>()
+                        .query_component_mut::<(PlayerCharacter, Mover)>()
                         .first_mut()
                     {
                         player_character.update_heading(movement_direction);

--- a/luda-adventure/src/ecs/app.rs
+++ b/luda-adventure/src/ecs/app.rs
@@ -1,0 +1,55 @@
+use super::{ComponentCombination, ComponentCombinationMut, Entity};
+
+pub struct App {
+    entities: Vec<Entity>,
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self {
+            entities: Vec::new(),
+        }
+    }
+    pub fn entities(&self) -> impl Iterator<Item = &Entity> {
+        self.entities.iter()
+    }
+    pub fn entities_mut(&mut self) -> impl Iterator<Item = &mut Entity> {
+        self.entities.iter_mut()
+    }
+    pub fn add_entity(&mut self, entity: Entity) {
+        self.entities.push(entity);
+    }
+    pub fn add_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+        self.entities.extend(entities);
+    }
+    pub fn query_entities<'a, T: ComponentCombination<'a>>(
+        &'a self,
+    ) -> Vec<(&'a Entity, T::Output)> {
+        let mut query = Vec::new();
+        for entity in &self.entities {
+            if let Some(component) = T::filter(entity) {
+                query.push((entity, component));
+            }
+        }
+        query
+    }
+    pub fn query_entities_mut<'a, T: ComponentCombinationMut<'a>>(
+        &'a mut self,
+    ) -> Vec<(&'a Entity, T::Output)> {
+        let mut query = Vec::new();
+        for entity in &self.entities {
+            if let Some(component) = T::filter(entity) {
+                query.push((entity, component));
+            }
+        }
+        query
+    }
+}
+
+impl std::fmt::Debug for App {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("App")
+            .field("entities", &self.entities)
+            .finish()
+    }
+}

--- a/luda-adventure/src/ecs/app.rs
+++ b/luda-adventure/src/ecs/app.rs
@@ -22,24 +22,20 @@ impl App {
     pub fn add_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
         self.entities.extend(entities);
     }
-    pub fn query_entities<'a, T: ComponentCombination<'a>>(
-        &'a self,
-    ) -> Vec<(&'a Entity, T::Output)> {
+    pub fn query_component<'a, T: ComponentCombination<'a>>(&'a self) -> Vec<T::Output> {
         let mut query = Vec::new();
         for entity in &self.entities {
-            if let Some(component) = T::filter(entity) {
-                query.push((entity, component));
+            if let Some(component) = entity.get_component::<T>() {
+                query.push(component);
             }
         }
         query
     }
-    pub fn query_entities_mut<'a, T: ComponentCombinationMut<'a>>(
-        &'a mut self,
-    ) -> Vec<(&'a Entity, T::Output)> {
+    pub fn query_component_mut<'a, T: ComponentCombinationMut<'a>>(&'a mut self) -> Vec<T::Output> {
         let mut query = Vec::new();
-        for entity in &self.entities {
-            if let Some(component) = T::filter(entity) {
-                query.push((entity, component));
+        for entity in &mut self.entities {
+            if let Some(component) = entity.get_component_mut::<T>() {
+                query.push(component);
             }
         }
         query

--- a/luda-adventure/src/ecs/app.rs
+++ b/luda-adventure/src/ecs/app.rs
@@ -1,4 +1,4 @@
-use super::{ComponentCombination, ComponentCombinationMut, Entity};
+use super::{ComponentQueryCombination, ComponentQueryCombinationMut, Entity};
 
 pub struct App {
     entities: Vec<Entity>,
@@ -22,7 +22,7 @@ impl App {
     pub fn add_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
         self.entities.extend(entities);
     }
-    pub fn query_component<'a, T: ComponentCombination<'a>>(&'a self) -> Vec<T::Output> {
+    pub fn query_component<'a, T: ComponentQueryCombination<'a>>(&'a self) -> Vec<T::Output> {
         let mut query = Vec::new();
         for entity in &self.entities {
             if let Some(component) = entity.get_component::<T>() {
@@ -31,7 +31,9 @@ impl App {
         }
         query
     }
-    pub fn query_component_mut<'a, T: ComponentCombinationMut<'a>>(&'a mut self) -> Vec<T::Output> {
+    pub fn query_component_mut<'a, T: ComponentQueryCombinationMut<'a>>(
+        &'a mut self,
+    ) -> Vec<T::Output> {
         let mut query = Vec::new();
         for entity in &mut self.entities {
             if let Some(component) = entity.get_component_mut::<T>() {

--- a/luda-adventure/src/ecs/component.rs
+++ b/luda-adventure/src/ecs/component.rs
@@ -1,0 +1,32 @@
+use super::Entity;
+use std::{cell::RefCell, fmt::Debug};
+
+pub trait Component: Debug {}
+pub trait WrappedComponent: Debug {
+    fn as_any(&self) -> &dyn std::any::Any;
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+}
+impl<T: Debug + 'static> WrappedComponent for RefCell<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self as &dyn std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self as &mut dyn std::any::Any
+    }
+}
+
+pub trait ComponentCombination<'a> {
+    type Output;
+    fn filter(entity: &'a Entity) -> Option<Self::Output>
+    where
+        Self: Sized;
+}
+
+pub trait ComponentCombinationMut<'a> {
+    type Output;
+    fn filter(entity: &'a Entity) -> Option<Self::Output>
+    where
+        Self: Sized;
+}
+
+ecs_macro::define_combinations!();

--- a/luda-adventure/src/ecs/component.rs
+++ b/luda-adventure/src/ecs/component.rs
@@ -1,12 +1,31 @@
-use super::Entity;
-use std::{cell::RefCell, fmt::Debug};
+use std::fmt::Debug;
 
 pub trait Component: Debug {}
-pub trait WrappedComponent: Debug {
+
+#[derive(Debug)]
+pub struct ComponentContainer<T> {
+    pub component: T,
+}
+impl<T> ComponentContainer<T>
+where
+    T: Component,
+{
+    pub fn new(component: T) -> Self {
+        Self { component }
+    }
+    pub fn as_ref(&self) -> &T {
+        &self.component
+    }
+    pub fn as_ref_mut(&mut self) -> &mut T {
+        &mut self.component
+    }
+}
+
+pub trait ContainedComponent: Debug + 'static {
     fn as_any(&self) -> &dyn std::any::Any;
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
-impl<T: Debug + 'static> WrappedComponent for RefCell<T> {
+impl<T: Debug + 'static> ContainedComponent for ComponentContainer<T> {
     fn as_any(&self) -> &dyn std::any::Any {
         self as &dyn std::any::Any
     }
@@ -14,19 +33,3 @@ impl<T: Debug + 'static> WrappedComponent for RefCell<T> {
         self as &mut dyn std::any::Any
     }
 }
-
-pub trait ComponentCombination<'a> {
-    type Output;
-    fn filter(entity: &'a Entity) -> Option<Self::Output>
-    where
-        Self: Sized;
-}
-
-pub trait ComponentCombinationMut<'a> {
-    type Output;
-    fn filter(entity: &'a Entity) -> Option<Self::Output>
-    where
-        Self: Sized;
-}
-
-ecs_macro::define_combinations!();

--- a/luda-adventure/src/ecs/component.rs
+++ b/luda-adventure/src/ecs/component.rs
@@ -1,3 +1,4 @@
+use super::Entity;
 use std::fmt::Debug;
 
 pub trait Component: Debug {}
@@ -32,4 +33,36 @@ impl<T: Debug + 'static> ContainedComponent for ComponentContainer<T> {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self as &mut dyn std::any::Any
     }
+}
+
+pub trait ComponentQueryArgument<'component> {
+    type Output;
+    fn filter(
+        contained_component: &Box<dyn ContainedComponent>,
+        filtered: &Option<&'component Box<dyn ContainedComponent>>,
+    ) -> bool;
+    fn output(filtered: Option<&'component Box<dyn ContainedComponent>>) -> Option<Self::Output>;
+}
+pub trait ComponentQueryArgumentMut<'component> {
+    type Output;
+    fn filter(
+        contained_component: &Box<dyn ContainedComponent>,
+        filtered: &Option<&'component mut Box<dyn ContainedComponent>>,
+    ) -> bool;
+    fn output(
+        filtered: Option<&'component mut Box<dyn ContainedComponent>>,
+    ) -> Option<Self::Output>;
+}
+
+pub trait ComponentQueryCombination<'entity> {
+    type Output;
+    fn filter(entity: &'entity Entity) -> Option<Self::Output>
+    where
+        Self: Sized;
+}
+pub trait ComponentQueryCombinationMut<'entity> {
+    type Output;
+    fn filter(entity: &'entity mut Entity) -> Option<Self::Output>
+    where
+        Self: Sized;
 }

--- a/luda-adventure/src/ecs/mod.rs
+++ b/luda-adventure/src/ecs/mod.rs
@@ -1,72 +1,7 @@
+mod app;
+mod component;
 mod entity;
 
+pub use app::*;
+pub use component::*;
 pub use entity::*;
-use namui::Uuid;
-
-pub trait Component {
-    fn insert(self, id: Uuid);
-    fn drop(id: Uuid);
-}
-
-pub trait ComponentCombination {
-    fn filter(entity: &Entity) -> Option<Self>
-    where
-        Self: Sized;
-}
-
-pub trait ComponentCombinationMut {
-    fn filter(entity: &mut Entity) -> Option<Self>
-    where
-        Self: Sized;
-}
-pub struct App {
-    entities: Vec<Entity>,
-}
-
-impl App {
-    pub fn new() -> Self {
-        Self {
-            entities: Vec::new(),
-        }
-    }
-    pub fn entities(&self) -> impl Iterator<Item = &Entity> {
-        self.entities.iter()
-    }
-    pub fn entities_mut(&mut self) -> impl Iterator<Item = &mut Entity> {
-        self.entities.iter_mut()
-    }
-    pub fn add_entity(&mut self, entity: Entity) {
-        self.entities.push(entity);
-    }
-    pub fn add_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
-        self.entities.extend(entities);
-    }
-    pub fn query_entities<T: ComponentCombination>(&self) -> Vec<(&Entity, T)> {
-        let mut query = Vec::new();
-        for entity in &self.entities {
-            if let Some(component) = T::filter(entity) {
-                query.push((entity, component));
-            }
-        }
-        query
-    }
-    pub fn query_entities_mut<T: ComponentCombinationMut>(&mut self) -> Vec<(&mut Entity, T)> {
-        let mut query = Vec::new();
-        for entity in &mut self.entities {
-            if let Some(component) = T::filter(entity) {
-                query.push((entity, component));
-            }
-        }
-        query
-    }
-}
-
-impl std::fmt::Debug for App {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("App")
-            .field("entities", &self.entities)
-            .finish()
-    }
-}
-
-ecs_macro::define_combinations!();


### PR DESCRIPTION
# What I did
## Query components without refcell
Also, there is no entity returned.
### Before
```rust
let (entity: Entity, (a: Ref<A>, b: Ref<B>, c: Ref<C>)) = app.query<&A, &B, &C>();
```
### After
```rust
let (a: &A, b: &B, c: &C) = app.query<A, B, C>();
```

## Support optional component
```rust
let (a: &A, c: Option<&C>) = app.query<A, Option<C>>();
```