### PR TITLE
Restore image resource name parsing

### DIFF
--- a/luda-editor/psd/src/sections/image_resources_section.rs
+++ b/luda-editor/psd/src/sections/image_resources_section.rs
@@ -84,6 +84,7 @@ impl ImageResourcesSection {
         }
 
         let resource_id = cursor.read_i16();
+        let _name = cursor.read_pascal_string();
 
         let data_len = cursor.read_u32();
         let pos = cursor.position() as usize;

--- a/luda-editor/psd/src/sections/mod.rs
+++ b/luda-editor/psd/src/sections/mod.rs
@@ -289,6 +289,23 @@ impl<'a> PsdCursor<'a> {
             &[] as &[u8]
         }
     }
+
+    /// Reads 'Pascal string'
+    ///
+    /// Pascal string is UTF-8 string, padded to make the size even
+    /// (a null name consists of two bytes of 0)
+    pub fn read_pascal_string(&mut self) -> String {
+        let len = self.read_u8();
+        let data = self.read(len as u32);
+        let result = String::from_utf8_lossy(data).into_owned();
+
+        if len % 2 == 0 {
+            // If the total length is odd, read an extra null byte
+            self.read_u8();
+        }
+
+        result
+    }
 }
 
 fn u8_slice_to_u16(bytes: &[u8]) -> Vec<u16> {


### PR DESCRIPTION
We had psd parsing problem. https://namseent.zulipchat.com/#narrow/stream/332914-.EA.B8.B0.EC.88.A0.EC.97.B0.EA.B5.AC.EC.86.8C/topic/.E2.9C.94.20psd-parsing-problem

I made a mistake removing image resource name parsing at https://github.com/NamseEnt/namseent/commit/d353bf0517572fb3162f0707dac907d74d65f018#diff-0e209d1a09f8eee1ed5c699c1df7b0fd7546320b7a6ee41f852021045eb380b3L88 , in PR #609 

This PR Restore broken parsing part