### PR TITLE
Prevent change order to after itself

### DIFF
--- a/luda-editor/client/src/pages/sequence_edit_page/components/cut_list_view/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/cut_list_view/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 use cut_cell::*;
 use namui::prelude::*;
 use namui_prebuilt::*;
-use rpc::data::{Cut, Memo};
+use rpc::data::{Cut, Memo, MoveCutAction};
 use std::collections::HashMap;
 
 static DRAGGING_CONTEXT: Atom<Option<DraggingContext>> = Atom::uninitialized_new();
@@ -156,17 +156,8 @@ impl Component for CutListView<'_> {
                     .checked_sub(1)
                     .and_then(|index| cuts.get(index))
                     .map(|cut| cut.id);
-
-                match after_cut_id {
-                    Some(after_cut_id) if after_cut_id == dragging.cut_id => {}
-                    _ => {
-                        SEQUENCE_ATOM.mutate(move |sequence| {
-                            sequence.update(rpc::data::SequenceUpdateAction::MoveCut {
-                                cut_id: dragging.cut_id,
-                                after_cut_id,
-                            })
-                        });
-                    }
+                if let Ok(move_cut_action) = MoveCutAction::new(dragging.cut_id, after_cut_id) {
+                    SEQUENCE_ATOM.mutate(move |sequence| sequence.update(move_cut_action.into()));
                 }
             }
             set_dragging.set(None);

--- a/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/mod.rs
@@ -66,10 +66,9 @@ impl Component for GraphicListView<'_> {
                     .and_then(|position| graphics.get(position))
                     .map(|(index, _)| *index);
 
-                let change_graphic_order_action =
-                    ChangeGraphicOrderAction::new(dragging.graphic_index, after_graphic_index);
-
-                if let Ok(change_graphic_order_action) = change_graphic_order_action {
+                if let Ok(change_graphic_order_action) =
+                    ChangeGraphicOrderAction::new(dragging.graphic_index, after_graphic_index)
+                {
                     SEQUENCE_ATOM.mutate(move |sequence| {
                         sequence.update_cut(
                             cut_id,

--- a/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use namui::prelude::*;
 use namui_prebuilt::{scroll_view, simple_rect, table};
+use rpc::data::ChangeGraphicOrderAction;
 
 #[component]
 pub struct GraphicListView<'a> {
@@ -65,19 +66,18 @@ impl Component for GraphicListView<'_> {
                     .and_then(|position| graphics.get(position))
                     .map(|(index, _)| *index);
 
-                match after_graphic_index {
-                    Some(after_graphic_index) if after_graphic_index == dragging.graphic_index => {}
-                    _ => {
-                        SEQUENCE_ATOM.mutate(move |sequence| {
-                            sequence.update_cut(
-                                cut_id,
-                                rpc::data::CutUpdateAction::ChangeGraphicOrder {
-                                    graphic_index: dragging.graphic_index,
-                                    after_graphic_index,
-                                },
-                            );
-                        });
-                    }
+                let change_graphic_order_action =
+                    ChangeGraphicOrderAction::new(dragging.graphic_index, after_graphic_index);
+
+                if let Ok(change_graphic_order_action) = change_graphic_order_action {
+                    SEQUENCE_ATOM.mutate(move |sequence| {
+                        sequence.update_cut(
+                            cut_id,
+                            rpc::data::CutUpdateAction::ChangeGraphicOrder(
+                                change_graphic_order_action,
+                            ),
+                        );
+                    })
                 }
             };
             set_dragging.set(None);

--- a/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
@@ -65,10 +65,9 @@ impl SequenceWrapped {
                         sequence.cuts.swap_remove(position);
                     }
                 }
-                rpc::data::SequenceUpdateAction::MoveCut {
-                    cut_id,
-                    after_cut_id,
-                } => {
+                rpc::data::SequenceUpdateAction::MoveCut(move_cut_action) => {
+                    let cut_id = move_cut_action.cut_id();
+                    let after_cut_id = move_cut_action.after_cut_id();
                     let moving_cut_position = sequence
                         .cuts
                         .iter()

--- a/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
@@ -68,27 +68,30 @@ impl SequenceWrapped {
                 rpc::data::SequenceUpdateAction::MoveCut {
                     cut_id,
                     after_cut_id,
-                } => {
-                    let moving_cut_position = sequence
-                        .cuts
-                        .iter()
-                        .position(|cut| cut.id == cut_id)
-                        .unwrap();
-                    let moving_cut = sequence.cuts.remove(moving_cut_position);
-                    let insert_position = match after_cut_id {
-                        Some(after_cut_id) => {
-                            let position = sequence
-                                .cuts
-                                .iter()
-                                .position(|cut| cut.id == after_cut_id)
-                                .unwrap();
-                            position + 1
-                        }
-                        None => 0,
-                    };
+                } => match after_cut_id {
+                    Some(after_cut_id) if after_cut_id == cut_id => {}
+                    after_cut_id => {
+                        let moving_cut_position = sequence
+                            .cuts
+                            .iter()
+                            .position(|cut| cut.id == cut_id)
+                            .unwrap();
+                        let moving_cut = sequence.cuts.remove(moving_cut_position);
+                        let insert_position = match after_cut_id {
+                            Some(after_cut_id) => {
+                                let position = sequence
+                                    .cuts
+                                    .iter()
+                                    .position(|cut| cut.id == after_cut_id)
+                                    .unwrap();
+                                position + 1
+                            }
+                            None => 0,
+                        };
 
-                    sequence.cuts.insert(insert_position, moving_cut);
-                }
+                        sequence.cuts.insert(insert_position, moving_cut);
+                    }
+                },
                 rpc::data::SequenceUpdateAction::SplitCutText {
                     cut_id,
                     new_cut_id,

--- a/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
@@ -3,7 +3,7 @@ mod syncer;
 
 use self::{history::*, syncer::*};
 use namui::Uuid;
-use rpc::data::{CutUpdateAction, Sequence};
+use rpc::data::{CutUpdateAction, MoveCutAction, Sequence};
 
 const MAX_EDIT_HISTORY: usize = 8;
 
@@ -65,9 +65,11 @@ impl SequenceWrapped {
                         sequence.cuts.swap_remove(position);
                     }
                 }
-                rpc::data::SequenceUpdateAction::MoveCut(move_cut_action) => {
-                    let cut_id = move_cut_action.cut_id();
-                    let after_cut_id = move_cut_action.after_cut_id();
+                rpc::data::SequenceUpdateAction::MoveCut(MoveCutAction {
+                    cut_id,
+                    after_cut_id,
+                    ..
+                }) => {
                     let moving_cut_position = sequence
                         .cuts
                         .iter()

--- a/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
@@ -68,30 +68,30 @@ impl SequenceWrapped {
                 rpc::data::SequenceUpdateAction::MoveCut {
                     cut_id,
                     after_cut_id,
-                } => match after_cut_id {
-                    Some(after_cut_id) if after_cut_id == cut_id => {}
-                    after_cut_id => {
-                        let moving_cut_position = sequence
-                            .cuts
-                            .iter()
-                            .position(|cut| cut.id == cut_id)
-                            .unwrap();
-                        let moving_cut = sequence.cuts.remove(moving_cut_position);
-                        let insert_position = match after_cut_id {
-                            Some(after_cut_id) => {
-                                let position = sequence
-                                    .cuts
-                                    .iter()
-                                    .position(|cut| cut.id == after_cut_id)
-                                    .unwrap();
-                                position + 1
-                            }
-                            None => 0,
-                        };
-
-                        sequence.cuts.insert(insert_position, moving_cut);
+                } => {
+                    if after_cut_id == Some(cut_id) {
+                        return;
                     }
-                },
+                    let moving_cut_position = sequence
+                        .cuts
+                        .iter()
+                        .position(|cut| cut.id == cut_id)
+                        .unwrap();
+                    let moving_cut = sequence.cuts.remove(moving_cut_position);
+                    let insert_position = match after_cut_id {
+                        Some(after_cut_id) => {
+                            let position = sequence
+                                .cuts
+                                .iter()
+                                .position(|cut| cut.id == after_cut_id)
+                                .unwrap();
+                            position + 1
+                        }
+                        None => 0,
+                    };
+
+                    sequence.cuts.insert(insert_position, moving_cut);
+                }
                 rpc::data::SequenceUpdateAction::SplitCutText {
                     cut_id,
                     new_cut_id,

--- a/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
@@ -70,7 +70,7 @@ impl SequenceWrapped {
                     after_cut_id,
                 } => {
                     if after_cut_id == Some(cut_id) {
-                        return;
+                        panic!("Cannot move cut after itself");
                     }
                     let moving_cut_position = sequence
                         .cuts

--- a/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/sequence/mod.rs
@@ -69,9 +69,6 @@ impl SequenceWrapped {
                     cut_id,
                     after_cut_id,
                 } => {
-                    if after_cut_id == Some(cut_id) {
-                        panic!("Cannot move cut after itself");
-                    }
                     let moving_cut_position = sequence
                         .cuts
                         .iter()

--- a/luda-editor/rpc/src/data/cut_update_action.rs
+++ b/luda-editor/rpc/src/data/cut_update_action.rs
@@ -203,10 +203,8 @@ impl CutUpdateAction {
                 graphic_index,
                 after_graphic_index,
             } => {
-                if let Some(after_graphic_index) = after_graphic_index {
-                    if after_graphic_index == graphic_index {
-                        return;
-                    }
+                if after_graphic_index == Some(graphic_index) {
+                    panic!("Cannot move cut after itself");
                 }
                 let Some(moving_graphic_position) = cut
                     .screen_graphics

--- a/luda-editor/rpc/src/data/cut_update_action.rs
+++ b/luda-editor/rpc/src/data/cut_update_action.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use super::*;
 use crate::simple_error_impl;
 use namui_type::Uuid;
@@ -58,8 +60,9 @@ pub enum CutUpdateAction {
 }
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ChangeGraphicOrderAction {
-    pub(crate) graphic_index: Uuid,
-    pub(crate) after_graphic_index: Option<Uuid>,
+    pub graphic_index: Uuid,
+    pub after_graphic_index: Option<Uuid>,
+    prevent_direct_creation: PhantomData<()>,
 }
 impl ChangeGraphicOrderAction {
     pub fn new(
@@ -72,6 +75,7 @@ impl ChangeGraphicOrderAction {
         Ok(Self {
             graphic_index,
             after_graphic_index,
+            prevent_direct_creation: PhantomData,
         })
     }
 }
@@ -229,6 +233,7 @@ impl CutUpdateAction {
             CutUpdateAction::ChangeGraphicOrder(ChangeGraphicOrderAction {
                 graphic_index,
                 after_graphic_index,
+                ..
             }) => {
                 let Some(moving_graphic_position) = cut
                     .screen_graphics

--- a/luda-editor/rpc/src/data/cut_update_action.rs
+++ b/luda-editor/rpc/src/data/cut_update_action.rs
@@ -203,6 +203,11 @@ impl CutUpdateAction {
                 graphic_index,
                 after_graphic_index,
             } => {
+                if let Some(after_graphic_index) = after_graphic_index {
+                    if after_graphic_index == graphic_index {
+                        return;
+                    }
+                }
                 let Some(moving_graphic_position) = cut
                     .screen_graphics
                     .iter()

--- a/luda-editor/rpc/src/data/cut_update_action.rs
+++ b/luda-editor/rpc/src/data/cut_update_action.rs
@@ -75,9 +75,9 @@ impl ChangeGraphicOrderAction {
         })
     }
 }
-impl Into<CutUpdateAction> for ChangeGraphicOrderAction {
-    fn into(self) -> CutUpdateAction {
-        CutUpdateAction::ChangeGraphicOrder(self)
+impl From<ChangeGraphicOrderAction> for CutUpdateAction {
+    fn from(value: ChangeGraphicOrderAction) -> Self {
+        Self::ChangeGraphicOrder(value)
     }
 }
 simple_error_impl!(ChangeGraphicOrderActionCreateError);

--- a/luda-editor/rpc/src/data/sequence_update_action.rs
+++ b/luda-editor/rpc/src/data/sequence_update_action.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::simple_error_impl;
 use namui_type::Uuid;
+use std::marker::PhantomData;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum SequenceUpdateAction {
@@ -23,8 +24,9 @@ pub enum SequenceUpdateAction {
 }
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MoveCutAction {
-    cut_id: Uuid,
-    after_cut_id: Option<Uuid>,
+    pub cut_id: Uuid,
+    pub after_cut_id: Option<Uuid>,
+    _prevent_direct_creation: PhantomData<()>,
 }
 impl MoveCutAction {
     pub fn new(cut_id: Uuid, after_cut_id: Option<Uuid>) -> Result<Self, MoveCutActionCreateError> {
@@ -34,13 +36,8 @@ impl MoveCutAction {
         Ok(Self {
             cut_id,
             after_cut_id,
+            _prevent_direct_creation: PhantomData,
         })
-    }
-    pub fn cut_id(&self) -> Uuid {
-        self.cut_id
-    }
-    pub fn after_cut_id(&self) -> Option<Uuid> {
-        self.after_cut_id
     }
 }
 impl From<MoveCutAction> for SequenceUpdateAction {

--- a/luda-editor/rpc/src/data/sequence_update_action.rs
+++ b/luda-editor/rpc/src/data/sequence_update_action.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::simple_error_impl;
 use namui_type::Uuid;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -13,13 +14,42 @@ pub enum SequenceUpdateAction {
     DeleteCut {
         cut_id: Uuid,
     },
-    MoveCut {
-        cut_id: Uuid,
-        after_cut_id: Option<Uuid>,
-    },
     SplitCutText {
         cut_id: Uuid,
         new_cut_id: Uuid,
         split_at: usize,
     },
+    MoveCut(MoveCutAction),
+}
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MoveCutAction {
+    cut_id: Uuid,
+    after_cut_id: Option<Uuid>,
+}
+impl MoveCutAction {
+    pub fn new(cut_id: Uuid, after_cut_id: Option<Uuid>) -> Result<Self, MoveCutActionCreateError> {
+        if after_cut_id == Some(cut_id) {
+            return Err(MoveCutActionCreateError::MoveAfterItself);
+        }
+        Ok(Self {
+            cut_id,
+            after_cut_id,
+        })
+    }
+    pub fn cut_id(&self) -> Uuid {
+        self.cut_id
+    }
+    pub fn after_cut_id(&self) -> Option<Uuid> {
+        self.after_cut_id
+    }
+}
+impl Into<SequenceUpdateAction> for MoveCutAction {
+    fn into(self) -> SequenceUpdateAction {
+        SequenceUpdateAction::MoveCut(self)
+    }
+}
+simple_error_impl!(MoveCutActionCreateError);
+#[derive(Debug)]
+pub enum MoveCutActionCreateError {
+    MoveAfterItself,
 }

--- a/luda-editor/rpc/src/data/sequence_update_action.rs
+++ b/luda-editor/rpc/src/data/sequence_update_action.rs
@@ -43,9 +43,9 @@ impl MoveCutAction {
         self.after_cut_id
     }
 }
-impl Into<SequenceUpdateAction> for MoveCutAction {
-    fn into(self) -> SequenceUpdateAction {
-        SequenceUpdateAction::MoveCut(self)
+impl From<MoveCutAction> for SequenceUpdateAction {
+    fn from(value: MoveCutAction) -> Self {
+        Self::MoveCut(value)
     }
 }
 simple_error_impl!(MoveCutActionCreateError);

--- a/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
+++ b/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
@@ -87,10 +87,9 @@ pub async fn update_sequence(
             sequence_document.cuts.remove(cut_position);
             transact
         }
-        rpc::data::SequenceUpdateAction::MoveCut {
-            cut_id,
-            after_cut_id,
-        } => {
+        rpc::data::SequenceUpdateAction::MoveCut(move_cut_action) => {
+            let cut_id = move_cut_action.cut_id();
+            let after_cut_id = move_cut_action.after_cut_id();
             let moving_cut_position = sequence_document
                 .cuts
                 .iter()

--- a/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
+++ b/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
@@ -90,9 +90,9 @@ pub async fn update_sequence(
         rpc::data::SequenceUpdateAction::MoveCut {
             cut_id,
             after_cut_id,
-        } => 'handle_move_cut_action: {
+        } => {
             if after_cut_id == Some(cut_id) {
-                break 'handle_move_cut_action transact;
+                return Err(Error::Unknown("Cannot move cut after itself".to_string()));
             }
             let moving_cut_position = sequence_document
                 .cuts

--- a/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
+++ b/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
@@ -91,9 +91,6 @@ pub async fn update_sequence(
             cut_id,
             after_cut_id,
         } => {
-            if after_cut_id == Some(cut_id) {
-                return Err(Error::Unknown("Cannot move cut after itself".to_string()));
-            }
             let moving_cut_position = sequence_document
                 .cuts
                 .iter()

--- a/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
+++ b/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
@@ -1,5 +1,8 @@
 use crate::documents::*;
-use rpc::update_sequence::{Error, Request, Response};
+use rpc::{
+    data::MoveCutAction,
+    update_sequence::{Error, Request, Response},
+};
 
 pub async fn update_sequence(
     session: Option<SessionDocument>,
@@ -87,9 +90,11 @@ pub async fn update_sequence(
             sequence_document.cuts.remove(cut_position);
             transact
         }
-        rpc::data::SequenceUpdateAction::MoveCut(move_cut_action) => {
-            let cut_id = move_cut_action.cut_id();
-            let after_cut_id = move_cut_action.after_cut_id();
+        rpc::data::SequenceUpdateAction::MoveCut(MoveCutAction {
+            cut_id,
+            after_cut_id,
+            ..
+        }) => {
             let moving_cut_position = sequence_document
                 .cuts
                 .iter()

--- a/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
+++ b/luda-editor/server/server-core/src/apis/sequence/update_sequence.rs
@@ -91,25 +91,30 @@ pub async fn update_sequence(
             cut_id,
             after_cut_id,
         } => {
-            let moving_cut_position = sequence_document
-                .cuts
-                .iter()
-                .position(|cut| cut.cut_id == cut_id)
-                .unwrap();
-            let moving_cut = sequence_document.cuts.remove(moving_cut_position);
-            let insert_position = match after_cut_id {
-                Some(after_cut_id) => {
-                    let position = sequence_document
+            match after_cut_id {
+                Some(after_cut_id) if after_cut_id == cut_id => {}
+                after_cut_id => {
+                    let moving_cut_position = sequence_document
                         .cuts
                         .iter()
-                        .position(|cut| cut.cut_id == after_cut_id)
+                        .position(|cut| cut.cut_id == cut_id)
                         .unwrap();
-                    position + 1
-                }
-                None => 0,
-            };
+                    let moving_cut = sequence_document.cuts.remove(moving_cut_position);
+                    let insert_position = match after_cut_id {
+                        Some(after_cut_id) => {
+                            let position = sequence_document
+                                .cuts
+                                .iter()
+                                .position(|cut| cut.cut_id == after_cut_id)
+                                .unwrap();
+                            position + 1
+                        }
+                        None => 0,
+                    };
 
-            sequence_document.cuts.insert(insert_position, moving_cut);
+                    sequence_document.cuts.insert(insert_position, moving_cut);
+                }
+            }
             transact
         }
         rpc::data::SequenceUpdateAction::SplitCutText {


### PR DESCRIPTION
Order changing functions works like
1. Remove self
2. Insert self after `after_*`

If `after_*` is indicating self, Inserting after `after_*` is impossible because self is already removed.
So ignore order change request if `after_*` is indicating self.
