### PR TITLE
Add username for luda-editor user

### DIFF
--- a/luda-editor/server/Cargo.lock
+++ b/luda-editor/server/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "futures",
  "lambda-web",
  "log",
+ "migration",
  "once_cell",
  "reqwest",
  "rpc",

--- a/luda-editor/server/Cargo.toml
+++ b/luda-editor/server/Cargo.toml
@@ -23,3 +23,4 @@ chrono = "0.4"
 log = "0.4"
 env_logger = "0.9"
 aws-smithy-async = "0.47"
+migration = { path = "../migration" }

--- a/luda-editor/server/src/services/auth/documents/mod.rs
+++ b/luda-editor/server/src/services/auth/documents/mod.rs
@@ -1,0 +1,24 @@
+mod user;
+
+use crate::storage::dynamo_db::Document;
+pub use user::*;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct IdentityDocument {
+    pub id: String,
+    pub user_id: rpc::Uuid,
+}
+
+impl Document for IdentityDocument {
+    fn partition_key_prefix() -> &'static str {
+        "identity"
+    }
+
+    fn partition_key_without_prefix(&self) -> String {
+        self.id.clone()
+    }
+
+    fn sort_key(&self) -> Option<String> {
+        None
+    }
+}

--- a/luda-editor/server/src/services/auth/documents/user/mod.rs
+++ b/luda-editor/server/src/services/auth/documents/user/mod.rs
@@ -1,0 +1,4 @@
+mod previous;
+mod v1;
+
+pub use v1::*;

--- a/luda-editor/server/src/services/auth/documents/user/previous/mod.rs
+++ b/luda-editor/server/src/services/auth/documents/user/previous/mod.rs
@@ -1,0 +1,3 @@
+#![allow(dead_code)]
+
+pub mod v0;

--- a/luda-editor/server/src/services/auth/documents/user/previous/v0.rs
+++ b/luda-editor/server/src/services/auth/documents/user/previous/v0.rs
@@ -19,23 +19,3 @@ impl Document for UserDocument {
         None
     }
 }
-
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct IdentityDocument {
-    pub id: String,
-    pub user_id: rpc::Uuid,
-}
-
-impl Document for IdentityDocument {
-    fn partition_key_prefix() -> &'static str {
-        "identity"
-    }
-
-    fn partition_key_without_prefix(&self) -> String {
-        self.id.clone()
-    }
-
-    fn sort_key(&self) -> Option<String> {
-        None
-    }
-}

--- a/luda-editor/server/src/services/auth/documents/user/v1.rs
+++ b/luda-editor/server/src/services/auth/documents/user/v1.rs
@@ -1,0 +1,32 @@
+use super::previous;
+use crate::storage::dynamo_db::Document;
+
+#[migration::version(1)]
+#[derive(Clone)]
+pub struct UserDocument {
+    pub id: rpc::Uuid,
+    pub name: String,
+}
+
+impl Document for UserDocument {
+    fn partition_key_prefix() -> &'static str {
+        "user"
+    }
+
+    fn partition_key_without_prefix(&self) -> String {
+        self.id.to_string()
+    }
+
+    fn sort_key(&self) -> Option<String> {
+        None
+    }
+}
+
+impl UserDocument {
+    pub fn migrate(previous: previous::v0::UserDocument) -> Self {
+        Self {
+            id: previous.id,
+            name: format!("anonymous"),
+        }
+    }
+}

--- a/luda-editor/server/src/services/auth/impls.rs
+++ b/luda-editor/server/src/services/auth/impls.rs
@@ -51,7 +51,7 @@ impl AuthService {
             Err(error) => Err(error.to_string()),
         }
     }
-    pub async fn get_github_user_id(&self, github_access_token: String) -> Result<String, String> {
+    pub async fn get_github_user(&self, github_access_token: String) -> Result<GithubUser, String> {
         let result = self
             .reqwest_client
             .get("https://api.github.com/user")
@@ -64,13 +64,17 @@ impl AuthService {
         #[derive(serde::Deserialize)]
         struct ResponseBody {
             id: u128,
+            login: String,
         }
         match result {
             Ok(response) => {
                 if response.status().is_success() {
                     let body = response.text().await.unwrap();
                     let response: ResponseBody = serde_json::from_str(&body).unwrap();
-                    Ok(response.id.to_string())
+                    Ok(GithubUser {
+                        id: response.id.to_string(),
+                        username: response.login,
+                    })
                 } else {
                     Err(format!(
                         "get_github_user_id failed: {:?}\n{body}",
@@ -83,4 +87,9 @@ impl AuthService {
             Err(error) => Err(error.to_string()),
         }
     }
+}
+
+pub struct GithubUser {
+    pub id: String,
+    pub username: String,
 }

--- a/luda-editor/server/src/services/auth/mod.rs
+++ b/luda-editor/server/src/services/auth/mod.rs
@@ -151,15 +151,19 @@ impl rpc::AuthService<SessionDocument> for AuthService {
             }
             let access_token = access_token.unwrap();
 
-            let github_user_id = self.get_github_user_id(access_token).await;
-            if let Err(error) = github_user_id {
+            let github_user = self.get_github_user(access_token).await;
+            if let Err(error) = github_user {
                 return Err(rpc::log_in_with_github_oauth_code::Error::Unknown(
                     error.to_string(),
                 ));
             }
-            let github_user_id = github_user_id.unwrap();
+            let github_user = github_user.unwrap();
 
-            let user = get_or_create_user(UserIdentity::Github { github_user_id }).await;
+            let user = get_or_create_user(UserIdentity::Github {
+                github_user_id: github_user.id,
+                username: github_user.username,
+            })
+            .await;
             if let Err(error) = user {
                 return Err(rpc::log_in_with_github_oauth_code::Error::Unknown(
                     error.to_string(),

--- a/luda-editor/server/src/services/auth/user_identity.rs
+++ b/luda-editor/server/src/services/auth/user_identity.rs
@@ -1,13 +1,27 @@
 pub enum UserIdentity {
-    Github { github_user_id: String },
+    Github {
+        github_user_id: String,
+        username: String,
+    },
 }
 
 impl UserIdentity {
     pub fn into_document_id(self) -> String {
         match self {
-            UserIdentity::Github { github_user_id } => {
+            UserIdentity::Github {
+                github_user_id,
+                username: _,
+            } => {
                 format!("github.{}", github_user_id)
             }
+        }
+    }
+    pub fn username(&self) -> &str {
+        match self {
+            UserIdentity::Github {
+                github_user_id: _,
+                username,
+            } => username,
         }
     }
 }


### PR DESCRIPTION
Previously, `UserDocument` didn't have username. I added it with `migration` crate which support struct version migration.
Local tested.