### PR TITLE
Load all images on start

### DIFF
--- a/luda-adventure/src/app/game/game.rs
+++ b/luda-adventure/src/app/game/game.rs
@@ -5,6 +5,7 @@ pub struct Game {
     pub state: GameState,
     pub ecs_app: crate::ecs::App,
     pub map_loader: MapLoader,
+    image_loader: ImageLoader,
     menu: Menu,
 }
 impl Game {
@@ -19,6 +20,7 @@ impl Game {
             state,
             ecs_app,
             map_loader: MapLoader::new(),
+            image_loader: ImageLoader::new(),
             menu: Menu::new(),
         }
     }
@@ -27,6 +29,7 @@ impl Game {
             state: GameState::new(),
             ecs_app: crate::ecs::App::new(),
             map_loader: MapLoader::new(),
+            image_loader: ImageLoader::new(),
             menu: Menu::new(),
         }
     }
@@ -43,6 +46,7 @@ impl Game {
         });
 
         self.map_loader.update(event, &mut self.ecs_app);
+        self.image_loader.update(event);
         self.menu.update(event);
     }
 

--- a/luda-adventure/src/app/game/image_loader.rs
+++ b/luda-adventure/src/app/game/image_loader.rs
@@ -39,15 +39,18 @@ impl ImageLoader {
             return;
         };
 
-        let Ok(image_urls) = get_image_urls() else {
-            namui::log!("failed to get image urls");
-            return;
-        };
-        self.image_loader_state = ImageLoaderState::Loading {
-            total_image_count: image_urls.len(),
-            loaded_image_count: 0,
-        };
-        load_images_concurrently(image_urls, CONCURRENT)
+        match get_image_urls() {
+            Ok(image_urls) => {
+                self.image_loader_state = ImageLoaderState::Loading {
+                    total_image_count: image_urls.len(),
+                    loaded_image_count: 0,
+                };
+                load_images_concurrently(image_urls, CONCURRENT)
+            }
+            Err(error) => {
+                self.image_loader_state = ImageLoaderState::Failed(error);
+            }
+        }
     }
 
     fn on_image_loaded(&mut self) {

--- a/luda-adventure/src/app/game/image_loader.rs
+++ b/luda-adventure/src/app/game/image_loader.rs
@@ -1,0 +1,101 @@
+use super::menu;
+use namui::prelude::*;
+
+pub struct ImageLoader {
+    image_loader_state: ImageLoaderState,
+}
+
+enum ImageLoaderState {
+    Idle,
+    Loading {
+        total_image_count: usize,
+        loaded_image_count: usize,
+    },
+    Loaded,
+    Failed(Box<dyn std::error::Error>),
+}
+
+impl ImageLoader {
+    pub fn new() -> Self {
+        Self {
+            image_loader_state: ImageLoaderState::Idle,
+        }
+    }
+
+    pub fn update(&mut self, event: &namui::Event) {
+        event
+            .is::<InternalEvent>(|event| match event {
+                InternalEvent::ImageLoaded => self.on_image_loaded(),
+            })
+            .is::<menu::Event>(|event| match event {
+                menu::Event::StartNewButtonClicked => self.start_load_all_images(),
+            });
+    }
+
+    fn start_load_all_images(&mut self) {
+        let ImageLoaderState::Idle = self.image_loader_state  else{
+            return;
+        };
+
+        let Ok(image_urls) = get_image_urls() else {
+            namui::log!("failed to get image urls");
+            return;
+        };
+        self.image_loader_state = ImageLoaderState::Loading {
+            total_image_count: image_urls.len(),
+            loaded_image_count: 0,
+        };
+        spawn_local(async move {
+            for image_url in image_urls {
+                namui::image::load_url(&image_url).await;
+                namui::event::send(InternalEvent::ImageLoaded);
+            }
+        })
+    }
+
+    fn on_image_loaded(&mut self) {
+        let ImageLoaderState::Loading {
+            total_image_count,
+            loaded_image_count,
+        } = &mut self.image_loader_state else {return;};
+
+        *loaded_image_count += 1;
+
+        let all_image_loaded = total_image_count == loaded_image_count;
+        if all_image_loaded {
+            self.image_loader_state = ImageLoaderState::Loaded;
+        }
+    }
+}
+
+enum InternalEvent {
+    ImageLoaded,
+}
+
+fn get_image_urls() -> Result<Vec<Url>, Box<dyn std::error::Error>> {
+    let mut directory_path_queue = vec!["image".to_string()];
+    let mut image_urls = Vec::new();
+    while let Some(directory_path) = directory_path_queue.pop() {
+        let directory = namui::file::bundle::read_dir(directory_path.as_str())
+            .map_err(|error| format!("{error:?}"))?;
+        for entry in directory {
+            let path = entry.path_string().to_string();
+            match entry.kind() {
+                namui::file::types::DirentKind::Directory => directory_path_queue.push(path),
+                namui::file::types::DirentKind::File => {
+                    if check_path_is_image_path(&path) {
+                        image_urls.push(entry.url().clone())
+                    }
+                }
+            }
+        }
+    }
+    Ok(image_urls)
+}
+
+fn check_path_is_image_path(path: &String) -> bool {
+    const IMAGE_EXTENSION_NAMES: [&str; 2] = ["png", "jpg"];
+    IMAGE_EXTENSION_NAMES
+        .iter()
+        .any(|extention_name| path.ends_with(extention_name))
+}

--- a/luda-adventure/src/app/game/image_loader.rs
+++ b/luda-adventure/src/app/game/image_loader.rs
@@ -105,7 +105,7 @@ fn load_images_concurrently(image_urls: Vec<Url>, concurrent: usize) {
             loop {
                 let image_url = { image_urls.lock().unwrap().pop() };
                 let Some(image_url) = image_url else {
-                  break;
+                    break;
                 };
                 namui::image::load_url(&image_url).await;
                 namui::event::send(InternalEvent::ImageLoaded);

--- a/luda-adventure/src/app/game/image_loader.rs
+++ b/luda-adventure/src/app/game/image_loader.rs
@@ -1,6 +1,6 @@
-use std::sync::{Arc, Mutex};
 use super::menu;
 use namui::prelude::*;
+use std::sync::{Arc, Mutex};
 
 pub struct ImageLoader {
     image_loader_state: ImageLoaderState,
@@ -103,14 +103,9 @@ fn load_images_concurrently(image_urls: Vec<Url>, concurrent: usize) {
         let image_urls = image_urls.clone();
         spawn_local(async move {
             loop {
-                let image_url = {
-                    image_urls
-                      .lock()
-                      .unwrap()
-                      .pop()
-                };
+                let image_url = { image_urls.lock().unwrap().pop() };
                 let Some(image_url) = image_url else {
-                  break;  
+                  break;
                 };
                 namui::image::load_url(&image_url).await;
                 namui::event::send(InternalEvent::ImageLoaded);

--- a/luda-adventure/src/app/game/mod.rs
+++ b/luda-adventure/src/app/game/mod.rs
@@ -2,6 +2,7 @@
 mod test;
 
 mod game;
+mod image_loader;
 mod interaction;
 pub mod known_id;
 mod map;
@@ -11,6 +12,7 @@ mod types;
 mod update;
 
 pub use game::*;
+pub use image_loader::*;
 pub use interaction::*;
 pub use map::*;
 pub use menu::*;


### PR DESCRIPTION
Load all images on start.

No waiting for loading now. If It takes too long because of more images in the future, we will need a loading splash.