### PR TITLE
Fix post-test works

### DIFF
--- a/.github/workflows/namui-test-host-linux.yml
+++ b/.github/workflows/namui-test-host-linux.yml
@@ -223,11 +223,11 @@ jobs:
       - test-namui-animation-editor
       - test-luda-adventure
     steps:
-      - run: echo ${{join(needs.*.result, ',')}}
-      - run: ANY_TEST_FAILED=${{!contains(join(needs.*.result, ','), 'failure')}}
-      - run: echo $ANY_TEST_FAILED
+      - run: echo ${{ join(needs.*.result, ',') }}
+      - run: echo "any_test_failed=${{ contains(join(needs.*.result, ','), 'failure') }}" >> $GITHUB_ENV
+      - run: echo ${{ env.any_test_failed }}
       - run: |
-          if [[ $ANY_TEST_FAILED == "true" ]]; then
+          if [[ ${{ env.any_test_failed }} == "true" ]]; then
               echo "::error::There are failed job"
               exit 1
           else

--- a/.github/workflows/namui-test-host-linux.yml
+++ b/.github/workflows/namui-test-host-linux.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/init-test-job
       - run: cargo test --manifest-path luda-editor/rpc/Cargo.toml
-      - run: cargo test --manifest-path luda-editor/server/Cargo.toml      
+      - run: cargo test --manifest-path luda-editor/server/Cargo.toml
       - uses: ./.github/actions/namui-test
         with:
           target: wasm-unknown-web
@@ -223,6 +223,7 @@ jobs:
       - test-namui-animation-editor
       - test-luda-adventure
     steps:
+      - run: echo ${{join(needs.*.result, ',')}}
       - run: ANY_TEST_FAILED=${{!contains(join(needs.*.result, ','), 'failure')}}
       - run: echo $ANY_TEST_FAILED
       - run: |


### PR DESCRIPTION
post-test never worked since it merged...!!!!!!!!!!!!!!!!!!!!

it's my fault, I didn't test it...

What was the problem
1. bash's `VARIABLE=VALUE` doesn't share that variable between other steps.
2. I didn't check true/false check

success case
![image](https://user-images.githubusercontent.com/3580430/203754870-6fe274b2-e61d-495a-9900-fab94be61791.png)


failure case
![image](https://user-images.githubusercontent.com/3580430/203754801-cf9fd53e-a47a-48eb-b16e-260d3e76b320.png)

Anycase, post-test runs. it should be failed on failure case.


How did I fix it
1. [Used github action environment](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable)
2. Test true/false cases

success case
![image](https://user-images.githubusercontent.com/3580430/203800646-9cea286a-9dd9-4b36-b456-923531b48ae2.png)


failure case
![image](https://user-images.githubusercontent.com/3580430/203754681-05c9cafe-8ed7-4cb5-8bcd-7a5bc9fbb28d.png)

Ok, it finally fails.
