### PR TITLE
Fix new image to be created with zero rotation

### DIFF
--- a/luda-editor/rpc/src/data/screen_graphic/v1.rs
+++ b/luda-editor/rpc/src/data/screen_graphic/v1.rs
@@ -62,7 +62,7 @@ impl ScreenImage {
                 center_xy: Xy::new(50.percent(), 50.percent()),
                 radius: 50.percent(),
             },
-            rotation: Angle::Degree(25.0),
+            rotation: Angle::Degree(0.0),
         }
     }
     pub fn migrate(previous: v0::ScreenImage) -> Self {


### PR DESCRIPTION
It was for testing when I working on rotation feature, but it was not restored at that time.