### PR TITLE
Route with hash

### DIFF
--- a/luda-editor/client/Cargo.lock
+++ b/luda-editor/client/Cargo.lock
@@ -517,9 +517,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -577,6 +577,7 @@ dependencies = [
  "rpc",
  "serde",
  "serde_json",
+ "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -1633,9 +1634,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1645,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1672,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1682,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1695,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-bindgen-test"

--- a/luda-editor/client/Cargo.toml
+++ b/luda-editor/client/Cargo.toml
@@ -13,10 +13,11 @@ namui-prebuilt = { path = "../../namui-prebuilt" }
 rpc = { path = "../rpc", features = ["client"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-web-sys = { version = "0.3", features = ["Location"] }
+web-sys = { version = "0.3", features = ["Location", "HashChangeEvent"] }
 once_cell = "1.13"
 revert-json-patch = { path = "../revert-json-patch" }
 futures = "0.3.17"
+wasm-bindgen = "0.2.84"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/luda-editor/client/src/app/mod.rs
+++ b/luda-editor/client/src/app/mod.rs
@@ -1,6 +1,6 @@
 mod login;
 
-use crate::pages::{project_list_page::ProjectListPage, router};
+use crate::pages::router;
 use namui::prelude::*;
 use namui_prebuilt::*;
 
@@ -26,9 +26,7 @@ impl namui::Entity for App {
         event.is::<Event>(|event| match event {
             Event::LoggedIn => {
                 *self = App::LoggedIn {
-                    router: router::Router::new(router::Route::ProjectListPage(
-                        ProjectListPage::new(),
-                    )),
+                    router: router::Router::new(),
                 };
             }
         });

--- a/luda-editor/client/src/pages/project_list_page/mod.rs
+++ b/luda-editor/client/src/pages/project_list_page/mod.rs
@@ -1,8 +1,7 @@
-use super::{sequence_list_page::SequenceListPage, *};
+use super::router::Router;
 use namui::prelude::*;
 use namui_prebuilt::*;
 use rpc::list_editable_projects::EditableProject;
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct ProjectListPage {
@@ -141,9 +140,7 @@ impl ProjectListPage {
             [MouseButton::Left],
             move |event| {
                 if event.button == Some(MouseButton::Left) {
-                    namui::event::send(router::Event::Route(Arc::new(move || {
-                        router::Route::SequenceListPage(SequenceListPage::new(project_id))
-                    })));
+                    Router::move_to(format!("/sequence_list/{project_id}"));
                 } else if event.button == Some(MouseButton::Right) {
                     // TODO
                     // namui::event::send(Event::CellRightClick {

--- a/luda-editor/client/src/pages/project_list_page/mod.rs
+++ b/luda-editor/client/src/pages/project_list_page/mod.rs
@@ -140,7 +140,7 @@ impl ProjectListPage {
             [MouseButton::Left],
             move |event| {
                 if event.button == Some(MouseButton::Left) {
-                    Router::move_to(format!("/sequence_list/{project_id}"));
+                    Router::move_to(super::router::RoutePath::SequenceList(project_id));
                 } else if event.button == Some(MouseButton::Right) {
                     // TODO
                     // namui::event::send(Event::CellRightClick {

--- a/luda-editor/client/src/pages/router.rs
+++ b/luda-editor/client/src/pages/router.rs
@@ -1,6 +1,6 @@
 use super::*;
 use namui::prelude::*;
-use std::sync::{Arc, Once};
+use std::sync::Once;
 use wasm_bindgen::prelude::*;
 use web_sys::HashChangeEvent;
 
@@ -14,14 +14,8 @@ pub struct Props {
     pub wh: Wh<Px>,
 }
 
-pub enum Event {
-    Route(Arc<dyn Fn() -> Route + 'static>),
-}
-unsafe impl Send for Event {}
-unsafe impl Sync for Event {}
-
 enum InternalEvent {
-    HashChanged(String),
+    PathChanged(String),
 }
 
 pub enum Route {
@@ -29,15 +23,40 @@ pub enum Route {
     SequenceListPage(sequence_list_page::SequenceListPage),
     SequenceEditPage(sequence_edit_page::SequenceEditPage),
 }
+impl Route {
+    pub fn from_path(path: &String) -> Self {
+        if path.starts_with("/sequence_list") {
+            let rest = path.clone().split_off("/sequence_list".len());
+            if let Ok(project_id) = Uuid::parse_str(rest.trim_matches('/')) {
+                return Self::SequenceListPage(sequence_list_page::SequenceListPage::new(
+                    project_id,
+                ));
+            }
+        }
+
+        if path.starts_with("/sequence_edit") {
+            let rest = path.clone().split_off("/sequence_edit".len());
+            if let Ok(sequence_id) = Uuid::parse_str(rest.trim_matches('/')) {
+                return Self::SequenceEditPage(sequence_edit_page::SequenceEditPage::new(
+                    sequence_id,
+                ));
+            }
+        }
+
+        Self::ProjectListPage(project_list_page::ProjectListPage::new())
+    }
+}
 
 impl Router {
-    pub fn new(route: Route) -> Self {
+    pub fn new() -> Self {
         Self::register_hash_change_event_listener();
+        let path = get_path_from_hash();
+        let route = Route::from_path(&path);
         Self { route }
     }
     pub fn update(&mut self, event: &namui::Event) {
-        event.is::<Event>(|event| match event {
-            Event::Route(route) => self.route = (route)(),
+        event.is::<InternalEvent>(|event| match event {
+            InternalEvent::PathChanged(path) => self.route = Route::from_path(path),
         });
         match &mut self.route {
             Route::ProjectListPage(project_list_page) => project_list_page.update(event),
@@ -62,8 +81,8 @@ impl Router {
     fn register_hash_change_event_listener() {
         HASH_CHANGE_EVENT_LISTENER.call_once(|| {
             let window = web_sys::window().unwrap();
-            let listener = Closure::<dyn FnMut(_)>::new(move |event: HashChangeEvent| {
-                InternalEvent::HashChanged(get_path_from_url(event.new_url()));
+            let listener = Closure::<dyn FnMut(_)>::new(move |_: HashChangeEvent| {
+                namui::event::send(InternalEvent::PathChanged(get_path_from_hash()));
             });
 
             window
@@ -73,14 +92,19 @@ impl Router {
             listener.forget();
         })
     }
+
+    pub fn move_to(path: String) {
+        let window = web_sys::window().unwrap();
+        window.location().set_hash(&path).unwrap();
+    }
 }
 
-fn get_path_from_url(url: String) -> String {
-    let Some((_, hash)) = url.split_once("#") else {
-        return "/".to_string();
-    };
-    match hash.starts_with("/") {
-        true => hash.to_string(),
+fn get_path_from_hash() -> String {
+    let window = web_sys::window().unwrap();
+    let hash = window.location().hash().unwrap_or("#".to_string());
+    let path = hash.trim_start_matches('#');
+    match path.starts_with("/") {
+        true => path.to_string(),
         false => "/".to_string(),
     }
 }

--- a/luda-editor/client/src/pages/router.rs
+++ b/luda-editor/client/src/pages/router.rs
@@ -15,7 +15,7 @@ pub struct Props {
 }
 
 enum InternalEvent {
-    PathChanged(String),
+    PathChanged(RoutePath),
 }
 
 pub enum Route {
@@ -23,27 +23,21 @@ pub enum Route {
     SequenceListPage(sequence_list_page::SequenceListPage),
     SequenceEditPage(sequence_edit_page::SequenceEditPage),
 }
-impl Route {
-    pub fn from_path(path: &String) -> Self {
-        if path.starts_with("/sequence_list") {
-            let rest = path.clone().split_off("/sequence_list".len());
-            if let Ok(project_id) = Uuid::parse_str(rest.trim_matches('/')) {
-                return Self::SequenceListPage(sequence_list_page::SequenceListPage::new(
-                    project_id,
-                ));
+impl From<RoutePath> for Route {
+    fn from(path: RoutePath) -> Self {
+        match path {
+            RoutePath::ProjectList => {
+                Self::ProjectListPage(project_list_page::ProjectListPage::new())
             }
-        }
-
-        if path.starts_with("/sequence_edit") {
-            let rest = path.clone().split_off("/sequence_edit".len());
-            if let Ok(sequence_id) = Uuid::parse_str(rest.trim_matches('/')) {
+            RoutePath::SequenceList(project_id) => {
+                Self::SequenceListPage(sequence_list_page::SequenceListPage::new(project_id))
+            }
+            RoutePath::SequenceEdit(sequence_id) => {
                 return Self::SequenceEditPage(sequence_edit_page::SequenceEditPage::new(
                     sequence_id,
-                ));
+                ))
             }
         }
-
-        Self::ProjectListPage(project_list_page::ProjectListPage::new())
     }
 }
 
@@ -51,12 +45,12 @@ impl Router {
     pub fn new() -> Self {
         Self::register_hash_change_event_listener();
         let path = get_path_from_hash();
-        let route = Route::from_path(&path);
+        let route = Route::from(path);
         Self { route }
     }
     pub fn update(&mut self, event: &namui::Event) {
         event.is::<InternalEvent>(|event| match event {
-            InternalEvent::PathChanged(path) => self.route = Route::from_path(path),
+            InternalEvent::PathChanged(path) => self.route = Route::from(path.clone()),
         });
         match &mut self.route {
             Route::ProjectListPage(project_list_page) => project_list_page.update(event),
@@ -93,18 +87,50 @@ impl Router {
         })
     }
 
-    pub fn move_to(path: String) {
+    pub fn move_to(path: RoutePath) {
         let window = web_sys::window().unwrap();
-        window.location().set_hash(&path).unwrap();
+        window.location().set_hash(&path.to_string()).unwrap();
     }
 }
 
-fn get_path_from_hash() -> String {
+fn get_path_from_hash() -> RoutePath {
     let window = web_sys::window().unwrap();
     let hash = window.location().hash().unwrap_or("#".to_string());
     let path = hash.trim_start_matches('#');
-    match path.starts_with("/") {
-        true => path.to_string(),
-        false => "/".to_string(),
+    RoutePath::from(path.to_string())
+}
+
+#[derive(Clone)]
+pub enum RoutePath {
+    ProjectList,
+    SequenceList(Uuid),
+    SequenceEdit(Uuid),
+}
+impl From<String> for RoutePath {
+    fn from(path_string: String) -> Self {
+        if path_string.starts_with("/sequence_list") {
+            let rest = path_string.clone().split_off("/sequence_list".len());
+            if let Ok(project_id) = Uuid::parse_str(rest.trim_matches('/')) {
+                return Self::SequenceList(project_id);
+            }
+        }
+
+        if path_string.starts_with("/sequence_edit") {
+            let rest = path_string.clone().split_off("/sequence_edit".len());
+            if let Ok(sequence_id) = Uuid::parse_str(rest.trim_matches('/')) {
+                return Self::SequenceEdit(sequence_id);
+            }
+        }
+
+        Self::ProjectList
+    }
+}
+impl ToString for RoutePath {
+    fn to_string(&self) -> String {
+        match self {
+            Self::ProjectList => "/".to_string(),
+            Self::SequenceList(project_id) => format!("/sequence_list/{project_id}"),
+            Self::SequenceEdit(sequence_id) => format!("/sequence_edit/{sequence_id}"),
+        }
     }
 }

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
@@ -1,13 +1,9 @@
 use super::*;
-use crate::{
-    components::sync::SyncStatus,
-    pages::{router, sequence_list_page::SequenceListPage},
-};
+use crate::{components::sync::SyncStatus, pages::router::Router};
 use namui_prebuilt::{
     button::{text_button, text_button_fit},
     *,
 };
-use std::sync::Arc;
 
 impl LoadedSequenceEditorPage {
     pub fn render_top_bar_for_player(&self, wh: Wh<Px>) -> RenderingTree {
@@ -48,9 +44,7 @@ impl LoadedSequenceEditorPage {
                 {
                     move |_| {
                         // TODO: Check saving finished
-                        namui::event::send(router::Event::Route(Arc::new(move || {
-                            router::Route::SequenceListPage(SequenceListPage::new(project_id))
-                        })));
+                        Router::move_to(format!("/sequence_list/{project_id}"));
                     }
                 },
             )

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/render/top_bar.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{components::sync::SyncStatus, pages::router::Router};
+use crate::{
+    components::sync::SyncStatus,
+    pages::router::{RoutePath, Router},
+};
 use namui_prebuilt::{
     button::{text_button, text_button_fit},
     *,
@@ -44,7 +47,7 @@ impl LoadedSequenceEditorPage {
                 {
                     move |_| {
                         // TODO: Check saving finished
-                        Router::move_to(format!("/sequence_list/{project_id}"));
+                        Router::move_to(RoutePath::SequenceList(project_id));
                     }
                 },
             )

--- a/luda-editor/client/src/pages/sequence_list_page/mod.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/mod.rs
@@ -251,7 +251,7 @@ impl SequenceListPage {
             [MouseButton::Left, MouseButton::Right],
             move |event| {
                 if event.button == Some(MouseButton::Left) {
-                    Router::move_to(format!("/sequence_edit/{sequence_id}"));
+                    Router::move_to(super::router::RoutePath::SequenceEdit(sequence_id));
                 } else if event.button == Some(MouseButton::Right) {
                     namui::event::send(Event::CellRightClick {
                         click_global_xy: event.global_xy,

--- a/luda-editor/client/src/pages/sequence_list_page/mod.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/mod.rs
@@ -1,11 +1,10 @@
 mod context_menu;
 mod rename_modal;
 
-use super::{router, sequence_edit_page::SequenceEditPage};
+use super::router::Router;
 use namui::prelude::*;
 use namui_prebuilt::*;
 use rpc::list_project_sequences::SequenceNameAndId;
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct SequenceListPage {
@@ -252,9 +251,7 @@ impl SequenceListPage {
             [MouseButton::Left, MouseButton::Right],
             move |event| {
                 if event.button == Some(MouseButton::Left) {
-                    namui::event::send(router::Event::Route(Arc::new(move || {
-                        router::Route::SequenceEditPage(SequenceEditPage::new(sequence_id))
-                    })));
+                    Router::move_to(format!("/sequence_edit/{sequence_id}"));
                 } else if event.button == Some(MouseButton::Right) {
                     namui::event::send(Event::CellRightClick {
                         click_global_xy: event.global_xy,


### PR DESCRIPTION
I added `wasm-bindgen` to luda-editor for subscribing `hashchange` event.
`hashchange` event will also be fired on forward/backward button of browser clicked.
so we can move between pages using forward/backward button.
If we don't need this feature, we can remove `wasm-bindgen`.