### PR TITLE
No linebreak for server logs

### DIFF
--- a/luda-editor/server/server-core/src/handle/mod.rs
+++ b/luda-editor/server/server-core/src/handle/mod.rs
@@ -28,7 +28,7 @@ pub async fn handle_with_wrapped_error(
             Ok(response)
         }
         Err(error) => {
-            eprintln!("{:#?}", error);
+            eprintln!("{:?}", error);
             Ok(Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(Body::from(error.to_string()))

--- a/luda-editor/server/server-core/src/session/mod.rs
+++ b/luda-editor/server/server-core/src/session/mod.rs
@@ -36,7 +36,7 @@ pub async fn get_session(req: &Request<Body>) -> Result<Option<SessionDocument>,
             }
             crate::storage::dynamo_db::GetItemError::DeserializeFailed(_)
             | crate::storage::dynamo_db::GetItemError::Unknown(_) => {
-                eprintln!("fail to get session from dynamo db: {:#?}", error);
+                eprintln!("fail to get session from dynamo db: {:?}", error);
                 Err(GetSessionError::Unknown(error.to_string()))
             }
         },

--- a/luda-editor/server/server-core/src/storage/dynamo_db/singular.rs
+++ b/luda-editor/server/server-core/src/storage/dynamo_db/singular.rs
@@ -31,7 +31,7 @@ impl DynamoDb {
             .await;
 
         if let Err(error) = result {
-            eprintln!("error on get_item_internal: {:#?}", error);
+            eprintln!("error on get_item_internal: {:?}", error);
             return Err(GetItemInternalError::Unknown(error.to_string()));
         }
         let item = result.unwrap().item;

--- a/luda-editor/server/server-core/src/storage/dynamo_db/transact.rs
+++ b/luda-editor/server/server-core/src/storage/dynamo_db/transact.rs
@@ -71,7 +71,7 @@ impl<TCancelError: std::error::Error + Send> Transact<TCancelError> {
             .send()
             .await;
         if let Err(error) = result {
-            eprintln!("error on transact: {:#?}", error);
+            eprintln!("error on transact: {:?}", error);
             return Err(TransactError::Unknown(error.to_string()));
         }
         Ok(())


### PR DESCRIPTION
It's difficult to debug on cloud watch logs 
![image](https://github.com/NamseEnt/namseent/assets/3580430/0e0dbb37-76d7-4dbc-94ef-46206f0bf16f)
