### PR TITLE
Allow jump to tab with keyboard, fixing reset problem

### DIFF
--- a/namui/src/namui/system/keyboard.rs
+++ b/namui/src/namui/system/keyboard.rs
@@ -36,10 +36,26 @@ impl KeyboardSystem {
                         record_key_down(code);
 
                         let is_dev_tool_open_called = any_code_press([Code::F12])
-                            || (ctrl_press() && shift_press() && any_code_press([Code::KeyI]));
+                            || (event.ctrl_key()
+                                && event.shift_key()
+                                && any_code_press([Code::KeyI]));
                         let is_refresh_called = any_code_press([Code::F5])
-                            || (ctrl_press() && any_code_press([Code::KeyR]));
-                        if !is_dev_tool_open_called && !is_refresh_called {
+                            || (event.ctrl_key() && any_code_press([Code::KeyR]));
+                        let is_jump_to_tab_called = event.ctrl_key()
+                            && any_code_press([
+                                Code::Digit1,
+                                Code::Digit2,
+                                Code::Digit3,
+                                Code::Digit4,
+                                Code::Digit5,
+                                Code::Digit6,
+                                Code::Digit7,
+                                Code::Digit8,
+                                Code::Digit9,
+                                Code::Digit0,
+                            ]);
+                        if !is_dev_tool_open_called && !is_refresh_called && !is_jump_to_tab_called
+                        {
                             event.prevent_default();
                         }
 


### PR DESCRIPTION
This PR does 2 things

1. Allow `jump to tab` (ctrl + 0 ~ 9)
2. Use keyboard event's ctrl, alt, shift state for right pressing status.
  a. Without this change, user cannot jump out and in again because namui reset pressing keys on blur of window. try ctrl+1, ctrl+2, ctrl+1, ctrl+2.

I want to use second implementation for general cases with pressing_keys, but it's not possible for now. Browser doesn't give use enough information which key was pressed just before we jump to namui's tab. I hope browser supports that features later.