### PR TITLE
Easy way to call [shift, ctrl, alt]_press()

### DIFF
--- a/namui/src/namui/system/keyboard.rs
+++ b/namui/src/namui/system/keyboard.rs
@@ -115,3 +115,13 @@ pub(crate) fn record_key_down(code: Code) {
     let mut pressing_code_set = KEYBOARD_SYSTEM.pressing_code_set.write().unwrap();
     pressing_code_set.insert(code);
 }
+
+pub fn shift_press() -> bool {
+    any_code_press([Code::ShiftLeft, Code::ShiftRight])
+}
+pub fn ctrl_press() -> bool {
+    any_code_press([Code::ControlLeft, Code::ControlRight])
+}
+pub fn alt_press() -> bool {
+    any_code_press([Code::AltLeft, Code::AltRight])
+}


### PR DESCRIPTION
There are many code which want to know whether shift key is pressed or not, but the problem is there are left and right shift key, so the code become longer than expect.
I put simple way to check shift, ctrl, alt key pressed.