### PR TITLE
Update makeShaderWithChildren function of canvaskit

### DIFF
--- a/namui/src/namui/skia/web/canvas_kit/runtime_effect.rs
+++ b/namui/src/namui/skia/web/canvas_kit/runtime_effect.rs
@@ -21,17 +21,14 @@ extern "C" {
 
     /// Returns a shader executed using the given uniform data and the children as inputs.
     /// @param uniforms
-    /// @param isOpaque
     /// @param children: should be CanvasKitShader
     /// @param localMatrix
-    ///
     #[wasm_bindgen(method)]
     pub(crate) fn makeShaderWithChildren(
         this: &CanvasKitRuntimeEffect,
         uniforms: &[f32],
-        isOpaque: Option<bool>,
         children: Option<Vec<JsValue>>,
-        // localMatrix: Option<InputMatrix>
+        // localMatrix: Option<InputMatrix>,
     ) -> CanvasKitShader;
 }
 

--- a/namui/src/namui/skia/web/runtime_effect.rs
+++ b/namui/src/namui/skia/web/runtime_effect.rs
@@ -20,11 +20,10 @@ impl RuntimeEffect {
             .into_iter()
             .map(|child| child.as_ref().canvas_kit_shader.clone())
             .collect();
-        Shader::new(self.canvas_kit_runtime_effect.makeShaderWithChildren(
-            uniforms,
-            Option::None,
-            Some(children),
-        ))
+        Shader::new(
+            self.canvas_kit_runtime_effect
+                .makeShaderWithChildren(uniforms, Some(children)),
+        )
     }
 }
 


### PR DESCRIPTION
`@param isOpaque` seems to be deprecated.