### PR TITLE
Disable pixel flooring for fix character shaking

### DIFF
--- a/luda-adventure/src/app/game/render/translate_to_camera_screen.rs
+++ b/luda-adventure/src/app/game/render/translate_to_camera_screen.rs
@@ -8,8 +8,8 @@ impl Game {
         rendering_tree: RenderingTree,
     ) -> namui::RenderingTree {
         translate(
-            -(rendering_context.px_per_tile * rendering_context.screen_rect.x()).floor(),
-            -(rendering_context.px_per_tile * rendering_context.screen_rect.y()).floor(),
+            -(rendering_context.px_per_tile * rendering_context.screen_rect.x()),
+            -(rendering_context.px_per_tile * rendering_context.screen_rect.y()),
             rendering_tree,
         )
     }

--- a/luda-adventure/src/component/renderer/sprite.rs
+++ b/luda-adventure/src/component/renderer/sprite.rs
@@ -10,7 +10,7 @@ pub struct Sprite {
 impl Sprite {
     pub fn render(&self, rendering_context: &RenderingContext) -> RenderingTree {
         image(ImageParam {
-            rect: px_rect(self.visual_rect, rendering_context),
+            rect: image_rect(self.visual_rect, rendering_context),
             source: ImageSource::Url(self.image_url.clone()),
             style: ImageStyle {
                 fit: ImageFit::Fill,
@@ -24,7 +24,7 @@ impl Sprite {
     }
 }
 
-fn px_rect(tile_rect: Rect<Tile>, rendering_context: &RenderingContext) -> Rect<Px> {
+fn image_rect(tile_rect: Rect<Tile>, rendering_context: &RenderingContext) -> Rect<Px> {
     Rect::Xywh {
         x: rendering_context.px_per_tile * tile_rect.x(),
         y: rendering_context.px_per_tile * tile_rect.y(),

--- a/luda-adventure/src/component/renderer/sprite.rs
+++ b/luda-adventure/src/component/renderer/sprite.rs
@@ -26,9 +26,9 @@ impl Sprite {
 
 fn px_rect(tile_rect: Rect<Tile>, rendering_context: &RenderingContext) -> Rect<Px> {
     Rect::Xywh {
-        x: (rendering_context.px_per_tile * tile_rect.x()).floor(),
-        y: (rendering_context.px_per_tile * tile_rect.y()).floor(),
-        width: (rendering_context.px_per_tile * tile_rect.width()).floor(),
-        height: (rendering_context.px_per_tile * tile_rect.height()).floor(),
+        x: rendering_context.px_per_tile * tile_rect.x(),
+        y: rendering_context.px_per_tile * tile_rect.y(),
+        width: rendering_context.px_per_tile * tile_rect.width(),
+        height: rendering_context.px_per_tile * tile_rect.height(),
     }
 }


### PR DESCRIPTION
The previous issue does not appear when using sprites.
*previous issue: Unintended lines between tile.
![Animation](https://user-images.githubusercontent.com/38313680/203364565-7bc71a9f-dac9-4f8d-b406-304efacdf0ac.gif)
