### PR TITLE
Create bitmap without premultiply alpha

### DIFF
--- a/namui/src/namui/system/image.rs
+++ b/namui/src/namui/system/image.rs
@@ -96,7 +96,7 @@ extern "C" {
     pub type ImageBitmap;
 
     #[wasm_bindgen(js_namespace = globalThis, js_name = createImageBitmap)]
-    async fn create_image_bitmap(image: JsValue) -> JsValue;
+    async fn create_image_bitmap_with_option(image: JsValue, options: JsValue) -> JsValue;
 }
 
 unsafe impl Sync for ImageBitmap {}
@@ -118,7 +118,14 @@ pub async fn new_image_from_u8(data: &[u8]) -> Result<Arc<Image>, Box<dyn std::e
 }
 
 pub(crate) async fn blob_to_image(blob: web_sys::Blob) -> Arc<Image> {
-    let image_bitmap: ImageBitmap = create_image_bitmap(blob.into()).await.into();
+    let option = {
+        let option = js_sys::Object::new();
+        js_sys::Reflect::set(&option, &"premultiplyAlpha".into(), &"none".into()).unwrap();
+        option
+    };
+    let image_bitmap: ImageBitmap = create_image_bitmap_with_option(blob.into(), option.into())
+        .await
+        .into();
 
     let image = Image::from_image_bitmap(image_bitmap);
 


### PR DESCRIPTION
We create `Image` with `createImageBitmap()` and `CanvasKit.MakeLazyImageFromTextureSource()`.
Both functions premultiply alpha defaultly. It makes alpha image darker.
![image](https://github.com/NamseEnt/namseent/assets/38313680/b64d6027-bd77-4981-9cc7-f06630f8bb09)

This pr make `ImageBitmap` to be created without premultiply.