### PR TITLE
Fix wrong block_on usage in namui-cli

### DIFF
--- a/namui-cli/src/main.rs
+++ b/namui-cli/src/main.rs
@@ -50,7 +50,7 @@ async fn main() {
         } => {
             let target = option_target.as_ref().unwrap_or(&current_target);
             let manifest_path = option_manifest_path.as_ref().unwrap_or(&manifest_path);
-            procedures::build(&target, &manifest_path, arch.into())
+            procedures::build(&target, &manifest_path, arch.into()).await
         }
     };
 

--- a/namui-cli/src/procedures/build/mod.rs
+++ b/namui-cli/src/procedures/build/mod.rs
@@ -2,7 +2,7 @@ use crate::*;
 use crate::{cli::Target, services::electron_package_service};
 use std::path::PathBuf;
 
-pub fn build(
+pub async fn build(
     target: &Target,
     manifest_path: &PathBuf,
     arch: Option<electron_package_service::Arch>,
@@ -12,11 +12,13 @@ pub fn build(
     if cfg!(target_os = "linux") {
         use super::linux;
         match target {
-            Target::WasmUnknownWeb => linux::wasm_unknown_web::build(&manifest_path),
+            Target::WasmUnknownWeb => linux::wasm_unknown_web::build(&manifest_path).await,
             Target::WasmWindowsElectron => {
-                linux::wasm_windows_electron::build(&manifest_path, arch)
+                linux::wasm_windows_electron::build(&manifest_path, arch).await
             }
-            Target::WasmLinuxElectron => linux::wasm_linux_electron::build(&manifest_path, arch),
+            Target::WasmLinuxElectron => {
+                linux::wasm_linux_electron::build(&manifest_path, arch).await
+            }
         }
     } else {
         Result::Err(anyhow!("{} is unsupported os", std::env::consts::OS).into())

--- a/namui-cli/src/procedures/linux/wasm_linux_electron/build.rs
+++ b/namui-cli/src/procedures/linux/wasm_linux_electron/build.rs
@@ -5,6 +5,6 @@ use crate::services::{
 use crate::*;
 use std::path::Path;
 
-pub fn build(manifest_path: &Path, arch: Option<Arch>) -> Result<()> {
-    electron_build_service::build(manifest_path, arch, Platform::Linux)
+pub async fn build(manifest_path: &Path, arch: Option<Arch>) -> Result<()> {
+    electron_build_service::build(manifest_path, arch, Platform::Linux).await
 }

--- a/namui-cli/src/procedures/linux/wasm_unknown_web/build.rs
+++ b/namui-cli/src/procedures/linux/wasm_unknown_web/build.rs
@@ -5,10 +5,9 @@ use crate::{
     cli::Target,
     services::{resource_collect_service, wasm_watch_build_service::WasmWatchBuildService},
 };
-use futures::executor::block_on;
 use std::path::Path;
 
-pub fn build(manifest_path: &Path) -> Result<()> {
+pub async fn build(manifest_path: &Path) -> Result<()> {
     let project_root_path = manifest_path.parent().unwrap().to_path_buf();
     let release_path = project_root_path
         .join("target")
@@ -16,14 +15,13 @@ pub fn build(manifest_path: &Path) -> Result<()> {
         .join("wasm_unknown_web");
 
     let build_status_service = BuildStatusService::new();
-    block_on(WasmWebRuntimeWatchBuildService::just_build(
-        build_status_service.clone(),
-    ))?;
-    block_on(WasmWatchBuildService::just_build(
+    WasmWebRuntimeWatchBuildService::just_build(build_status_service.clone()).await?;
+    WasmWatchBuildService::just_build(
         build_status_service,
         project_root_path.clone(),
         Target::WasmUnknownWeb,
-    ))?;
+    )
+    .await?;
 
     let bundle_manifest =
         crate::services::bundle::NamuiBundleManifest::parse(project_root_path.clone())?;

--- a/namui-cli/src/procedures/linux/wasm_windows_electron/build.rs
+++ b/namui-cli/src/procedures/linux/wasm_windows_electron/build.rs
@@ -5,6 +5,6 @@ use crate::services::{
 use crate::*;
 use std::path::Path;
 
-pub fn build(manifest_path: &Path, arch: Option<Arch>) -> Result<()> {
-    electron_build_service::build(manifest_path, arch, Platform::Win32)
+pub async fn build(manifest_path: &Path, arch: Option<Arch>) -> Result<()> {
+    electron_build_service::build(manifest_path, arch, Platform::Win32).await
 }

--- a/namui-cli/src/services/electron_build_service.rs
+++ b/namui-cli/src/services/electron_build_service.rs
@@ -5,10 +5,9 @@ use super::{
 };
 use crate::cli::Target;
 use crate::*;
-use futures::executor::block_on;
 use std::path::Path;
 
-pub fn build(manifest_path: &Path, arch: Option<Arch>, platform: Platform) -> Result<()> {
+pub async fn build(manifest_path: &Path, arch: Option<Arch>, platform: Platform) -> Result<()> {
     let project_root_path = manifest_path.parent().unwrap().to_path_buf();
     let build_status_service = BuildStatusService::new();
 
@@ -28,11 +27,8 @@ pub fn build(manifest_path: &Path, arch: Option<Arch>, platform: Platform) -> Re
         arch = package_result.arch
     ));
 
-    block_on(WasmWatchBuildService::just_build(
-        build_status_service,
-        project_root_path.clone(),
-        target,
-    ))?;
+    WasmWatchBuildService::just_build(build_status_service, project_root_path.clone(), target)
+        .await?;
 
     let namui_bundle_manifest =
         super::bundle::NamuiBundleManifest::parse(project_root_path.clone())?;

--- a/namui-cli/src/services/wasm_watch_build_service.rs
+++ b/namui-cli/src/services/wasm_watch_build_service.rs
@@ -9,7 +9,6 @@ use crate::{
     services::build_status_service::{BuildStatusCategory, BuildStatusService},
     *,
 };
-use futures::executor::block_on;
 use std::{path::PathBuf, sync::Arc};
 use tokio::try_join;
 
@@ -196,11 +195,13 @@ impl WasmWatchBuildService {
             .await
         {
             BuildResult::Successful(cargo_build_result) => {
-                block_on(build_status_service.build_finished(
-                    BuildStatusCategory::WebRuntime,
-                    cargo_build_result.error_messages,
-                    vec![],
-                ));
+                build_status_service
+                    .build_finished(
+                        BuildStatusCategory::WebRuntime,
+                        cargo_build_result.error_messages,
+                        vec![],
+                    )
+                    .await;
                 Ok(())
             }
             BuildResult::Canceled => unreachable!(),


### PR DESCRIPTION
Don't use futures block_on on tokio runtime