### PR TITLE
Support on_text_updated for text_input event handler

### DIFF
--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -30,16 +30,24 @@ pub struct Props {
 #[derive(Clone, Default)]
 pub struct EventHandler {
     pub(crate) on_key_down: Option<Arc<dyn Fn(KeyDownEvent) + 'static>>,
+    pub(crate) on_text_updated: Option<Arc<dyn Fn(&str) + 'static>>,
 }
 unsafe impl Send for EventHandler {}
 unsafe impl Sync for EventHandler {}
 
 impl EventHandler {
     pub fn new() -> Self {
-        Self { on_key_down: None }
+        Self {
+            on_key_down: None,
+            on_text_updated: None,
+        }
     }
     pub fn on_key_down(mut self, on_key_down: impl Fn(KeyDownEvent) + 'static) -> Self {
         self.on_key_down = Some(Arc::new(on_key_down));
+        self
+    }
+    pub fn on_text_updated(mut self, on_text_updated: impl Fn(&str) + 'static) -> Self {
+        self.on_text_updated = Some(Arc::new(on_text_updated));
         self
     }
 }

--- a/namui/src/namui/system/text_input/mod.rs
+++ b/namui/src/namui/system/text_input/mod.rs
@@ -169,6 +169,19 @@ fn on_text_element_input(input_element: &HtmlTextAreaElement) {
     }
     let last_focused_text_input = last_focused_text_input.as_ref().unwrap();
 
+    last_focused_text_input
+        .props
+        .event_handler
+        .as_ref()
+        .map(|event_handler| {
+            event_handler
+                .on_text_updated
+                .as_ref()
+                .map(|on_text_updated| {
+                    on_text_updated(&text);
+                })
+        });
+
     crate::event::send(text_input::Event::TextUpdated {
         id: last_focused_text_input.id.clone(),
         text: text.to_string(),


### PR DESCRIPTION
`text_input::EventHandler` from now on supports `on_text_updated`.

I will use this for sheet(#456) with below code,
https://github.com/NamseEnt/namseent/blob/58a6fc65f1fef0efecc262f7b5cfb80c96bca3f9/namui-prebuilt/src/sheet/cell/text_cell.rs#L76-L80