### PR TITLE
Load default font of typeface on init

### DIFF
--- a/namui/src/namui/system/font/mod.rs
+++ b/namui/src/namui/system/font/mod.rs
@@ -52,13 +52,13 @@ pub fn with_fallbacks(font: Arc<Font>) -> Vec<Arc<Font>> {
         .chain(std::iter::once_with(|| get_fallback_fonts(font_size)).flatten())
         .collect::<Vec<_>>()
 }
-pub fn get_font_of_typeface(typeface: Arc<Typeface>, font_size: IntPx) -> Arc<Font> {
+pub fn get_font_of_typeface(typeface: &Typeface, font_size: IntPx) -> Arc<Font> {
     let key = Font::generate_id(&typeface, font_size);
     let font = FONT_SYSTEM.typeface_fonts.get(&key);
     match font {
         Some(font) => font.clone(),
         None => {
-            let font = crate_font(&typeface, font_size);
+            let font = crate_font(typeface, font_size);
             FONT_SYSTEM.typeface_fonts.insert(key, font.clone());
             font
         }
@@ -81,6 +81,6 @@ fn crate_font(typeface: &Typeface, font_size: IntPx) -> Arc<Font> {
 }
 pub fn get_fallback_fonts(font_size: IntPx) -> Vec<Arc<Font>> {
     crate::typeface::get_fallback_font_typefaces()
-        .map(|typeface| crate::font::get_font_of_typeface(typeface.clone(), font_size))
+        .map(|typeface| crate::font::get_font_of_typeface(&typeface, font_size))
         .collect()
 }

--- a/namui/src/namui/system/font/mod.rs
+++ b/namui/src/namui/system/font/mod.rs
@@ -52,13 +52,13 @@ pub fn with_fallbacks(font: Arc<Font>) -> Vec<Arc<Font>> {
         .chain(std::iter::once_with(|| get_fallback_fonts(font_size)).flatten())
         .collect::<Vec<_>>()
 }
-pub fn get_font_of_typeface(typeface: &Typeface, font_size: IntPx) -> Arc<Font> {
+pub fn get_font_of_typeface(typeface: Arc<Typeface>, font_size: IntPx) -> Arc<Font> {
     let key = Font::generate_id(&typeface, font_size);
     let font = FONT_SYSTEM.typeface_fonts.get(&key);
     match font {
         Some(font) => font.clone(),
         None => {
-            let font = crate_font(typeface, font_size);
+            let font = crate_font(&typeface, font_size);
             FONT_SYSTEM.typeface_fonts.insert(key, font.clone());
             font
         }
@@ -81,6 +81,6 @@ fn crate_font(typeface: &Typeface, font_size: IntPx) -> Arc<Font> {
 }
 pub fn get_fallback_fonts(font_size: IntPx) -> Vec<Arc<Font>> {
     crate::typeface::get_fallback_font_typefaces()
-        .map(|typeface| crate::font::get_font_of_typeface(&typeface, font_size))
+        .map(|typeface| crate::font::get_font_of_typeface(typeface.clone(), font_size))
         .collect()
 }

--- a/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
@@ -19,12 +19,9 @@ pub async fn load_all_typefaces() -> Result<(), Box<dyn std::error::Error>> {
 async fn load_fallback_font_typefaces() -> Result<(), Box<dyn std::error::Error>> {
     let typeface = get_noto_color_emoji_typeface().await?;
 
-    crate::typeface::load_fallback_font_typeface("emoji".to_string(), typeface);
+    let typeface = crate::typeface::load_fallback_font_typeface("emoji".to_string(), typeface);
 
-    crate::typeface::get_fallback_font_typefaces().for_each(|font_family_type_face_pair| {
-        let typeface = font_family_type_face_pair.value();
-        load_default_font_of_typeface(typeface);
-    });
+    load_default_font_of_typeface(&typeface);
 
     Ok(())
 }

--- a/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
@@ -17,10 +17,8 @@ pub async fn load_all_typefaces() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn load_fallback_font_typefaces() -> Result<(), Box<dyn std::error::Error>> {
-    let typeface = get_noto_color_emoji_typeface().await?;
-
-    let typeface = crate::typeface::load_fallback_font_typeface("emoji".to_string(), typeface);
-
+    let typeface = Arc::new(get_noto_color_emoji_typeface().await?);
+    crate::typeface::load_fallback_font_typeface("emoji".to_string(), typeface.clone());
     load_default_font_of_typeface(typeface);
 
     Ok(())
@@ -40,10 +38,8 @@ pub async fn load_sans_typeface_of_all_languages() -> Result<(), Box<dyn std::er
 
     let typeface_files = get_typeface_files(&typeface_file_urls).await?;
     typeface_files.iter().for_each(|(typeface_type, bytes)| {
-        let typeface = crate::typeface::load_typeface(&typeface_type, bytes);
-
-        crate::typeface::get_typeface(typeface_type.clone());
-
+        let typeface = Arc::new(Typeface::new(bytes));
+        crate::typeface::load_typeface(&typeface_type, typeface.clone());
         load_default_font_of_typeface(typeface);
     });
 

--- a/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use futures::{future::try_join_all, try_join};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 const DEFAULT_FONT_SIZE: IntPx = int_px(12);
 
@@ -23,7 +23,7 @@ async fn load_fallback_font_typefaces() -> Result<(), Box<dyn std::error::Error>
 
     crate::typeface::get_fallback_font_typefaces().for_each(|font_family_type_face_pair| {
         let typeface = font_family_type_face_pair.value();
-        load_default_font_of_typeface(typeface.clone());
+        load_default_font_of_typeface(typeface);
     });
 
     Ok(())
@@ -43,13 +43,11 @@ pub async fn load_sans_typeface_of_all_languages() -> Result<(), Box<dyn std::er
 
     let typeface_files = get_typeface_files(&typeface_file_urls).await?;
     typeface_files.iter().for_each(|(typeface_type, bytes)| {
-        crate::typeface::load_typeface(&typeface_type, bytes);
+        let typeface = crate::typeface::load_typeface(&typeface_type, bytes);
 
-        let Some(typeface) = crate::typeface::get_typeface(typeface_type.clone()) else {
-            log!("Could not load typeface {:?}", typeface_type);
-            return;
-        };
-        load_default_font_of_typeface(typeface);
+        crate::typeface::get_typeface(typeface_type.clone());
+
+        load_default_font_of_typeface(&typeface);
     });
 
     Ok(())
@@ -152,6 +150,6 @@ mod tests {
     }
 }
 
-fn load_default_font_of_typeface(typeface: Arc<Typeface>) {
+fn load_default_font_of_typeface(typeface: &Typeface) {
     font::get_font_of_typeface(typeface, DEFAULT_FONT_SIZE);
 }

--- a/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
@@ -1,6 +1,8 @@
 use crate::*;
 use futures::{future::try_join_all, try_join};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
+
+const DEFAULT_FONT_SIZE: IntPx = int_px(12);
 
 type TypefaceFileUrls = HashMap<TypefaceType, String>;
 type TypefaceFileUrlsFile = HashMap<Language, HashMap<FontWeight, String>>;
@@ -18,6 +20,12 @@ async fn load_fallback_font_typefaces() -> Result<(), Box<dyn std::error::Error>
     let typeface = get_noto_color_emoji_typeface().await?;
 
     crate::typeface::load_fallback_font_typeface("emoji".to_string(), typeface);
+
+    crate::typeface::get_fallback_font_typefaces().for_each(|font_family_type_face_pair| {
+        let typeface = font_family_type_face_pair.value();
+        load_default_font_of_typeface(typeface.clone());
+    });
+
     Ok(())
 }
 
@@ -34,9 +42,15 @@ pub async fn load_sans_typeface_of_all_languages() -> Result<(), Box<dyn std::er
     let typeface_file_urls: TypefaceFileUrls = get_typeface_file_urls().await?;
 
     let typeface_files = get_typeface_files(&typeface_file_urls).await?;
-    typeface_files
-        .iter()
-        .for_each(|(typeface_type, bytes)| crate::typeface::load_typeface(&typeface_type, bytes));
+    typeface_files.iter().for_each(|(typeface_type, bytes)| {
+        crate::typeface::load_typeface(&typeface_type, bytes);
+
+        let Some(typeface) = crate::typeface::get_typeface(typeface_type.clone()) else {
+            log!("Could not load typeface {:?}", typeface_type);
+            return;
+        };
+        load_default_font_of_typeface(typeface);
+    });
 
     Ok(())
 }
@@ -136,4 +150,8 @@ mod tests {
             serde_json::from_str(&serialized_font_file_url_map).unwrap();
         assert_eq!(deserialized_font_file_url_map, answer);
     }
+}
+
+fn load_default_font_of_typeface(typeface: Arc<Typeface>) {
+    font::get_font_of_typeface(typeface, DEFAULT_FONT_SIZE);
 }

--- a/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
+++ b/namui/src/namui/system/typeface/load_sans_typeface_of_all_languages.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use futures::{future::try_join_all, try_join};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 const DEFAULT_FONT_SIZE: IntPx = int_px(12);
 
@@ -21,7 +21,7 @@ async fn load_fallback_font_typefaces() -> Result<(), Box<dyn std::error::Error>
 
     let typeface = crate::typeface::load_fallback_font_typeface("emoji".to_string(), typeface);
 
-    load_default_font_of_typeface(&typeface);
+    load_default_font_of_typeface(typeface);
 
     Ok(())
 }
@@ -44,7 +44,7 @@ pub async fn load_sans_typeface_of_all_languages() -> Result<(), Box<dyn std::er
 
         crate::typeface::get_typeface(typeface_type.clone());
 
-        load_default_font_of_typeface(&typeface);
+        load_default_font_of_typeface(typeface);
     });
 
     Ok(())
@@ -147,6 +147,6 @@ mod tests {
     }
 }
 
-fn load_default_font_of_typeface(typeface: &Typeface) {
+fn load_default_font_of_typeface(typeface: Arc<Typeface>) {
     font::get_font_of_typeface(typeface, DEFAULT_FONT_SIZE);
 }

--- a/namui/src/namui/system/typeface/mod.rs
+++ b/namui/src/namui/system/typeface/mod.rs
@@ -30,12 +30,12 @@ pub fn get_typeface(option: TypefaceType) -> Option<Arc<Typeface>> {
         .map(|typeface| typeface.clone())
 }
 
-pub(crate) fn load_typeface(option: &TypefaceType, bytes: &impl AsRef<[u8]>) {
-    let typeface = Typeface::new(bytes);
+pub(crate) fn load_typeface(option: &TypefaceType, bytes: &impl AsRef<[u8]>) -> Arc<Typeface> {
+    let typeface = Arc::new(Typeface::new(bytes));
 
-    TYPEFACE_SYSTEM
-        .typefaces
-        .insert(*option, Arc::new(typeface));
+    TYPEFACE_SYSTEM.typefaces.insert(*option, typeface.clone());
+
+    typeface
 }
 
 pub fn get_fallback_font_typefaces<'a>() -> impl Iterator<Item = RefMulti<'a, String, Arc<Typeface>>>

--- a/namui/src/namui/system/typeface/mod.rs
+++ b/namui/src/namui/system/typeface/mod.rs
@@ -30,12 +30,8 @@ pub fn get_typeface(option: TypefaceType) -> Option<Arc<Typeface>> {
         .map(|typeface| typeface.clone())
 }
 
-pub(crate) fn load_typeface(option: &TypefaceType, bytes: &impl AsRef<[u8]>) -> Arc<Typeface> {
-    let typeface = Arc::new(Typeface::new(bytes));
-
+pub(crate) fn load_typeface(option: &TypefaceType, typeface: Arc<Typeface>) {
     TYPEFACE_SYSTEM.typefaces.insert(*option, typeface.clone());
-
-    typeface
 }
 
 pub fn get_fallback_font_typefaces<'a>() -> impl Iterator<Item = RefMulti<'a, String, Arc<Typeface>>>
@@ -43,13 +39,8 @@ pub fn get_fallback_font_typefaces<'a>() -> impl Iterator<Item = RefMulti<'a, St
     TYPEFACE_SYSTEM.fallback_font_typefaces.iter()
 }
 
-pub(crate) fn load_fallback_font_typeface(
-    font_family: FontFamily,
-    typeface: Typeface,
-) -> Arc<Typeface> {
-    let typeface = Arc::new(typeface);
+pub(crate) fn load_fallback_font_typeface(font_family: FontFamily, typeface: Arc<Typeface>) {
     TYPEFACE_SYSTEM
         .fallback_font_typefaces
-        .insert(font_family, typeface.clone());
-    typeface
+        .insert(font_family, typeface);
 }

--- a/namui/src/namui/system/typeface/mod.rs
+++ b/namui/src/namui/system/typeface/mod.rs
@@ -43,8 +43,13 @@ pub fn get_fallback_font_typefaces<'a>() -> impl Iterator<Item = RefMulti<'a, St
     TYPEFACE_SYSTEM.fallback_font_typefaces.iter()
 }
 
-pub(crate) fn load_fallback_font_typeface(font_family: FontFamily, typeface: Typeface) {
+pub(crate) fn load_fallback_font_typeface(
+    font_family: FontFamily,
+    typeface: Typeface,
+) -> Arc<Typeface> {
+    let typeface = Arc::new(typeface);
     TYPEFACE_SYSTEM
         .fallback_font_typefaces
-        .insert(font_family, Arc::new(typeface));
+        .insert(font_family, typeface.clone());
+    typeface
 }


### PR DESCRIPTION
# What?
Loads default font of FontFace during init.
*default font is a 12px font.
**12px is namui_prebuilt::typography's body font size.

# Why?
Freezing occurs when text is first drawn in an adventure. 
This occurs first once per FontFace, regardless of font size.
So preload default font on init time.