### PR TITLE
Fix wrong cache path

### DIFF
--- a/.github/actions/init-test-job/action.yml
+++ b/.github/actions/init-test-job/action.yml
@@ -16,14 +16,16 @@ runs:
       run: time rustup target add wasm32-unknown-unknown
 
     - uses: actions/cache@v3
-      id: namui-cli-rust-cache
+      id: rust-cache
       with:
         path: |
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          namui-cli/target/
+          ./**/target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('namui-cli/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+        
 
     - name: Get npm cache directory
       id: npm-cache-dir


### PR DESCRIPTION
I read some comment that `**/cargo.lock` doesn't work for cache path, but relative path would work(`./**/cargo.lock`), so I tested and it works!