### PR TITLE
Return None if there is no hashmap while filtering

### DIFF
--- a/luda-adventure/ecs-macro/src/lib.rs
+++ b/luda-adventure/ecs-macro/src/lib.rs
@@ -45,8 +45,7 @@ pub fn component(_attribute_input: TokenStream, input: TokenStream) -> TokenStre
                 unsafe {
                     #set_name
                         .get_or_init(|| rustc_hash::FxHashMap::default())
-                        .get(&app_id)
-                        .unwrap()
+                        .get(&app_id)?
                         .get(&entity.id())
                 }
             }
@@ -56,8 +55,7 @@ pub fn component(_attribute_input: TokenStream, input: TokenStream) -> TokenStre
                 unsafe {
                     #set_name
                         .get_or_init(|| rustc_hash::FxHashMap::default())
-                        .get(&app_id)
-                        .unwrap()
+                        .get(&app_id)?
                         .get(&entity.id())
                 }
             }


### PR DESCRIPTION
# What happened
Sometimes it goes panic. 
This can occur when querying components that are not registered at least one.
```rust
#set_name
    .get_or_init(|| rustc_hash::FxHashMap::default())
    .get(&app_id)
    .unwrap()
    .get(&entity.id())
```
