### PR TITLE
Wh.to_rect()

### DIFF
--- a/namui-type/src/types/vector_types/wh.rs
+++ b/namui-type/src/types/vector_types/wh.rs
@@ -9,4 +9,15 @@ impl<T: Clone> Wh<T> {
             y: self.height.clone(),
         }
     }
+    pub fn to_rect(self) -> crate::Rect<T>
+    where
+        T: From<f32>,
+    {
+        crate::Rect::Xywh {
+            x: 0.0.into(),
+            y: 0.0.into(),
+            width: self.width,
+            height: self.height,
+        }
+    }
 }


### PR DESCRIPTION
I call too much of `Rect::from_xy(Xy::zero(), wh)`, it's too long to type. I HATE IT AND I WANT TO STOP IT!!