### PR TITLE
Fix DeleteGraphic action to keep graphic order

### DIFF
--- a/luda-editor/rpc/src/data/cut_update_action.rs
+++ b/luda-editor/rpc/src/data/cut_update_action.rs
@@ -192,7 +192,7 @@ impl CutUpdateAction {
                     .iter()
                     .position(|(index, _)| *index == graphic_index)
                 {
-                    cut.screen_graphics.swap_remove(position);
+                    cut.screen_graphics.remove(position);
                 }
             }
         }


### PR DESCRIPTION
I used `swap_remove()` on `cut.screen_graphics` because I just heard It is faster than `remove()`.
But `swap_remove()` changes `cut.screen_graphics`'s order.