### PR TITLE
Release and publish in single workflow

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -62,7 +62,7 @@ jobs:
 
           export TAG="extension/$EXTENSION_VERSION"
           echo "Tag: $TAG"
-
+          echo "tag=123" >> "$GITHUB_OUTPUT"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "tag already exists";
           else

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'extension/*'
   pull_request:
 
 concurrency:
@@ -52,6 +50,7 @@ jobs:
         run: cargo test
 
       - name: create tag
+        id: tag
         if: success() && startsWith(github.ref, 'refs/heads/master')
         working-directory: extension
         run: |
@@ -69,14 +68,18 @@ jobs:
           else
             git tag -a "$TAG" -m "$TAG"
             git push origin "$TAG"
+            
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           fi
 
       - name: create release
-        if: success() && startsWith(github.ref, 'refs/tags/extension/')
+        if: success() && ${{ steps.tag.outputs.tag != '' }}
         uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
 
       - name: publish
-        if: success() && startsWith(github.ref, 'refs/tags/extension/')
+        if: success() && ${{ steps.tag.outputs.tag != '' }}
         working-directory: extension
         run: |
           npm install -g vsce

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -72,18 +72,14 @@ jobs:
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Test
-        id: test
-        run: echo "" >> "$GITHUB_OUTPUT"
-
       - name: create release
-        if: steps.test.outputs.set_tag
+        if: steps.tag.outputs.tag
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
 
       - name: publish
-        if: steps.test.outputs.set_tag
+        if: steps.tag.outputs.tag
         working-directory: extension
         run: |
           npm install -g vsce

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -73,16 +73,17 @@ jobs:
           fi
 
       - name: Test
+        id: test
         run: echo "set_tag=true" >> "$GITHUB_OUTPUT"
 
       - name: create release
-        if: steps.tag.outputs.set_tag
+        if: steps.test.outputs.set_tag
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
 
       - name: publish
-        if: steps.tag.outputs.set_tag
+        if: steps.test.outputs.set_tag
         working-directory: extension
         run: |
           npm install -g vsce

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -73,13 +73,13 @@ jobs:
           fi
 
       - name: create release
-        if: success() && ${{ steps.tag.outputs.tag }}
+        if: steps.tag.outputs.tag
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
 
       - name: publish
-        if: success() && ${{ steps.tag.outputs.tag }}
+        if: steps.tag.outputs.tag
         working-directory: extension
         run: |
           npm install -g vsce

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Test
         id: test
-        run: echo "set_tag=true" >> "$GITHUB_OUTPUT"
+        run: echo "set_tag=false" >> "$GITHUB_OUTPUT"
 
       - name: create release
         if: steps.test.outputs.set_tag

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: create tag
         id: tag
-        if: success() && startsWith(github.ref, 'refs/heads/master')
+        # if: success() && startsWith(github.ref, 'refs/heads/master')
         working-directory: extension
         run: |
           git config --local user.email ""
@@ -84,4 +84,4 @@ jobs:
         run: |
           npm install -g vsce
           npm install
-          npm run publish
+          # // npm run publish

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -73,16 +73,16 @@ jobs:
           fi
 
       - name: Test
-        run: echo "tag=123" >> "$GITHUB_OUTPUT"
+        run: echo "set_tag=true" >> "$GITHUB_OUTPUT"
 
       - name: create release
-        if: steps.tag.outputs.tag
+        if: steps.tag.outputs.set_tag
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
 
       - name: publish
-        if: steps.tag.outputs.tag
+        if: steps.tag.outputs.set_tag
         working-directory: extension
         run: |
           npm install -g vsce

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -73,13 +73,13 @@ jobs:
           fi
 
       - name: create release
-        if: success() && ${{ steps.tag.outputs.tag != '' }}
+        if: success() && ${{ steps.tag.outputs.tag }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
 
       - name: publish
-        if: success() && ${{ steps.tag.outputs.tag != '' }}
+        if: success() && ${{ steps.tag.outputs.tag }}
         working-directory: extension
         run: |
           npm install -g vsce

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -62,7 +62,7 @@ jobs:
 
           export TAG="extension/$EXTENSION_VERSION"
           echo "Tag: $TAG"
-          echo "tag=123" >> "$GITHUB_OUTPUT"
+
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "tag already exists";
           else
@@ -71,6 +71,9 @@ jobs:
             
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Test
+        run: echo "tag=123" >> "$GITHUB_OUTPUT"
 
       - name: create release
         if: steps.tag.outputs.tag

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Test
         id: test
-        run: echo "set_tag=false" >> "$GITHUB_OUTPUT"
+        run: echo "" >> "$GITHUB_OUTPUT"
 
       - name: create release
         if: steps.test.outputs.set_tag

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: create tag
         id: tag
-        # if: success() && startsWith(github.ref, 'refs/heads/master')
+        if: success() && startsWith(github.ref, 'refs/heads/master')
         working-directory: extension
         run: |
           git config --local user.email ""
@@ -84,4 +84,4 @@ jobs:
         run: |
           npm install -g vsce
           npm install
-          # // npm run publish
+          npm run publish


### PR DESCRIPTION
Github actions doesn't call another github actions in single github-token so this fucking workflows never invoke push:tag. si bal