### PR TITLE
Hide always-on cg parts on cg picker

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_editor/render/part_picker.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_editor/render/part_picker.rs
@@ -5,7 +5,7 @@ use namui_prebuilt::{
     typography::{center_text, center_text_full_height},
     *,
 };
-use rpc::data::{CgFile, CgPart, CgPartVariant, ScreenCg};
+use rpc::data::{CgFile, CgPart, CgPartVariant, PartSelectionType, ScreenCg};
 use std::iter::once;
 use tooltip::*;
 
@@ -75,17 +75,23 @@ fn render_cg_part_group_list(
     screen_cg: &ScreenCg,
 ) -> RenderingTree {
     let cg_id = cg_file.id;
-    table::vertical(cg_file.parts.iter().flat_map(|cg_part| {
-        render_cg_part_group(
-            wh.width,
-            cg_part,
-            project_id,
-            cg_id,
-            cut_id,
-            graphic_index,
-            screen_cg,
-        )
-    }))(wh)
+    table::vertical(
+        cg_file
+            .parts
+            .iter()
+            .filter(|part| part.selection_type != PartSelectionType::AlwaysOn)
+            .flat_map(|cg_part| {
+                render_cg_part_group(
+                    wh.width,
+                    cg_part,
+                    project_id,
+                    cg_id,
+                    cut_id,
+                    graphic_index,
+                    screen_cg,
+                )
+            }),
+    )(wh)
 }
 
 fn render_cg_part_group<'a>(

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_editor/render/part_picker.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded/components/character_editor/render/part_picker.rs
@@ -97,76 +97,6 @@ fn render_cg_part_group<'a>(
     graphic_index: usize,
     screen_cg: &'a ScreenCg,
 ) -> Vec<TableCell<'a>> {
-    let title_bar = render_title_bar(cg_part);
-
-    let max_thumbnails_per_row = (width / (THUMBNAIL_WH.width)).floor() as usize;
-
-    match cg_part.selection_type {
-        rpc::data::PartSelectionType::AlwaysOn => once(title_bar)
-            .chain(render_thumbnail_rows(
-                cg_part,
-                max_thumbnails_per_row,
-                project_id,
-                cg_id,
-                cut_id,
-                graphic_index,
-                screen_cg,
-            ))
-            .chain(once(render_divider(BUTTON_HEIGHT)))
-            .collect(),
-        _ => once(title_bar)
-            .chain(render_thumbnail_rows_with_no_selection_button(
-                cg_part,
-                max_thumbnails_per_row,
-                project_id,
-                cg_id,
-                cut_id,
-                graphic_index,
-                screen_cg,
-            ))
-            .chain(once(render_divider(BUTTON_HEIGHT)))
-            .collect(),
-    }
-}
-
-fn render_thumbnail_rows<'a>(
-    cg_part: &'a CgPart,
-    max_thumbnails_per_row: usize,
-    project_id: Uuid,
-    cg_id: Uuid,
-    cut_id: Uuid,
-    graphic_index: usize,
-    screen_cg: &'a ScreenCg,
-) -> impl Iterator<Item = TableCell<'a>> {
-    let chunks = cg_part.variants.chunks(max_thumbnails_per_row);
-    let variant_rows = chunks.map(move |row| {
-        table::fixed(THUMBNAIL_WH.height, move |wh| {
-            table::horizontal(row.iter().map(|variant| {
-                render_thumbnail(
-                    cg_part,
-                    variant,
-                    project_id,
-                    cg_id,
-                    cut_id,
-                    graphic_index,
-                    screen_cg,
-                )
-            }))(wh)
-        })
-    });
-
-    variant_rows
-}
-
-fn render_thumbnail_rows_with_no_selection_button<'a>(
-    cg_part: &'a CgPart,
-    max_thumbnails_per_row: usize,
-    project_id: Uuid,
-    cg_id: Uuid,
-    cut_id: Uuid,
-    graphic_index: usize,
-    screen_cg: &'a ScreenCg,
-) -> impl Iterator<Item = TableCell<'a>> {
     let no_selection = !screen_cg
         .part_variants
         .iter()
@@ -177,9 +107,12 @@ fn render_thumbnail_rows_with_no_selection_button<'a>(
                 .any(|variant| variant.id == *selected_variant_id)
         });
 
+    let title_bar = render_title_bar(cg_part);
+
     let no_selection_button =
         render_no_selection_button(no_selection, cg_part, cut_id, graphic_index);
 
+    let max_thumbnails_per_row = (width / (THUMBNAIL_WH.width)).floor() as usize;
     let chunks = cg_part.variants.chunks_exact(max_thumbnails_per_row);
     let chunk_remainder = chunks.remainder();
     let last_variant_row = table::fixed(THUMBNAIL_WH.height, move |wh| {
@@ -200,7 +133,7 @@ fn render_thumbnail_rows_with_no_selection_button<'a>(
                 .chain(once(no_selection_button)),
         )(wh)
     });
-    let variant_rows = chunks.map(move |row| {
+    let variant_rows = chunks.map(|row| {
         table::fixed(THUMBNAIL_WH.height, move |wh| {
             table::horizontal(row.iter().map(|variant| {
                 render_thumbnail(
@@ -216,7 +149,11 @@ fn render_thumbnail_rows_with_no_selection_button<'a>(
         })
     });
 
-    variant_rows.chain(once(last_variant_row))
+    once(title_bar)
+        .chain(variant_rows)
+        .chain(once(last_variant_row))
+        .chain(once(render_divider(BUTTON_HEIGHT)))
+        .collect()
 }
 
 fn render_title_bar(cg_part: &CgPart) -> TableCell {


### PR DESCRIPTION
### Before
![image](https://github.com/NamseEnt/namseent/assets/38313680/77a56e03-801e-42f8-a042-7ceb2b502752)

### After
![image](https://github.com/NamseEnt/namseent/assets/38313680/4d4479b5-fe6f-439a-a1f5-55f25995ceed)
