### PR TITLE
Strip whitespace of ignored project paths

### DIFF
--- a/cargo-check-and-fmt-all.py
+++ b/cargo-check-and-fmt-all.py
@@ -4,9 +4,12 @@ import os
 from platform import uname
 
 ignored_projects = list(
-    filter(
-        lambda line: not line.startswith("#"),
-        open(".ignored_projects", "r").readlines(),
+    map(
+        lambda line: line.strip(),
+        filter(
+            lambda line: not line.startswith("#"),
+            open(".ignored_projects", "r").readlines(),
+        )
     )
 )
 

--- a/cargo-clean-all.py
+++ b/cargo-clean-all.py
@@ -4,12 +4,14 @@ import os
 from platform import uname
 
 ignored_projects = list(
-    filter(
-        lambda line: not line.startswith("#"),
-        open(".ignored_projects", "r").readlines(),
+    map(
+        lambda line: line.strip(),
+        filter(
+            lambda line: not line.startswith("#"),
+            open(".ignored_projects", "r").readlines(),
+        )
     )
 )
-
 
 def in_wsl() -> bool:
     return "microsoft-standard" in uname().release

--- a/cargo-clean-check-fmt-all.py
+++ b/cargo-clean-check-fmt-all.py
@@ -4,9 +4,12 @@ import os
 from platform import uname
 
 ignored_projects = list(
-    filter(
-        lambda line: not line.startswith("#"),
-        open(".ignored_projects", "r").readlines(),
+    map(
+        lambda line: line.strip(),
+        filter(
+            lambda line: not line.startswith("#"),
+            open(".ignored_projects", "r").readlines(),
+        )
     )
 )
 

--- a/cargo-fix-fmt-all.py
+++ b/cargo-fix-fmt-all.py
@@ -4,9 +4,12 @@ import os
 from platform import uname
 
 ignored_projects = list(
-    filter(
-        lambda line: not line.startswith("#"),
-        open(".ignored_projects", "r").readlines(),
+    map(
+        lambda line: line.strip(),
+        filter(
+            lambda line: not line.startswith("#"),
+            open(".ignored_projects", "r").readlines(),
+        )
     )
 )
 

--- a/cargo-metadata-all.py
+++ b/cargo-metadata-all.py
@@ -4,9 +4,12 @@ import os
 from platform import uname
 
 ignored_projects = list(
-    filter(
-        lambda line: not line.startswith("#"),
-        open(".ignored_projects", "r").readlines(),
+    map(
+        lambda line: line.strip(),
+        filter(
+            lambda line: not line.startswith("#"),
+            open(".ignored_projects", "r").readlines(),
+        )
     )
 )
 

--- a/cargo-update-all.py
+++ b/cargo-update-all.py
@@ -4,9 +4,12 @@ import os
 from platform import uname
 
 ignored_projects = list(
-    filter(
-        lambda line: not line.startswith("#"),
-        open(".ignored_projects", "r").readlines(),
+    map(
+        lambda line: line.strip(),
+        filter(
+            lambda line: not line.startswith("#"),
+            open(".ignored_projects", "r").readlines(),
+        )
     )
 )
 


### PR DESCRIPTION
There was trailing `\n` in ignored_project paths.
This pr strips '\n'.
