### PR TITLE
Open context menu on mouse right down

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/image_select_modal/render/mod.rs
@@ -75,10 +75,12 @@ impl ImageSelectModal {
                                     cut: &props.cut,
                                     project_id: self.project_id,
                                     selected_index: self.selected_screen_image_index,
-                                    on_click: move |index| {
-                                        namui::event::send(InternalEvent::SelectScreenImageIndex {
-                                            index,
-                                        })
+                                    on_click: move |index, event| {
+                                        if event.button == Some(MouseButton::Left) {
+                                            namui::event::send(
+                                                InternalEvent::SelectScreenImageIndex { index },
+                                            )
+                                        }
                                     },
                                 })
                             }),

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/screen_image_list/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/screen_image_list/mod.rs
@@ -3,7 +3,7 @@ use namui::prelude::*;
 use namui_prebuilt::*;
 use rpc::data::*;
 
-pub struct Props<'a, OnClick: Fn(usize) + 'static + Copy> {
+pub struct Props<'a, OnClick: Fn(usize, &MouseEvent) + 'static + Copy> {
     pub wh: Wh<Px>,
     pub cut: &'a Cut,
     pub project_id: Uuid,
@@ -11,7 +11,9 @@ pub struct Props<'a, OnClick: Fn(usize) + 'static + Copy> {
     pub selected_index: Option<usize>,
 }
 
-pub fn render<'a, OnClick: Fn(usize) + 'static + Copy>(props: Props<'a, OnClick>) -> RenderingTree {
+pub fn render<'a, OnClick: Fn(usize, &MouseEvent) + 'static + Copy>(
+    props: Props<'a, OnClick>,
+) -> RenderingTree {
     namui::render([
         simple_rect(props.wh, Color::WHITE, 1.px(), Color::BLACK),
         table::horizontal(props.cut.screen_images.iter().enumerate().map(
@@ -52,8 +54,8 @@ pub fn render<'a, OnClick: Fn(usize) + 'static + Copy>(props: Props<'a, OnClick>
                         },
                     ])
                     .attach_event(move |builder| {
-                        builder.on_mouse_down_in(move |_event| {
-                            (props.on_click)(index);
+                        builder.on_mouse_down_in(move |event| {
+                            (props.on_click)(index, event);
                         });
                     })
                 })

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/mod.rs
@@ -41,7 +41,7 @@ enum Event {
         cut_id: namui::Uuid,
         global_xy: Xy<Px>,
     },
-    ScreenEditorCellClicked {
+    ScreenEditorCellMouseLeftDown {
         index: usize,
         cut_id: Uuid,
     },

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/line_list/mod.rs
@@ -118,11 +118,20 @@ impl LoadedSequenceEditorPage {
                                         cut,
                                         project_id: self.project_id(),
                                         selected_index: None,
-                                        on_click: move |index| {
-                                            namui::event::send(Event::ScreenEditorCellClicked {
-                                                index,
-                                                cut_id,
-                                            });
+                                        on_click: move |index, event| {
+                                            if event.button == Some(MouseButton::Left) {
+                                                namui::event::send(
+                                                    Event::ScreenEditorCellMouseLeftDown {
+                                                        index,
+                                                        cut_id,
+                                                    },
+                                                );
+                                            } else if event.button == Some(MouseButton::Right) {
+                                                namui::event::send(Event::LineRightClicked {
+                                                    global_xy: event.global_xy,
+                                                    cut_id,
+                                                })
+                                            }
                                         },
                                     })
                                 },

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/update/mod.rs
@@ -30,7 +30,7 @@ impl LoadedSequenceEditorPage {
                         }
                     }
                 }
-                &Event::ScreenEditorCellClicked { index, cut_id } => {
+                &Event::ScreenEditorCellMouseLeftDown { index, cut_id } => {
                     self.image_select_modal = Some(image_select_modal::ImageSelectModal::new(
                         self.project_id(),
                         cut_id,


### PR DESCRIPTION
Previously, when I click right-side image list, it just open the image select modal. I wanted open context menu to copy-paste images.

I changed it to open context menu on right click the image list.
![image](https://user-images.githubusercontent.com/3580430/202846198-bc486316-0af7-4ff9-b3df-4a8af9542269.png)
