### PR TITLE
Trap keydown event in text_input

### DIFF
--- a/namui/src/namui/system/text_input/mod.rs
+++ b/namui/src/namui/system/text_input/mod.rs
@@ -51,6 +51,7 @@ impl TextInputSystem {
                         event.target().unwrap(),
                     )
                     .unwrap();
+
                     system::text_input::on_text_element_input(&target);
                 }) as Box<dyn FnMut(_)>)
                 .into_js_value()
@@ -62,7 +63,10 @@ impl TextInputSystem {
             .add_event_listener_with_callback(
                 "keydown",
                 Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
+                    event.stop_immediate_propagation();
                     let code = Code::from_str(&event.code()).unwrap();
+                    crate::keyboard::record_key_down(code);
+
                     // NOTE: Not support page up/down yet.
                     if [
                         Code::ArrowUp,


### PR DESCRIPTION
# What happened

- on keyboard Enter, I focused text_input
  - What I expected
    - Just focus text_input without text changes
  - What happened
    - text_input focused but also changed text (\n)

To prevent this problem, I trap the keydown event in text_input. This solve the problem.

Also removed alt_key checking on document.on_key_down because that was only for text_input. From now on, we don't need it.