### PR TITLE
Recolor context menu

### DIFF
--- a/luda-editor/client/src/components/context_menu.rs
+++ b/luda-editor/client/src/components/context_menu.rs
@@ -71,15 +71,15 @@ impl ContextMenu {
                 } => {
                     next_y += cell_wh.height;
                     let is_selected = self.mouse_over_item_id.as_ref() == Some(&id);
-                    let border = if is_selected {
-                        simple_rect(cell_wh, Color::TRANSPARENT, 0.px(), Color::WHITE)
-                    } else {
+                    let background = if is_selected {
                         simple_rect(
                             cell_wh,
                             Color::TRANSPARENT,
                             0.px(),
-                            Color::grayscale_f01(0.2),
+                            Color::from_u8(129, 198, 232, 255),
                         )
+                    } else {
+                        RenderingTree::Empty
                     };
                     let text_color = if is_selected {
                         Color::BLACK
@@ -91,7 +91,7 @@ impl ContextMenu {
                         0.px(),
                         y,
                         render([
-                            border,
+                            background,
                             typography::body::left(
                                 cell_wh.height,
                                 format!("  {}", text),
@@ -129,7 +129,7 @@ impl ContextMenu {
             Wh::new(cell_wh.width, next_y),
             Color::TRANSPARENT,
             0.px(),
-            Color::BLACK,
+            Color::grayscale_f01(0.2),
         );
 
         on_top(absolute(


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/3580430/202845363-8912a6eb-ce5f-4269-acfa-5668f8c7119a.png)

After

![image](https://user-images.githubusercontent.com/3580430/202845367-62ef0645-1bcf-4f8c-b555-340cea9e1a2d.png)

I think I should make a Color Palette for luda editor in separated file.