### PR TITLE
Handle utf16 multiple length selection problem with font fallback

### DIFF
--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -34,19 +34,19 @@ impl TextInputExample {
             ],
             text_3x3: [
                 [
-                    "Left Top\nHello you!\nmamama mimimi mo".to_string(),
-                    "Center Top\nHello you!\nmamama mimimi mo".to_string(),
+                    "Left Top\nHel🔗lo you!\nmamama mimimi mo".to_string(),
+                    "Center Top\nHello yo🔗u!\nmamama mimimi mo".to_string(),
                     "Right Top\nHello you!\nmamama mimimi mo".to_string(),
                 ],
                 [
                     "Left Center\nHello you!\nmamama mimimi mo".to_string(),
-                    "Center Center\nHello you!\nmamama mimimi mo".to_string(),
-                    "Right Center\nHello you!\nmamama mimimi mo".to_string(),
+                    "Center Center\nHello you!🔗\nmamama mimimi mo".to_string(),
+                    "Right Center\nHe🔗llo you!\nmamama mimimi mo".to_string(),
                 ],
                 [
-                    "Left Bottom\nHello you!\nmamama mimimi mo".to_string(),
-                    "Center Bottom\nHello you!\nmamama mimimi mo".to_string(),
-                    "Right Bottom\nHello you!\nmamama mimimi mo".to_string(),
+                    "Left Bottom\nHello you!\nmama🔗ma mimimi mo".to_string(),
+                    "Center Bottom\n🔗Hello you!\nmamama mimimi mo".to_string(),
+                    "Right Bottom\nHell🔗o you!\nmamama mimimi mo".to_string(),
                 ],
             ],
             left_top_value: None,
@@ -106,30 +106,6 @@ impl Entity for TextInputExample {
                 }));
             }
         }
-
-        let left_top_value_text = namui::text(TextParam {
-            x: px(10.0),
-            y: px(10.0),
-            align: TextAlign::Left,
-            baseline: TextBaseline::Top,
-            text: self
-                .left_top_value
-                .map(|v| v.to_string())
-                .unwrap_or("is't not f32".to_string()),
-            font_type: namui::FontType {
-                font_weight: namui::FontWeight::REGULAR,
-                language: namui::Language::Ko,
-                serif: false,
-                size: int_px(20),
-            },
-            style: namui::TextStyle {
-                color: namui::Color::BLACK,
-                ..Default::default()
-            },
-            max_width: Some(100.px()),
-        });
-
-        tree.push(left_top_value_text);
 
         render(tree)
     }

--- a/namui/src/namui/common/text/glyph_group.rs
+++ b/namui/src/namui/common/text/glyph_group.rs
@@ -1,3 +1,4 @@
+use super::*;
 use crate::*;
 use once_cell::sync::OnceCell;
 use std::sync::{Arc, Mutex};
@@ -5,95 +6,72 @@ use std::sync::{Arc, Mutex};
 #[derive(Debug, Clone)]
 pub struct GlyphGroup {
     pub glyph_ids: Vec<u16>,
-    pub end_index: usize,
+    pub end_char_index: usize,
     pub width: Px,
+    pub widths: Vec<Px>,
     pub font: Arc<Font>,
 }
 
 pub(crate) fn get_glyph_groups(
     text: &str,
     fonts: &Vec<Arc<Font>>,
-    paint: &Arc<Paint>,
+    paint: Option<&Paint>,
 ) -> Vec<GlyphGroup> {
     let cache_key = CacheKey {
         text: text.to_string(),
         fonts: fonts.to_vec(),
-        paint: paint.clone(),
+        paint_id: paint.map(|p| p.id),
     };
     if let Some(cached) = get_glyph_groups_cache(&cache_key) {
         return cached;
     }
 
+    let measures = measure_glyphs(text, fonts, paint);
+
     let mut groups: Vec<GlyphGroup> = vec![];
-    let mut non_calculated_char_and_indexes: Vec<(char, usize)> = text
-        .chars()
-        .enumerate()
-        .map(|(index, char)| (char, index))
-        .collect();
-    let mut fonts = fonts.iter().peekable();
 
-    while !non_calculated_char_and_indexes.is_empty() && fonts.peek().is_some() {
-        let font = fonts.next().unwrap();
-
-        let text = non_calculated_char_and_indexes
-            .iter()
-            .map(|(char, _)| char)
-            .collect::<String>();
-
-        let glyph_ids = font.get_glyph_ids(&text);
-
-        let mut available_glyph_id_and_indexes = vec![];
-        for (index, glyph_id) in glyph_ids.iter().enumerate() {
-            if *glyph_id != 0 {
-                available_glyph_id_and_indexes.push((*glyph_id, index));
-                non_calculated_char_and_indexes.retain(|(_, index2)| index != *index2);
+    let mut is_continue_to_last = false;
+    for (char_index, measure) in measures.into_iter().enumerate() {
+        match measure {
+            GlyphMeasure::Failed => {
+                is_continue_to_last = false;
             }
-        }
-
-        if available_glyph_id_and_indexes.is_empty() {
-            continue;
-        }
-
-        let available_glyph_id_and_index_and_width: Vec<(u16, usize, Px)> = {
-            let available_glyph_ids: Vec<_> = available_glyph_id_and_indexes
-                .iter()
-                .map(|(glyph_id, _)| *glyph_id)
-                .collect();
-
-            let widths = font.get_glyph_widths(available_glyph_ids.into(), Option::Some(paint));
-
-            widths
-                .into_iter()
-                .zip(available_glyph_id_and_indexes.into_iter())
-                .map(|(width, (glyph_id, index))| (glyph_id, index, width))
-                .collect()
-        };
-
-        for (glyph_id, index, width) in available_glyph_id_and_index_and_width {
-            if let Some(last_group) = groups.last_mut() {
-                if last_group.end_index + 1 == index {
-                    last_group.glyph_ids.push(glyph_id);
-                    last_group.width += width;
-                    last_group.end_index = index;
-                    continue;
-                }
-            }
-            groups.push(GlyphGroup {
-                glyph_ids: vec![glyph_id],
-                end_index: index,
+            GlyphMeasure::Success {
+                glyph_id,
                 width,
-                font: font.clone(),
-            });
+                font,
+            } => {
+                if is_continue_to_last {
+                    if let Some(last_group) = groups.last_mut() {
+                        if last_group.end_char_index + 1 == char_index && last_group.font == font {
+                            last_group.glyph_ids.push(glyph_id);
+                            last_group.width += width;
+                            last_group.end_char_index = char_index;
+                            last_group.widths.push(width);
+                            continue;
+                        }
+                    }
+                }
+
+                groups.push(GlyphGroup {
+                    glyph_ids: vec![glyph_id],
+                    end_char_index: char_index,
+                    width,
+                    font: font.clone(),
+                    widths: vec![width],
+                });
+                is_continue_to_last = true;
+            }
         }
     }
-    groups.sort_by(|a, b| a.end_index.cmp(&b.end_index));
 
     put_glyph_groups_cache(cache_key, groups.clone());
+
     groups
 }
 impl GlyphGroup {
     pub(crate) fn start_index(&self) -> usize {
-        self.end_index + 1 - self.glyph_ids.len()
+        self.end_char_index + 1 - self.glyph_ids.len()
     }
 }
 
@@ -103,20 +81,20 @@ static GLYPH_GROUPS_CACHE: OnceCell<Mutex<lru::LruCache<CacheKey, Vec<GlyphGroup
 struct CacheKey {
     text: String,
     fonts: Vec<Arc<Font>>,
-    paint: Arc<Paint>,
+    paint_id: Option<Uuid>,
 }
 
 impl std::hash::Hash for CacheKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.text.hash(state);
         self.fonts.hash(state);
-        self.paint.hash(state);
+        self.paint_id.hash(state);
     }
 }
 
 impl PartialEq for CacheKey {
     fn eq(&self, other: &Self) -> bool {
-        self.text == other.text && self.fonts == other.fonts && self.paint == other.paint
+        self.text == other.text && self.fonts == other.fonts && self.paint_id == other.paint_id
     }
 }
 

--- a/namui/src/namui/common/text/line_texts.rs
+++ b/namui/src/namui/common/text/line_texts.rs
@@ -25,13 +25,13 @@ pub(crate) struct Line {
 pub(crate) struct LineTexts<'a> {
     vec: Vec<Line>,
     pub fonts: &'a Vec<Arc<Font>>,
-    pub paint: &'a Arc<Paint>,
+    pub paint: Option<&'a Paint>,
 }
 impl<'a> LineTexts<'a> {
     pub fn new(
         text: &str,
         fonts: &'a Vec<Arc<Font>>,
-        paint: &'a Arc<Paint>,
+        paint: Option<&'a Paint>,
         max_width: Option<Px>,
     ) -> LineTexts<'a> {
         let vec = if let Some(max_width) = max_width {
@@ -155,7 +155,7 @@ impl<'a> Fragment for NamuiWord<'a> {
 }
 
 impl<'a> NamuiWord<'a> {
-    fn from_word(word: core::Word<'a>, fonts: &Vec<Arc<Font>>, paint: &Arc<Paint>) -> Self {
+    fn from_word(word: core::Word<'a>, fonts: &Vec<Arc<Font>>, paint: Option<&Paint>) -> Self {
         Self {
             word: word.word,
             width: get_text_width_with_fonts(fonts, word.word, paint),
@@ -170,7 +170,7 @@ impl<'a> NamuiWord<'a> {
         self,
         max_width: Px,
         fonts: &Vec<Arc<Font>>,
-        paint: &Arc<Paint>,
+        paint: Option<&Paint>,
     ) -> Vec<NamuiWord<'a>> {
         if self.width <= max_width {
             return vec![self];

--- a/namui/src/namui/common/text/measure_glyphs.rs
+++ b/namui/src/namui/common/text/measure_glyphs.rs
@@ -1,0 +1,140 @@
+use crate::*;
+use once_cell::sync::OnceCell;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug)]
+pub enum GlyphMeasure {
+    Failed,
+    Success {
+        glyph_id: u16,
+        width: Px,
+        font: Arc<Font>,
+    },
+}
+
+pub(crate) fn measure_glyphs(
+    text: &str,
+    fonts: &Vec<Arc<Font>>,
+    paint: Option<&Paint>,
+) -> Vec<GlyphMeasure> {
+    let cache_key = CacheKey {
+        text: text.to_string(),
+        fonts: fonts.to_vec(),
+        paint_id: paint.map(|p| p.id),
+    };
+    if let Some(cached) = get_glyph_width_measures_cache(&cache_key) {
+        return cached;
+    }
+
+    let mut not_calculated_chars: Vec<_> = text.chars().enumerate().collect();
+    let mut measures: Vec<GlyphMeasure> = vec![GlyphMeasure::Failed; not_calculated_chars.len()];
+
+    for font in fonts.iter() {
+        if not_calculated_chars.is_empty() {
+            break;
+        }
+
+        let not_calculated_text = not_calculated_chars
+            .iter()
+            .map(|(_, char)| char)
+            .collect::<String>();
+
+        let glyph_ids = font.get_glyph_ids(&not_calculated_text);
+
+        if not_calculated_chars.len() != glyph_ids.len() {
+            panic!(
+                "non_calculated_chars.len(){} != glyph_ids.len(){}",
+                not_calculated_chars.len(),
+                glyph_ids.len()
+            );
+        }
+
+        let non_zero_glyph_ids_with_char_index = glyph_ids
+            .iter()
+            .enumerate()
+            .filter(|(_, glyph_id)| **glyph_id != 0)
+            .map(|(index, glyph_id)| (not_calculated_chars[index].0, *glyph_id))
+            .collect::<Vec<_>>();
+
+        if non_zero_glyph_ids_with_char_index.is_empty() {
+            continue;
+        }
+
+        let non_zero_glyph_char_indexes = non_zero_glyph_ids_with_char_index
+            .iter()
+            .map(|(index, _)| *index)
+            .collect::<Vec<_>>();
+
+        not_calculated_chars
+            .retain(|(char_index, _)| !non_zero_glyph_char_indexes.contains(char_index));
+
+        let glyph_id_char_index_and_width_vec: Vec<(u16, usize, Px)> = {
+            let glyph_ids: Vec<u16> = non_zero_glyph_ids_with_char_index
+                .iter()
+                .map(|(_, glyph_id)| *glyph_id)
+                .collect();
+
+            let widths = font.get_glyph_widths(glyph_ids.into(), paint);
+
+            widths
+                .into_iter()
+                .zip(non_zero_glyph_ids_with_char_index.into_iter())
+                .map(|(width, (char_index, glyph_id))| (glyph_id, char_index, width))
+                .collect()
+        };
+
+        for (glyph_id, char_index, width) in glyph_id_char_index_and_width_vec {
+            measures[char_index] = GlyphMeasure::Success {
+                width,
+                font: font.clone(),
+                glyph_id,
+            };
+        }
+    }
+
+    put_glyph_width_measures_cache(cache_key, measures.clone());
+
+    measures
+}
+
+static GLYPH_WIDTH_MEASURES_CACHE: OnceCell<Mutex<lru::LruCache<CacheKey, Vec<GlyphMeasure>>>> =
+    OnceCell::new();
+
+struct CacheKey {
+    text: String,
+    fonts: Vec<Arc<Font>>,
+    paint_id: Option<Uuid>,
+}
+
+impl std::hash::Hash for CacheKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.text.hash(state);
+        self.fonts.hash(state);
+        self.paint_id.hash(state);
+    }
+}
+
+impl PartialEq for CacheKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text && self.fonts == other.fonts && self.paint_id == other.paint_id
+    }
+}
+
+impl Eq for CacheKey {}
+
+fn get_glyph_width_measures_cache(key: &CacheKey) -> Option<Vec<GlyphMeasure>> {
+    GLYPH_WIDTH_MEASURES_CACHE
+        .get_or_init(|| Mutex::new(lru::LruCache::new(1024)))
+        .lock()
+        .unwrap()
+        .get(key)
+        .cloned()
+}
+
+fn put_glyph_width_measures_cache(key: CacheKey, value: Vec<GlyphMeasure>) {
+    GLYPH_WIDTH_MEASURES_CACHE
+        .get_or_init(|| Mutex::new(lru::LruCache::new(1024)))
+        .lock()
+        .unwrap()
+        .put(key, value);
+}

--- a/namui/src/namui/common/text/mod.rs
+++ b/namui/src/namui/common/text/mod.rs
@@ -1,11 +1,15 @@
 mod glyph_group;
 mod line_texts;
+mod measure_glyphs;
 mod multiline_caret;
+mod text_width;
 
 use crate::{namui::skia::FontMetrics, *};
 pub(crate) use glyph_group::*;
 pub(crate) use line_texts::*;
-use std::{collections::VecDeque, sync::Arc};
+pub(crate) use measure_glyphs::*;
+use std::sync::Arc;
+pub(crate) use text_width::*;
 
 pub fn get_left_in_align(x: Px, align: TextAlign, width: Px) -> Px {
     match align {
@@ -21,11 +25,6 @@ pub fn get_bottom_of_baseline(baseline: TextBaseline, font_metrics: FontMetrics)
         TextBaseline::Bottom => -font_metrics.descent,
     }
 }
-pub fn get_fallback_fonts(font_size: IntPx) -> VecDeque<Arc<Font>> {
-    crate::typeface::get_fallback_font_typefaces()
-        .map(|typeface| crate::font::get_font_of_typeface(typeface.clone(), font_size))
-        .collect()
-}
 pub fn get_multiline_y_baseline_offset(
     baseline: TextBaseline,
     line_height: Px,
@@ -40,7 +39,7 @@ pub fn get_multiline_y_baseline_offset(
 pub(crate) fn get_text_width_with_fonts(
     fonts: &Vec<Arc<Font>>,
     text: &str,
-    paint: &Arc<Paint>,
+    paint: Option<&Paint>,
 ) -> Px {
     let groups = get_glyph_groups(text, fonts, paint);
     groups.iter().map(|group| group.width).sum()

--- a/namui/src/namui/common/text/multiline_caret.rs
+++ b/namui/src/namui/common/text/multiline_caret.rs
@@ -1,5 +1,4 @@
 use crate::{
-    namui::skia::GlyphIds,
     system::text_input::{ArrowUpDown, KeyInInterest},
     text::*,
     *,
@@ -124,19 +123,14 @@ impl MultilineCaret<'_> {
 
         let mut x = 0.px();
         for glyph_group in glyph_groups {
-            if self.caret_index_in_line <= glyph_group.end_index {
+            if self.caret_index_in_line <= glyph_group.end_char_index {
                 let start_index = glyph_group.start_index();
 
-                let glyph_ids_left: GlyphIds = glyph_group
-                    .glyph_ids
+                let glyph_widths_left = glyph_group
+                    .widths
                     .into_iter()
-                    .take(self.caret_index_in_line - start_index)
-                    .collect();
-                return x + glyph_group
-                    .font
-                    .get_glyph_widths(glyph_ids_left, Some(self.line_texts.paint))
-                    .iter()
-                    .sum::<Px>();
+                    .take(self.caret_index_in_line - start_index);
+                return x + glyph_widths_left.sum::<Px>();
             } else {
                 x += glyph_group.width;
             }
@@ -159,7 +153,7 @@ impl MultilineCaret<'_> {
             let glyph_ids = glyph_group.glyph_ids.into_boxed_slice();
             let glyph_widths = glyph_group
                 .font
-                .get_glyph_widths(glyph_ids, Some(self.line_texts.paint));
+                .get_glyph_widths(glyph_ids, self.line_texts.paint);
 
             for glyph_width in glyph_widths.into_iter() {
                 let last = caret_positions.last().unwrap().clone();

--- a/namui/src/namui/common/text/text_width.rs
+++ b/namui/src/namui/common/text/text_width.rs
@@ -1,0 +1,17 @@
+use super::*;
+use crate::*;
+use std::sync::Arc;
+
+pub(crate) fn get_text_widths(
+    text: &str,
+    fonts: &Vec<Arc<Font>>,
+    paint: Option<&Paint>,
+) -> Vec<Px> {
+    measure_glyphs(text, fonts, paint)
+        .into_iter()
+        .filter_map(|measure| match measure {
+            GlyphMeasure::Failed => None,
+            GlyphMeasure::Success { width, .. } => Some(width),
+        })
+        .collect()
+}

--- a/namui/src/namui/draw/text.rs
+++ b/namui/src/namui/draw/text.rs
@@ -34,13 +34,11 @@ impl TextDrawCommand {
             return;
         }
 
-        let fonts = std::iter::once(self.font.clone())
-            .chain(std::iter::once_with(|| get_fallback_fonts(self.font.size)).flatten())
-            .collect::<Vec<_>>();
+        let fonts = crate::font::with_fallbacks(self.font.clone());
 
         let paint = self.paint_builder.build();
 
-        let line_texts = LineTexts::new(&self.text, &fonts, &paint, self.max_width);
+        let line_texts = LineTexts::new(&self.text, &fonts, Some(&paint), self.max_width);
 
         let line_height = self.line_height_px();
 
@@ -59,7 +57,7 @@ impl TextDrawCommand {
                 )
             })
             .for_each(|(y, line_text)| {
-                let glyph_groups = get_glyph_groups(&line_text, &fonts, &paint);
+                let glyph_groups = get_glyph_groups(&line_text, &fonts, Some(&paint));
 
                 let total_width = glyph_groups.iter().map(|group| group.width).sum();
 
@@ -70,8 +68,9 @@ impl TextDrawCommand {
                 for GlyphGroup {
                     glyph_ids,
                     width,
-                    end_index: _,
+                    end_char_index: _,
                     font,
+                    widths: _,
                 } in glyph_groups
                 {
                     let bottom = y + bottom_of_fonts
@@ -99,13 +98,11 @@ impl TextDrawCommand {
             return None;
         }
 
-        let fonts = std::iter::once(self.font.clone())
-            .chain(std::iter::once_with(|| get_fallback_fonts(self.font.size)).flatten())
-            .collect::<Vec<_>>();
+        let fonts = crate::font::with_fallbacks(self.font.clone());
 
         let paint = self.paint_builder.build();
 
-        let line_texts = LineTexts::new(&self.text, &fonts, &paint, self.max_width);
+        let line_texts = LineTexts::new(&self.text, &fonts, Some(&paint), self.max_width);
 
         let line_height = self.line_height_px();
 

--- a/namui/src/namui/skia/base/paint_builder.rs
+++ b/namui/src/namui/skia/base/paint_builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     namui::skia::{Shader, StrokeJoin},
-    BlendMode, Color, ColorFilter, Paint, PaintStyle, Px, StrokeCap,
+    uuid_from_hash, BlendMode, Color, ColorFilter, Paint, PaintStyle, Px, StrokeCap,
 };
 use once_cell::sync::OnceCell;
 use ordered_float::OrderedFloat;
@@ -8,6 +8,7 @@ use std::{
     hash::Hash,
     sync::{Arc, Mutex},
 };
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct PaintBuilder {
@@ -146,17 +147,20 @@ impl PaintBuilder {
         }
     }
 
-    fn generate_id(&self) -> Box<[u8]> {
-        bincode::serialize(&(
-            &self.color,
-            &self.paint_style,
-            &self.anti_alias,
-            &self.stroke_width,
-            &self.stroke_cap,
-            &self.color_filter,
-        ))
-        .unwrap()
-        .into()
+    fn generate_id(&self) -> Uuid {
+        uuid_from_hash(self.as_paint_builder_without_shader())
+    }
+
+    fn as_paint_builder_without_shader(&self) -> PaintBuilderWithoutShader {
+        PaintBuilderWithoutShader {
+            color: self.color,
+            paint_style: self.paint_style,
+            anti_alias: self.anti_alias,
+            stroke_width: self.stroke_width,
+            stroke_cap: self.stroke_cap,
+            stroke_join: self.stroke_join,
+            color_filter: self.color_filter,
+        }
     }
 }
 

--- a/namui/src/namui/skia/web/font.rs
+++ b/namui/src/namui/skia/web/font.rs
@@ -60,6 +60,9 @@ impl Font {
         }
     }
     pub(crate) fn get_glyph_widths(&self, glyph_ids: GlyphIds, paint: Option<&Paint>) -> Vec<Px> {
+        if glyph_ids.len() == 0 {
+            return vec![];
+        }
         let mut caches = self.glyph_widths_caches.lock().unwrap();
 
         let key = (glyph_ids.clone(), paint.cloned());
@@ -122,7 +125,10 @@ impl Drop for Font {
 
 impl std::fmt::Debug for Font {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "")
+        f.debug_struct("Font")
+            .field("id", &self.id)
+            .field("size", &self.size)
+            .finish()
     }
 }
 

--- a/namui/src/namui/skia/web/paint.rs
+++ b/namui/src/namui/skia/web/paint.rs
@@ -6,13 +6,13 @@ use std::sync::{Arc, Mutex};
 unsafe impl Sync for CanvasKitPaint {}
 unsafe impl Send for CanvasKitPaint {}
 pub(crate) struct Paint {
-    id: Box<[u8]>,
+    pub id: Uuid,
     last_set_shader: Arc<Mutex<Option<Arc<Shader>>>>,
     pub(crate) canvas_kit_paint: CanvasKitPaint,
 }
 impl Paint {
     pub fn new(
-        id: Box<[u8]>,
+        id: Uuid,
         color: Option<Color>,
         style: Option<&PaintStyle>,
         anti_alias: Option<bool>,

--- a/namui/src/namui/system/text_input/key_down.rs
+++ b/namui/src/namui/system/text_input/key_down.rs
@@ -73,7 +73,7 @@ fn handle_selection_change(
     let selection =
         get_selection_on_keyboard_down(&input_element, &text_input.props, key_in_interest);
 
-    let Some(utf16_selection) = selection.as_utf8_selection(input_element.value()) else {
+    let Some(utf16_selection) = selection.as_utf16(input_element.value()) else {
         return;
     };
 

--- a/namui/src/namui/system/text_input/key_down.rs
+++ b/namui/src/namui/system/text_input/key_down.rs
@@ -134,9 +134,7 @@ fn get_caret_index_after_apply_key_movement(
     let multiline_caret = line_texts.get_multiline_caret(selection.end);
 
     let caret_after_move = multiline_caret.get_caret_on_key(key);
-    crate::log!("caret_after_move: {:?}", caret_after_move);
 
     let next_selection_end = caret_after_move.to_selection_index();
-    crate::log!("next_selection_end: {:?}", next_selection_end);
     next_selection_end
 }

--- a/namui/src/namui/system/text_input/mod.rs
+++ b/namui/src/namui/system/text_input/mod.rs
@@ -251,15 +251,6 @@ fn get_input_element_selection(input_element: &HtmlTextAreaElement) -> Selection
         }
     };
 
-    crate::log!("utf16_code_unit_selection: {:?}", utf16_code_unit_selection);
-    crate::log!(
-        "result: {:?}",
-        Selection::from_utf16(
-            utf16_code_unit_selection.clone(),
-            input_element.value().as_str()
-        )
-    );
-
     Selection::from_utf16(utf16_code_unit_selection, input_element.value().as_str())
 }
 

--- a/namui/src/namui/system/text_input/mouse_event.rs
+++ b/namui/src/namui/system/text_input/mouse_event.rs
@@ -104,7 +104,7 @@ fn update_focus_with_mouse_movement(
 
     input_element.set_value(&custom_data.props.text);
 
-    let utf16_selection = selection.as_utf8_selection(input_element.value());
+    let utf16_selection = selection.as_utf16(input_element.value());
 
     input_element
         .set_selection_range_with_direction(

--- a/namui/src/namui/system/text_input/selection.rs
+++ b/namui/src/namui/system/text_input/selection.rs
@@ -1,0 +1,136 @@
+use std::ops::Range;
+
+/// Unlike JS, we count the number of utf-8 characters.
+/// JS counts the number of utf-16 code units.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Selection {
+    None,
+    Range(Range<usize>),
+}
+
+impl Selection {
+    pub(crate) fn as_utf8_selection(&self, text: impl AsRef<str>) -> Option<Range<usize>> {
+        let Selection::Range(utf8_range) = self else {
+            return None;
+        };
+
+        let mut range = utf8_range.clone();
+
+        for (index, char) in text.as_ref().chars().enumerate() {
+            if range.start <= index && range.end <= index {
+                break;
+            }
+            let char_len_utf16 = char.len_utf16();
+            if char_len_utf16 <= 1 {
+                continue;
+            }
+            if range.start > index {
+                range.start += char_len_utf16 - 1;
+            }
+            if range.end > index {
+                range.end += char_len_utf16 - 1;
+            }
+        }
+
+        Some(range)
+    }
+
+    pub(crate) fn from_utf16(utf16_selection: Option<Range<usize>>, text: impl AsRef<str>) -> Self {
+        let Some(utf8_selection) = utf16_selection else {
+            return Selection::None;
+        };
+
+        let mut range = utf8_selection;
+
+        for (index, char) in text.as_ref().chars().enumerate() {
+            if range.start <= index && range.end <= index {
+                break;
+            }
+            let char_len_utf16 = char.len_utf16();
+            if char_len_utf16 <= 1 {
+                continue;
+            }
+            if range.start > index {
+                range.start -= char_len_utf16 - 1;
+            }
+            if range.end > index {
+                range.end -= char_len_utf16 - 1;
+            }
+        }
+
+        Self::Range(range)
+    }
+
+    pub(crate) fn map(&self, f: impl FnOnce(Range<usize>) -> Range<usize>) -> Self {
+        match self {
+            Self::None => Self::None,
+            Self::Range(range) => Self::Range(f(range.clone())),
+        }
+    }
+
+    pub(crate) fn map_or(&self, default: bool, f: impl FnOnce(Range<usize>) -> bool) -> bool {
+        match self {
+            Self::None => default,
+            Self::Range(range) => f(range.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn to_utf8_selection_test() {
+        assert_eq!(
+            Selection::Range(0..0),
+            Selection::from_utf16(Some(0..0), "")
+        );
+        assert_eq!(
+            Selection::Range(0..0),
+            Selection::from_utf16(Some(0..0), "abc")
+        );
+        assert_eq!(
+            Selection::Range(1..1),
+            Selection::from_utf16(Some(1..1), "abc")
+        );
+        assert_eq!(
+            Selection::Range(3..3),
+            Selection::from_utf16(Some(3..3), "abc")
+        );
+        assert_eq!(
+            Selection::Range(2..2),
+            Selection::from_utf16(Some(3..3), "🔗1")
+        );
+        assert_eq!(
+            Selection::Range(1..1),
+            Selection::from_utf16(Some(2..2), "🔗1")
+        );
+        assert_eq!(
+            Selection::Range(0..0),
+            Selection::from_utf16(Some(0..0), "🔗1")
+        );
+        assert_eq!(
+            Selection::Range(2..3),
+            Selection::from_utf16(Some(3..5), "🔗1🔗")
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn to_utf16_code_unit_selection_test() {
+        assert_eq!(Some(0..0), Selection::Range(0..0).as_utf8_selection(""));
+        assert_eq!(Some(0..0), Selection::Range(0..0).as_utf8_selection("abc"));
+        assert_eq!(Some(1..1), Selection::Range(1..1).as_utf8_selection("abc"));
+        assert_eq!(Some(3..3), Selection::Range(3..3).as_utf8_selection("abc"));
+        assert_eq!(Some(3..3), Selection::Range(2..2).as_utf8_selection("🔗1"));
+        assert_eq!(Some(2..2), Selection::Range(1..1).as_utf8_selection("🔗1"));
+        assert_eq!(Some(0..0), Selection::Range(0..0).as_utf8_selection("🔗1"));
+        assert_eq!(
+            Some(3..5),
+            Selection::Range(2..3).as_utf8_selection("🔗1🔗")
+        );
+    }
+}


### PR DESCRIPTION
Closes #474 

I found that,
1. js's String.length is not the same with utf8 character length. they counted utf16 code units. I changed our logic only uses with the length of utf-8 chars
2. There were some logics which missed font fallbacks. I filled that.
