### PR TITLE
Keep use Arc<Paint> as possible

### DIFF
--- a/namui/src/namui/common/text/glyph_group.rs
+++ b/namui/src/namui/common/text/glyph_group.rs
@@ -15,12 +15,12 @@ pub struct GlyphGroup {
 pub(crate) fn get_glyph_groups(
     text: &str,
     fonts: &Vec<Arc<Font>>,
-    paint: Option<&Paint>,
+    paint: Arc<Paint>,
 ) -> Vec<GlyphGroup> {
     let cache_key = CacheKey {
         text: text.to_string(),
         fonts: fonts.to_vec(),
-        paint_id: paint.map(|p| p.id),
+        paint_id: paint.id,
     };
     if let Some(cached) = get_glyph_groups_cache(&cache_key) {
         return cached;
@@ -81,7 +81,7 @@ static GLYPH_GROUPS_CACHE: OnceCell<Mutex<lru::LruCache<CacheKey, Vec<GlyphGroup
 struct CacheKey {
     text: String,
     fonts: Vec<Arc<Font>>,
-    paint_id: Option<Uuid>,
+    paint_id: Uuid,
 }
 
 impl std::hash::Hash for CacheKey {

--- a/namui/src/namui/common/text/measure_glyphs.rs
+++ b/namui/src/namui/common/text/measure_glyphs.rs
@@ -15,12 +15,12 @@ pub enum GlyphMeasure {
 pub(crate) fn measure_glyphs(
     text: &str,
     fonts: &Vec<Arc<Font>>,
-    paint: Option<&Paint>,
+    paint: Arc<Paint>,
 ) -> Vec<GlyphMeasure> {
     let cache_key = CacheKey {
         text: text.to_string(),
         fonts: fonts.to_vec(),
-        paint_id: paint.map(|p| p.id),
+        paint_id: paint.id,
     };
     if let Some(cached) = get_glyph_width_measures_cache(&cache_key) {
         return cached;
@@ -74,7 +74,7 @@ pub(crate) fn measure_glyphs(
                 .map(|(_, glyph_id)| *glyph_id)
                 .collect();
 
-            let widths = font.get_glyph_widths(glyph_ids.into(), paint);
+            let widths = font.get_glyph_widths(glyph_ids.into(), paint.as_ref());
 
             widths
                 .into_iter()
@@ -103,7 +103,7 @@ static GLYPH_WIDTH_MEASURES_CACHE: OnceCell<Mutex<lru::LruCache<CacheKey, Vec<Gl
 struct CacheKey {
     text: String,
     fonts: Vec<Arc<Font>>,
-    paint_id: Option<Uuid>,
+    paint_id: Uuid,
 }
 
 impl std::hash::Hash for CacheKey {

--- a/namui/src/namui/common/text/mod.rs
+++ b/namui/src/namui/common/text/mod.rs
@@ -1,7 +1,7 @@
 mod glyph_group;
 mod line_texts;
 mod measure_glyphs;
-mod multiline_caret;
+pub(crate) mod multiline_caret;
 mod text_width;
 
 use crate::{namui::skia::FontMetrics, *};
@@ -39,7 +39,7 @@ pub fn get_multiline_y_baseline_offset(
 pub(crate) fn get_text_width_with_fonts(
     fonts: &Vec<Arc<Font>>,
     text: &str,
-    paint: Option<&Paint>,
+    paint: Arc<Paint>,
 ) -> Px {
     let groups = get_glyph_groups(text, fonts, paint);
     groups.iter().map(|group| group.width).sum()

--- a/namui/src/namui/common/text/multiline_caret.rs
+++ b/namui/src/namui/common/text/multiline_caret.rs
@@ -4,16 +4,13 @@ use crate::{
     *,
 };
 
-#[derive(Debug, Clone, Copy)]
-pub struct MultilineCaret<'a> {
+#[derive(Debug, Clone)]
+pub struct MultilineCaret {
     pub line_index: usize,
     pub caret_index_in_line: usize,
-    line_texts: &'a LineTexts<'a>,
+    line_texts: LineTexts,
 }
-pub(crate) fn get_multiline_caret<'a>(
-    selection_index: usize,
-    line_texts: &'a LineTexts,
-) -> MultilineCaret<'a> {
+pub(crate) fn get_multiline_caret(selection_index: usize, line_texts: LineTexts) -> MultilineCaret {
     let mut line_index = 0;
     let mut left_index = selection_index;
 
@@ -22,7 +19,7 @@ pub(crate) fn get_multiline_caret<'a>(
             return MultilineCaret {
                 line_index,
                 caret_index_in_line: left_index,
-                line_texts,
+                line_texts: line_texts.clone(),
             };
         } else if left_index == line.chars.len() {
             match line.new_line_by {
@@ -31,14 +28,14 @@ pub(crate) fn get_multiline_caret<'a>(
                         return MultilineCaret {
                             line_index: line_index + 1,
                             caret_index_in_line: 0,
-                            line_texts,
+                            line_texts: line_texts.clone(),
                         };
                     }
                     NewLineBy::LineFeed => {
                         return MultilineCaret {
                             line_index,
                             caret_index_in_line: left_index,
-                            line_texts,
+                            line_texts: line_texts.clone(),
                         };
                     }
                 },
@@ -46,7 +43,7 @@ pub(crate) fn get_multiline_caret<'a>(
                     return MultilineCaret {
                         line_index,
                         caret_index_in_line: left_index,
-                        line_texts,
+                        line_texts: line_texts.clone(),
                     };
                 }
             }
@@ -65,8 +62,8 @@ pub(crate) fn get_multiline_caret<'a>(
     }
 }
 
-impl MultilineCaret<'_> {
-    pub(crate) fn get_caret_on_key(&self, key: KeyInInterest) -> MultilineCaret<'_> {
+impl MultilineCaret {
+    pub(crate) fn get_caret_on_key(&self, key: KeyInInterest) -> MultilineCaret {
         let (line_index, x) = match key {
             KeyInInterest::ArrowUpDown(up_down) => match up_down {
                 ArrowUpDown::Up => {
@@ -74,13 +71,13 @@ impl MultilineCaret<'_> {
                         return MultilineCaret {
                             line_index: 0,
                             caret_index_in_line: 0,
-                            line_texts: self.line_texts,
+                            line_texts: self.line_texts.clone(),
                         };
                     }
                     (self.line_index - 1, self.get_x())
                 }
                 ArrowUpDown::Down => {
-                    if self.is_last_line() {
+                    if self.is_at_bottom() {
                         return MultilineCaret {
                             line_index: self.line_index,
                             caret_index_in_line: self
@@ -89,7 +86,7 @@ impl MultilineCaret<'_> {
                                 .nth(self.line_index)
                                 .unwrap()
                                 .len(),
-                            line_texts: self.line_texts,
+                            line_texts: self.line_texts.clone(),
                         };
                     }
                     (self.line_index + 1, self.get_x())
@@ -106,7 +103,7 @@ impl MultilineCaret<'_> {
         MultilineCaret {
             line_index,
             caret_index_in_line: caret_index_on_direction,
-            line_texts: self.line_texts,
+            line_texts: self.line_texts.clone(),
         }
     }
 
@@ -118,8 +115,11 @@ impl MultilineCaret<'_> {
     fn get_x(&self) -> Px {
         let line_text = self.line_texts.iter_str().nth(self.line_index).unwrap();
 
-        let glyph_groups =
-            get_glyph_groups(&line_text, self.line_texts.fonts, self.line_texts.paint);
+        let glyph_groups = get_glyph_groups(
+            &line_text,
+            &self.line_texts.fonts,
+            self.line_texts.paint.clone(),
+        );
 
         let mut x = 0.px();
         for glyph_group in glyph_groups {
@@ -138,22 +138,21 @@ impl MultilineCaret<'_> {
         x
     }
 
-    fn is_last_line(&self) -> bool {
-        self.line_index == self.line_texts.iter_str().count() - 1
-    }
-
     fn get_caret_index_on_x(&self, x: Px, line_index: usize) -> usize {
         let line_text = self.line_texts.iter_str().nth(line_index).unwrap();
 
-        let glyph_groups =
-            get_glyph_groups(&line_text, self.line_texts.fonts, self.line_texts.paint);
+        let glyph_groups = get_glyph_groups(
+            &line_text,
+            &self.line_texts.fonts,
+            self.line_texts.paint.clone(),
+        );
 
         let mut caret_positions = vec![(0.px(), 0)];
         for glyph_group in glyph_groups {
             let glyph_ids = glyph_group.glyph_ids.into_boxed_slice();
             let glyph_widths = glyph_group
                 .font
-                .get_glyph_widths(glyph_ids, self.line_texts.paint);
+                .get_glyph_widths(glyph_ids, self.line_texts.paint.as_ref());
 
             for glyph_width in glyph_widths.into_iter() {
                 let last = caret_positions.last().unwrap().clone();
@@ -176,5 +175,13 @@ impl MultilineCaret<'_> {
             }
         }
         closest_caret_index
+    }
+
+    pub(crate) fn is_at_bottom(&self) -> bool {
+        let line_count = self.line_texts.iter_str().count();
+        if line_count == 0 {
+            return true;
+        }
+        self.line_index == line_count - 1
     }
 }

--- a/namui/src/namui/common/text/text_width.rs
+++ b/namui/src/namui/common/text/text_width.rs
@@ -2,11 +2,7 @@ use super::*;
 use crate::*;
 use std::sync::Arc;
 
-pub(crate) fn get_text_widths(
-    text: &str,
-    fonts: &Vec<Arc<Font>>,
-    paint: Option<&Paint>,
-) -> Vec<Px> {
+pub(crate) fn get_text_widths(text: &str, fonts: &Vec<Arc<Font>>, paint: Arc<Paint>) -> Vec<Px> {
     measure_glyphs(text, fonts, paint)
         .into_iter()
         .filter_map(|measure| match measure {

--- a/namui/src/namui/draw/text.rs
+++ b/namui/src/namui/draw/text.rs
@@ -40,7 +40,7 @@ impl TextDrawCommand {
         let paint = self.paint_builder.build();
         let underline_paint = self.underline.as_ref().map(|underline| underline.build());
 
-        let line_texts = LineTexts::new(&self.text, &fonts, Some(&paint), self.max_width);
+        let line_texts = LineTexts::new(&self.text, fonts.clone(), paint.clone(), self.max_width);
 
         let line_height = self.line_height_px();
 
@@ -59,7 +59,7 @@ impl TextDrawCommand {
                 )
             })
             .for_each(|(y, line_text)| {
-                let glyph_groups = get_glyph_groups(&line_text, &fonts, Some(&paint));
+                let glyph_groups = get_glyph_groups(&line_text, &fonts, paint.clone());
 
                 let total_width = glyph_groups.iter().map(|group| group.width).sum();
 
@@ -112,7 +112,7 @@ impl TextDrawCommand {
 
         let paint = self.paint_builder.build();
 
-        let line_texts = LineTexts::new(&self.text, &fonts, Some(&paint), self.max_width);
+        let line_texts = LineTexts::new(&self.text, fonts, paint.clone(), self.max_width);
 
         let line_height = self.line_height_px();
 
@@ -134,14 +134,14 @@ impl TextDrawCommand {
                 let glyph_ids = font.get_glyph_ids(line_text);
 
                 let paint = self.paint_builder.build();
-                let glyph_bounds = font.get_glyph_bounds(glyph_ids.clone(), Some(&paint));
+                let glyph_bounds = font.get_glyph_bounds(glyph_ids.clone(), paint.as_ref());
 
                 glyph_bounds
                     .iter()
                     .map(|bound| (bound.top(), bound.bottom()))
                     .reduce(|acc, (top, bottom)| (acc.0.min(top), acc.1.max(bottom)))
                     .and_then(|(top, bottom)| {
-                        let widths = font.get_glyph_widths(glyph_ids, Option::Some(&paint));
+                        let widths = font.get_glyph_widths(glyph_ids, paint.as_ref());
                         let width = widths.iter().fold(px(0.0), |prev, curr| prev + curr);
                         let x_axis_anchor = get_left_in_align(self.x, self.align, width);
 

--- a/namui/src/namui/render/text.rs
+++ b/namui/src/namui/render/text.rs
@@ -187,7 +187,8 @@ fn draw_background(param: &TextParam, font: Arc<Font>) -> RenderingTree {
     let font_metrics = font.metrics;
     let fonts = with_fallbacks(font);
 
-    let width = get_text_width_with_fonts(&fonts, &param.text, None);
+    let text_paint = get_text_paint(param.style.color).build();
+    let width = get_text_width_with_fonts(&fonts, &param.text, text_paint);
 
     let height = param.line_height_px();
     let bottom_of_baseline = get_bottom_of_baseline(param.baseline, font_metrics);

--- a/namui/src/namui/render/text_input/draw_caret.rs
+++ b/namui/src/namui/render/text_input/draw_caret.rs
@@ -8,12 +8,12 @@ impl TextInput {
         props: &Props,
         line_texts: &LineTexts,
         selection: &Selection,
-        paint: &Paint,
+        paint: Arc<Paint>,
     ) -> RenderingTree {
         let Selection::Range(range) = selection else {
             return RenderingTree::Empty;
         };
-        let caret = line_texts.get_multiline_caret(range.end);
+        let caret = line_texts.clone().into_multiline_caret(range.end);
 
         let line_height = props.line_height_px();
 
@@ -52,8 +52,8 @@ impl TextInput {
         let font_metrics = font.metrics;
         let fonts = with_fallbacks(font);
 
-        let left_text_width = get_text_width_with_fonts(&fonts, &left_text_string, Some(paint));
-        let right_text_width = get_text_width_with_fonts(&fonts, &right_text_string, Some(paint));
+        let left_text_width = get_text_width_with_fonts(&fonts, &left_text_string, paint.clone());
+        let right_text_width = get_text_width_with_fonts(&fonts, &right_text_string, paint.clone());
 
         let total_width = left_text_width + right_text_width;
 

--- a/namui/src/namui/render/text_input/draw_texts_divided_by_selection.rs
+++ b/namui/src/namui/render/text_input/draw_texts_divided_by_selection.rs
@@ -13,7 +13,7 @@ impl TextInput {
         &self,
         props: &Props,
         fonts: &Vec<Arc<Font>>,
-        paint: &Arc<Paint>,
+        paint: Arc<Paint>,
         line_texts: &LineTexts,
         selection: &Selection,
     ) -> RenderingTree {
@@ -34,8 +34,12 @@ impl TextInput {
             (selection.end, selection.start)
         };
 
-        let left_caret = line_texts.get_multiline_caret(left_selection_index);
-        let right_caret = line_texts.get_multiline_caret(right_selection_index);
+        let left_caret = line_texts
+            .clone()
+            .into_multiline_caret(left_selection_index);
+        let right_caret = line_texts
+            .clone()
+            .into_multiline_caret(right_selection_index);
 
         let y_of_line = |line_index: usize| {
             let line_height = props.line_height_px();
@@ -206,7 +210,7 @@ impl TextInput {
             left_text_string,
             selected_text_string,
             right_text_string,
-            &paint,
+            paint.clone(),
         );
 
         if render_only_selection_background {
@@ -218,9 +222,9 @@ impl TextInput {
                 TextBaseline::Bottom => line_height,
             };
 
-            let mut width = get_text_width_with_fonts(fonts, &selected_text_string, Some(&paint));
+            let mut width = get_text_width_with_fonts(fonts, &selected_text_string, paint.clone());
             if with_newline_background {
-                width += get_text_width_with_fonts(fonts, " ", Some(&paint))
+                width += get_text_width_with_fonts(fonts, " ", paint.clone())
             };
 
             namui::rect(crate::RectParam {
@@ -285,12 +289,12 @@ impl TextInput {
         left_text_string: &str,
         selected_text_string: &str,
         right_text_string: &str,
-        paint: &Paint,
+        paint: Arc<Paint>,
     ) -> (Px, Px, Px) {
         let (left_text_width, selected_text_width, right_text_width) = (
-            get_text_width_with_fonts(&fonts, left_text_string, Some(paint)),
-            get_text_width_with_fonts(&fonts, selected_text_string, Some(paint)),
-            get_text_width_with_fonts(&fonts, right_text_string, Some(paint)),
+            get_text_width_with_fonts(&fonts, left_text_string, paint.clone()),
+            get_text_width_with_fonts(&fonts, selected_text_string, paint.clone()),
+            get_text_width_with_fonts(&fonts, right_text_string, paint.clone()),
         );
 
         let total_width = left_text_width + selected_text_width + right_text_width;

--- a/namui/src/namui/render/text_input/mod.rs
+++ b/namui/src/namui/render/text_input/mod.rs
@@ -82,6 +82,12 @@ pub struct KeyDownEvent {
     pub is_composing: bool,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct CursorPosition {
+    pub is_at_top: bool,
+    pub is_at_bottom: bool,
+}
+
 impl KeyDownEvent {
     pub fn prevent_default(&self) {
         self.is_prevented_default.store(true, Ordering::Relaxed);
@@ -137,8 +143,8 @@ impl TextInput {
 
         let line_texts = LineTexts::new(
             &props.text,
-            &fonts,
-            Some(&paint),
+            fonts.clone(),
+            paint.clone(),
             props.text_param().max_width,
         );
 
@@ -165,8 +171,14 @@ impl TextInput {
                     ..props.style.rect
                 },
             }),
-            self.draw_texts_divided_by_selection(&props, &fonts, &paint, &line_texts, &selection),
-            self.draw_caret(&props, &line_texts, &selection, &paint),
+            self.draw_texts_divided_by_selection(
+                &props,
+                &fonts,
+                paint.clone(),
+                &line_texts,
+                &selection,
+            ),
+            self.draw_caret(&props, &line_texts, &selection, paint.clone()),
         ])
         .with_custom(custom_data.clone())
         .attach_event(|builder| {

--- a/namui/src/namui/skia/base/paint_builder.rs
+++ b/namui/src/namui/skia/base/paint_builder.rs
@@ -119,11 +119,11 @@ impl PaintBuilder {
         let paint = Paint::new(
             id,
             self.color,
-            self.paint_style.as_ref(),
+            self.paint_style,
             self.anti_alias,
             self.stroke_width,
-            self.stroke_cap.as_ref(),
-            self.stroke_join.as_ref(),
+            self.stroke_cap,
+            self.stroke_join,
             self.color_filter
                 .as_ref()
                 .map(|(color, blend_mode)| Self::get_or_create_color_filter(*color, *blend_mode)),

--- a/namui/src/namui/skia/web/paint.rs
+++ b/namui/src/namui/skia/web/paint.rs
@@ -14,11 +14,11 @@ impl Paint {
     pub fn new(
         id: Uuid,
         color: Option<Color>,
-        style: Option<&PaintStyle>,
+        style: Option<PaintStyle>,
         anti_alias: Option<bool>,
         stroke_width: Option<Px>,
-        stroke_cap: Option<&StrokeCap>,
-        stroke_join: Option<&StrokeJoin>,
+        stroke_cap: Option<StrokeCap>,
+        stroke_join: Option<StrokeJoin>,
         color_filter: Option<impl AsRef<ColorFilter>>,
     ) -> Self {
         let canvas_kit_paint = CanvasKitPaint::new();

--- a/namui/src/namui/system/text_input/mouse_event.rs
+++ b/namui/src/namui/system/text_input/mouse_event.rs
@@ -143,7 +143,12 @@ fn get_selection_on_mouse_movement(
 
     let paint = get_text_paint(props.style.text.color).build();
 
-    let line_texts = LineTexts::new(&props.text, &fonts, Some(&paint), Some(props.rect.width()));
+    let line_texts = LineTexts::new(
+        &props.text,
+        fonts.clone(),
+        paint.clone(),
+        Some(props.rect.width()),
+    );
 
     // const continouslyFastClickCount: number;
 
@@ -165,6 +170,7 @@ fn get_selection_on_mouse_movement(
         click_local_xy,
         is_dragging,
         &selection,
+        paint,
     ))
 }
 
@@ -175,9 +181,10 @@ fn get_one_click_selection(
     click_local_xy: Xy<Px>,
     is_dragging: bool,
     last_selection: &Selection,
+    paint: Arc<Paint>,
 ) -> Range<usize> {
     let selection_index_of_xy =
-        get_selection_index_of_xy(text_input_props, fonts, line_texts, click_local_xy);
+        get_selection_index_of_xy(text_input_props, fonts, line_texts, click_local_xy, paint);
 
     let start = match last_selection {
         Selection::Range(range) => {
@@ -198,6 +205,7 @@ fn get_selection_index_of_xy(
     fonts: &Vec<Arc<Font>>,
     line_texts: &LineTexts,
     click_local_xy: Xy<Px>,
+    paint: Arc<Paint>,
 ) -> usize {
     let line_len = line_texts.line_len();
     if line_len == 0 {
@@ -229,7 +237,7 @@ fn get_selection_index_of_xy(
 
     let line_text = line_texts.iter_str().nth(line_index).unwrap();
 
-    let glyph_widths = get_text_widths(&line_text, &fonts, None);
+    let glyph_widths = get_text_widths(&line_text, &fonts, paint);
 
     let line_width = glyph_widths.iter().sum::<Px>();
 


### PR DESCRIPTION
Removed too much of referencing of Paint, and just keep using Arc<Paint> as possible.