### PR TITLE
Clip bounding box with transformed

### DIFF
--- a/namui/src/namui/render/rendering_tree/bounding_box.rs
+++ b/namui/src/namui/render/rendering_tree/bounding_box.rs
@@ -76,7 +76,9 @@ impl RenderingTree {
                         .and_then(|bounding_box| {
                             let path = clip.path_builder.build();
 
-                            let clip_bounding_box = path.get_bounding_box();
+                            let clip_bounding_box = path
+                                .get_bounding_box()
+                                .map(|bounding_box| matrix.transform_rect(bounding_box));
 
                             match clip.clip_op {
                                 ClipOp::Intersect => {


### PR DESCRIPTION
I tried to use table in scroll_view. But it was shown as follows.
*Red rect is bounding box
![before](https://user-images.githubusercontent.com/38313680/232237968-d776b84c-fb79-43fd-a303-33500b265e90.png)

After this pr. It will be shown as follows.
![after](https://user-images.githubusercontent.com/38313680/232238023-7639895a-78dc-409e-b570-d9a066a4926a.png)
