### PR TITLE
Make canvaskit image reusable for multiple surfaces

### DIFF
--- a/namui/src/namui/skia/web/canvas_kit/surface.rs
+++ b/namui/src/namui/skia/web/canvas_kit/surface.rs
@@ -39,31 +39,31 @@ extern "C" {
     // #[wasm_bindgen(structural, method)]
     // fn makeImageFromTexture(this: &CanvasKitSurface, tex: WebGLTexture, info: ImageInfo) -> Image | null;
 
-    ///
-    /// Returns a texture-backed image based on the content in src. It uses RGBA_8888, unpremul
-    /// and SRGB - for more control, use makeImageFromTexture.
-    ///
-    /// The underlying texture for this image will be created immediately from src, so
-    /// it can be disposed of after this call. This image will *only* be usable for this
-    /// surface (because WebGL textures are not transferable to other WebGL contexts).
-    /// For an image that can be used across multiple surfaces, at the cost of being lazily
-    /// loaded, see MakeLazyImageFromTextureSource.
-    ///
-    /// Not available for software-backed surfaces.
-    /// @param src
-    /// @param info - If provided, will be used to determine the width/height/format of the
-    ///               source image. If not, sensible defaults will be used.
-    /// @param srcIsPremul - set to true if the src data has premultiplied alpha. Otherwise, it will
-    ///               be assumed to be Unpremultiplied. Note: if this is true and info specifies
-    ///               Unpremul, Skia will not convert the src pixels first.
-    ///
-    #[wasm_bindgen(structural, method)]
-    pub(crate) fn makeImageFromTextureSource(
-        this: &CanvasKitSurface,
-        src: JsValue, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
-        info: Option<js_sys::Object>, // ImageInfo | PartialImageInfo
-        srcIsPremul: Option<bool>,
-    ) -> CanvasKitImage;
+    // ///
+    // /// Returns a texture-backed image based on the content in src. It uses RGBA_8888, unpremul
+    // /// and SRGB - for more control, use makeImageFromTexture.
+    // ///
+    // /// The underlying texture for this image will be created immediately from src, so
+    // /// it can be disposed of after this call. This image will *only* be usable for this
+    // /// surface (because WebGL textures are not transferable to other WebGL contexts).
+    // /// For an image that can be used across multiple surfaces, at the cost of being lazily
+    // /// loaded, see MakeLazyImageFromTextureSource.
+    // ///
+    // /// Not available for software-backed surfaces.
+    // /// @param src
+    // /// @param info - If provided, will be used to determine the width/height/format of the
+    // ///               source image. If not, sensible defaults will be used.
+    // /// @param srcIsPremul - set to true if the src data has premultiplied alpha. Otherwise, it will
+    // ///               be assumed to be Unpremultiplied. Note: if this is true and info specifies
+    // ///               Unpremul, Skia will not convert the src pixels first.
+    // ///
+    // #[wasm_bindgen(structural, method)]
+    // pub(crate) fn makeImageFromTextureSource(
+    //     this: &CanvasKitSurface,
+    //     src: JsValue, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
+    //     info: Option<js_sys::Object>, // ImageInfo | PartialImageInfo
+    //     srcIsPremul: Option<bool>,
+    // ) -> CanvasKitImage;
 
     // ///
     // /// Returns current contents of the surface as an Image. This image will be optimized to be

--- a/namui/src/namui/skia/web/surface.rs
+++ b/namui/src/namui/skia/web/surface.rs
@@ -1,5 +1,4 @@
 use super::*;
-use wasm_bindgen::JsValue;
 
 pub(crate) struct Surface {
     canvas_kit_surface: CanvasKitSurface,
@@ -20,19 +19,6 @@ impl Surface {
     }
     pub fn canvas(&self) -> &Canvas {
         &self.canvas
-    }
-    pub fn make_image_from_texture_source(
-        &self,
-        src: JsValue, // NOTE: It can also be an HTMLVideoElement or an HTMLCanvasElement.
-        info: Option<PartialImageInfo>,
-        src_is_premul: Option<bool>,
-    ) -> Image {
-        let info = info.map(|info| info.into_js_object());
-        let image = self
-            .canvas_kit_surface
-            .makeImageFromTextureSource(src, info, src_is_premul);
-        let image = image.makeCopyWithDefaultMipmaps();
-        Image::new(image)
     }
 }
 

--- a/namui/src/namui/system/image.rs
+++ b/namui/src/namui/system/image.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{file::picker::File, Image};
+use crate::{file::picker::File, namui::skia::canvas_kit, Image};
 use dashmap::DashMap;
 use std::{
     collections::HashSet,
@@ -107,7 +107,7 @@ pub async fn new_image_from_u8(data: &[u8]) -> Result<Arc<Image>, Box<dyn std::e
 
     let image_bitmap = create_image_bitmap(blob.into()).await;
 
-    let image = graphics::surface().make_image_from_texture_source(image_bitmap, None, None);
+    let image = canvas_kit().make_lazy_image_from_texture_source(image_bitmap, None, None);
 
     Ok(Arc::new(image))
 }


### PR DESCRIPTION
When namui detect screen resize, it re-create canvaskit surface again, I followed [this](https://groups.google.com/g/skia-discuss/c/3c10MvyaSug).

We used `surface.makeImageFromTextureSource`, it makes the image that only can be used in that surface, so when we re-create surface by resize, all image created before doesn't work.

I changed the image creation logic to `canvaskit.MakeLazyImageFromTextureSource` which support reuse image for multiple surfaces.

Local resize tested