### PR TITLE
Add user acl management page

### DIFF
--- a/luda-editor/client/src/pages/mod.rs
+++ b/luda-editor/client/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod graphic_asset_manage_page;
+pub mod project_acl_manage_page;
 pub mod project_list_page;
 pub mod router;
 pub mod sequence_edit_page;

--- a/luda-editor/client/src/pages/project_acl_manage_page/mod.rs
+++ b/luda-editor/client/src/pages/project_acl_manage_page/mod.rs
@@ -1,0 +1,315 @@
+mod top_bar;
+
+use crate::app::notification::push_notification;
+use crate::color;
+use crate::{app::notification::Notification, RPC};
+use namui::prelude::*;
+use namui::text_input::Style;
+use namui_prebuilt::button::TextButton;
+use namui_prebuilt::list_view::AutoListView;
+use namui_prebuilt::typography;
+use namui_prebuilt::{simple_rect, table::hooks::*};
+use rpc::list_user_acls::UserAcl;
+use rpc::types::ProjectAclUserPermission;
+use std::fmt::Write;
+use std::ops::Deref;
+use top_bar::TopBar;
+
+const BUTTON_WIDTH: Px = px(128.0);
+
+#[namui::component]
+pub struct ProjectAclManagePage {
+    pub wh: Wh<Px>,
+    pub project_id: Uuid,
+}
+
+impl Component for ProjectAclManagePage {
+    fn render(self, ctx: &RenderCtx) -> RenderDone {
+        let Self { wh, project_id } = self;
+
+        const TOP_BAR_HEIGHT: Px = px(48.0);
+        const MAX_LIST_WIDTH: Px = px(768.0);
+        const ITEM_HEIGHT: Px = px(36.0);
+        const SCROLL_BAR_WIDTH: Px = px(4.0);
+
+        let project_id = ctx.track_eq(&project_id);
+        let list_width = wh.width.min(MAX_LIST_WIDTH);
+        let (acls, set_acls) = ctx.state::<Vec<rpc::list_user_acls::UserAcl>>(Vec::new);
+
+        let update_acl = |user_id: Uuid, permission: Option<ProjectAclUserPermission>| {
+            let project_id = *project_id;
+            RPC.edit_user_acl(rpc::edit_user_acl::Request {
+                project_id,
+                user_id,
+                permission,
+            })
+            .callback(move |result| match result {
+                Ok(_) => {
+                    start_fetch_graphic_assets(project_id, set_acls);
+                }
+                Err(error) => {
+                    push_notification(Notification::error(format!(
+                        "Failed to update user acl - {}: {}",
+                        user_id, error
+                    )));
+                }
+            });
+        };
+
+        ctx.effect("Fetch acls", || {
+            start_fetch_graphic_assets(*project_id, set_acls);
+        });
+
+        ctx.compose(|ctx| {
+            vertical([
+                fixed(TOP_BAR_HEIGHT, |wh, ctx| {
+                    ctx.add(TopBar {
+                        wh: Wh::new(wh.width, TOP_BAR_HEIGHT),
+                        project_id: *project_id,
+                    });
+                }),
+                ratio(
+                    1,
+                    horizontal([
+                        ratio(1, |_, _| {}),
+                        fixed(
+                            list_width,
+                            vertical([
+                                fixed(ITEM_HEIGHT, |wh, ctx| {
+                                    ctx.add(typography::body::left(
+                                        wh.height,
+                                        "Enter user id(ex: 2bb95042-efbb-4a43-a7f1-d1d10328d09b)",
+                                        color::STROKE_NORMAL,
+                                    ));
+                                }),
+                                fixed(ITEM_HEIGHT, |wh, ctx| {
+                                    ctx.add(EditorAdder {
+                                        wh,
+                                        update_acl: &update_acl,
+                                    });
+                                }),
+                                fixed(ITEM_HEIGHT, |_, _| {}),
+                                ratio(1, |wh, ctx| {
+                                    let item_wh = Wh::new(wh.width, ITEM_HEIGHT);
+                                    ctx.add(AutoListView {
+                                        height: wh.height,
+                                        scroll_bar_width: SCROLL_BAR_WIDTH,
+                                        item_wh,
+                                        items: acls
+                                            .iter()
+                                            .map(|acl| {
+                                                (
+                                                    acl.user_id.to_string(),
+                                                    ListItem {
+                                                        wh: item_wh,
+                                                        acl,
+                                                        update_acl: &update_acl,
+                                                    },
+                                                )
+                                            })
+                                            .collect(),
+                                    });
+                                }),
+                            ]),
+                        ),
+                        ratio(1, |_, _| {}),
+                    ]),
+                ),
+            ])(wh, ctx)
+        });
+
+        ctx.component(simple_rect(
+            wh,
+            Color::TRANSPARENT,
+            0.px(),
+            Color::TRANSPARENT,
+        ));
+
+        ctx.done()
+    }
+}
+
+#[component]
+struct ListItem<'a> {
+    wh: Wh<Px>,
+    acl: &'a UserAcl,
+    update_acl: &'a dyn Fn(Uuid, Option<ProjectAclUserPermission>),
+}
+impl Component for ListItem<'_> {
+    fn render(self, ctx: &RenderCtx) -> RenderDone {
+        let Self {
+            wh,
+            acl,
+            update_acl,
+        } = self;
+        const PADDING: Px = px(8.0);
+        ctx.compose(|ctx| {
+            horizontal([
+                ratio(
+                    1,
+                    padding(PADDING, |wh, ctx| {
+                        ctx.add(typography::body::left(
+                            wh.height,
+                            acl.user_name.clone(),
+                            color::STROKE_NORMAL,
+                        ));
+                    }),
+                ),
+                fixed(BUTTON_WIDTH, |wh, ctx| {
+                    ctx.add(TextButton {
+                        rect: wh.to_rect(),
+                        text: "Remove",
+                        text_color: color::STROKE_NORMAL,
+                        stroke_color: color::STROKE_NORMAL,
+                        stroke_width: 1.px(),
+                        fill_color: color::BACKGROUND,
+                        mouse_buttons: vec![MouseButton::Left],
+                        on_mouse_up_in: Box::new(|_| {
+                            update_acl(acl.user_id, None);
+                        }),
+                    });
+                }),
+            ])(wh, ctx)
+        });
+        ctx.component(simple_rect(
+            wh,
+            color::STROKE_NORMAL,
+            1.px(),
+            color::BACKGROUND,
+        ));
+        ctx.done()
+    }
+}
+
+#[component]
+struct EditorAdder<'a> {
+    wh: Wh<Px>,
+    update_acl: &'a dyn Fn(Uuid, Option<ProjectAclUserPermission>),
+}
+impl Component for EditorAdder<'_> {
+    fn render(self, ctx: &RenderCtx) -> RenderDone {
+        let Self { wh, update_acl } = self;
+        const PADDING: Ltrb<Px> = Ltrb {
+            left: px(8.0),
+            top: px(0.0),
+            right: px(8.0),
+            bottom: px(0.0),
+        };
+        let (input_value, set_input_value) = ctx.state::<String>(String::new);
+        let text_input_instance = TextInputInstance::new(ctx);
+        let add_user_as_editor = || {
+            let Ok(user_id) = Uuid::parse_str(&input_value) else {
+                push_notification(Notification::error(format!(
+                    "Invalid user id - {input_value}",
+                )));
+                return;
+            };
+            update_acl(user_id, Some(ProjectAclUserPermission::Editor));
+        };
+
+        ctx.compose(|ctx| {
+            horizontal([
+                ratio(1, |wh, ctx| {
+                    ctx.add(TextInput {
+                        instance: text_input_instance,
+                        rect: wh.to_rect(),
+                        text: input_value.deref().clone(),
+                        text_align: TextAlign::Left,
+                        text_baseline: TextBaseline::Middle,
+                        font: Font {
+                            size: typography::adjust_font_size(wh.height),
+                            name: "NotoSansKR-Regular".to_string(),
+                        },
+                        style: Style {
+                            rect: RectStyle {
+                                stroke: Some(RectStroke {
+                                    color: color::STROKE_NORMAL,
+                                    width: 1.px(),
+                                    border_position: BorderPosition::Inside,
+                                }),
+                                fill: Some(RectFill {
+                                    color: color::BACKGROUND,
+                                }),
+                                round: None,
+                            },
+                            text: TextStyle {
+                                color: color::STROKE_NORMAL,
+                                ..Default::default()
+                            },
+                            padding: PADDING,
+                        },
+                        prevent_default_codes: vec![Code::Enter],
+                        on_event: &|event| match event {
+                            text_input::Event::TextUpdated { text } => {
+                                set_input_value.set(text.to_string());
+                            }
+                            text_input::Event::KeyDown { event } => {
+                                if event.code == Code::Enter {
+                                    add_user_as_editor();
+                                }
+                            }
+                            _ => {}
+                        },
+                    });
+                }),
+                fixed(BUTTON_WIDTH, |wh, ctx| {
+                    ctx.add(TextButton {
+                        rect: wh.to_rect(),
+                        text: "Add",
+                        text_color: color::STROKE_NORMAL,
+                        stroke_color: color::STROKE_NORMAL,
+                        stroke_width: 1.px(),
+                        fill_color: color::BACKGROUND,
+                        mouse_buttons: vec![MouseButton::Left],
+                        on_mouse_up_in: Box::new(|_| {
+                            add_user_as_editor();
+                        }),
+                    });
+                }),
+            ])(wh, ctx)
+        });
+        ctx.done()
+    }
+}
+
+fn start_fetch_graphic_assets(
+    project_id: Uuid,
+    set_acls: SetState<Vec<rpc::list_user_acls::UserAcl>>,
+) {
+    spawn_local(async move {
+        let mut acls = Vec::new();
+        let mut last_key = None;
+        loop {
+            match RPC
+                .list_user_acls(rpc::list_user_acls::Request {
+                    project_id,
+                    last_key,
+                })
+                .await
+            {
+                Ok(response) => {
+                    acls.extend(response.user_acls);
+                    if let Some(next_key) = response.next_key {
+                        last_key = Some(next_key);
+                        continue;
+                    }
+                }
+                Err(error) => {
+                    let mut error_message = "Failed to fetch acls, ".to_string();
+                    match error {
+                        rpc::list_user_acls::Error::Unauthorized => {
+                            let _ =
+                                write!(error_message, "Please login with project owner account");
+                        }
+                        rpc::list_user_acls::Error::Unknown(error) => {
+                            let _ = write!(error_message, "{:?}", error);
+                        }
+                    }
+                    push_notification(Notification::error(error_message));
+                }
+            }
+            break;
+        }
+        set_acls.set(acls);
+    });
+}

--- a/luda-editor/client/src/pages/project_acl_manage_page/top_bar.rs
+++ b/luda-editor/client/src/pages/project_acl_manage_page/top_bar.rs
@@ -1,0 +1,60 @@
+use crate::{
+    color,
+    pages::router::{move_to, Route},
+};
+use namui::prelude::*;
+use namui_prebuilt::{button::TextButtonFit, simple_rect, table::hooks::*, typography};
+
+#[component]
+pub(super) struct TopBar {
+    pub wh: Wh<Px>,
+    pub project_id: Uuid,
+}
+
+impl Component for TopBar {
+    fn render(self, ctx: &RenderCtx) -> RenderDone {
+        let Self { wh, project_id } = self;
+
+        const PADDING: Px = px(8.0);
+
+        let on_back_button_clicked = || move_to(Route::SequenceList { project_id });
+
+        ctx.compose(|ctx| {
+            padding(PADDING, |wh, ctx| {
+                horizontal([
+                    ratio(1, |_wh, _ctx| {}),
+                    fit(
+                        FitAlign::CenterMiddle,
+                        TextButtonFit {
+                            height: wh.height,
+                            text: "Back",
+                            text_color: color::BACKGROUND,
+                            stroke_color: color::STROKE_NORMAL,
+                            stroke_width: 1.px(),
+                            fill_color: color::STROKE_NORMAL,
+                            side_padding: PADDING,
+                            mouse_buttons: vec![MouseButton::Left],
+                            on_mouse_up_in: Box::new(|_| on_back_button_clicked()),
+                        }
+                        .with_mouse_cursor(MouseCursor::Pointer),
+                    ),
+                ])(wh, ctx);
+
+                ctx.add(typography::title::center(
+                    wh,
+                    "Project ACL",
+                    color::STROKE_NORMAL,
+                ));
+            })(wh, ctx)
+        });
+
+        ctx.component(simple_rect(
+            wh,
+            color::STROKE_NORMAL,
+            1.px(),
+            color::BACKGROUND,
+        ));
+
+        ctx.done()
+    }
+}

--- a/luda-editor/client/src/pages/project_acl_manage_page/top_bar.rs
+++ b/luda-editor/client/src/pages/project_acl_manage_page/top_bar.rs
@@ -17,8 +17,6 @@ impl Component for TopBar {
 
         const PADDING: Px = px(8.0);
 
-        let on_back_button_clicked = || move_to(Route::SequenceList { project_id });
-
         ctx.compose(|ctx| {
             padding(PADDING, |wh, ctx| {
                 horizontal([
@@ -34,7 +32,9 @@ impl Component for TopBar {
                             fill_color: color::STROKE_NORMAL,
                             side_padding: PADDING,
                             mouse_buttons: vec![MouseButton::Left],
-                            on_mouse_up_in: Box::new(|_| on_back_button_clicked()),
+                            on_mouse_up_in: Box::new(|_| {
+                                move_to(Route::SequenceList { project_id })
+                            }),
                         }
                         .with_mouse_cursor(MouseCursor::Pointer),
                     ),

--- a/luda-editor/client/src/pages/project_list_page/mod.rs
+++ b/luda-editor/client/src/pages/project_list_page/mod.rs
@@ -1,3 +1,8 @@
+use crate::{
+    app::notification::{push_notification, remove_notification, Notification},
+    RPC,
+};
+use futures::FutureExt;
 use namui::prelude::*;
 use namui_prebuilt::*;
 use rpc::list_editable_projects::EditableProject;
@@ -10,6 +15,7 @@ pub struct ProjectListPage {
 impl Component for ProjectListPage {
     fn render(self, ctx: &RenderCtx) -> RenderDone {
         let Self { wh } = self;
+        const ITEM_HEIGHT: Px = px(40.0);
         let (error_message, set_error_message) = ctx.state::<Option<String>>(|| None);
         let (is_loading, set_is_loading) = ctx.state(|| true);
         let (project_list, set_project_list) =
@@ -57,6 +63,31 @@ impl Component for ProjectListPage {
             })
         };
 
+        let on_copy_id_button_clicked = || {
+            let loading_notification_id = push_notification(
+                Notification::info("Getting user id...".to_string()).set_loading(true),
+            );
+            spawn_local(
+                async move {
+                    let Ok(rpc::get_user_id::Response { user_id }) =
+                        RPC.get_user_id(rpc::get_user_id::Request {}).await
+                    else {
+                        push_notification(Notification::error("Failed to get user id".to_string()));
+                        return;
+                    };
+
+                    if let Err(error) = clipboard::write_text(user_id.to_string()).await {
+                        push_notification(Notification::error(format!(
+                            "Failed to copy: {}",
+                            error
+                        )));
+                        push_notification(Notification::info(format!("user id: {}", user_id)));
+                    };
+                }
+                .then(move |()| async move { remove_notification(loading_notification_id) }),
+            );
+        };
+
         ctx.effect("Fetch project list on mount", || {
             start_fetch_list();
         });
@@ -79,7 +110,20 @@ impl Component for ProjectListPage {
                 table::hooks::ratio(
                     2.0,
                     table::hooks::vertical([
-                        table::hooks::fixed(40.px(), |wh, ctx| {
+                        table::hooks::fixed(ITEM_HEIGHT, |wh, ctx| {
+                            ctx.add(namui_prebuilt::button::TextButton {
+                                rect: Rect::from_xy_wh(Xy::single(0.px()), wh),
+                                text: "Copy User ID",
+                                text_color: Color::WHITE,
+                                stroke_color: Color::grayscale_f01(0.5),
+                                stroke_width: 1.px(),
+                                fill_color: Color::BLACK,
+                                mouse_buttons: vec![MouseButton::Left],
+                                on_mouse_up_in: Box::new(|_| on_copy_id_button_clicked()),
+                            });
+                        }),
+                        table::hooks::fixed(ITEM_HEIGHT, |_, _| {}),
+                        table::hooks::fixed(ITEM_HEIGHT, |wh, ctx| {
                             ctx.add(namui_prebuilt::button::TextButton {
                                 rect: Rect::from_xy_wh(Xy::single(0.px()), wh),
                                 text: "[+] Add Project",
@@ -92,7 +136,7 @@ impl Component for ProjectListPage {
                             });
                         }),
                         table::hooks::ratio(1.0, |wh, ctx| {
-                            let item_wh = Wh::new(wh.width, 40.px());
+                            let item_wh = Wh::new(wh.width, ITEM_HEIGHT);
                             ctx.add(list_view::AutoListView {
                                 height: wh.height,
                                 scroll_bar_width: 10.px(),

--- a/luda-editor/client/src/pages/project_list_page/mod.rs
+++ b/luda-editor/client/src/pages/project_list_page/mod.rs
@@ -82,7 +82,12 @@ impl Component for ProjectListPage {
                             error
                         )));
                         push_notification(Notification::info(format!("user id: {}", user_id)));
+                        return;
                     };
+
+                    push_notification(Notification::info(
+                        "User id copied to clipboard.".to_string(),
+                    ));
                 }
                 .then(move |()| async move { remove_notification(loading_notification_id) }),
             );

--- a/luda-editor/client/src/pages/router.rs
+++ b/luda-editor/client/src/pages/router.rs
@@ -38,6 +38,9 @@ impl Component for Router {
             Route::GraphicAssetManage { project_id } => {
                 ctx.add(graphic_asset_manage_page::GraphicAssetManagePage { wh, project_id });
             }
+            Route::ProjectAclManage { project_id } => {
+                ctx.add(project_acl_manage_page::ProjectAclManagePage { wh, project_id });
+            }
         });
 
         ctx.done()
@@ -50,6 +53,7 @@ pub enum Route {
     SequenceList { project_id: Uuid },
     SequenceEdit { project_id: Uuid, sequence_id: Uuid },
     GraphicAssetManage { project_id: Uuid },
+    ProjectAclManage { project_id: Uuid },
 }
 impl From<String> for Route {
     fn from(mut path_string: String) -> Self {
@@ -88,6 +92,13 @@ impl From<String> for Route {
             }
         }
 
+        if path_string.starts_with("/project_acl_manage") {
+            let rest = path_string.split_off("/project_acl_manage".len());
+            if let Ok(project_id) = Uuid::parse_str(rest.trim_matches('/')) {
+                return Self::ProjectAclManage { project_id };
+            }
+        }
+
         Self::ProjectList
     }
 }
@@ -102,6 +113,9 @@ impl ToString for Route {
             } => format!("/sequence_edit/{project_id}/{sequence_id}"),
             Self::GraphicAssetManage { project_id } => {
                 format!("/graphic_asset_manage/{project_id}")
+            }
+            Self::ProjectAclManage { project_id } => {
+                format!("/project_acl_manage/{project_id}")
             }
         }
     }

--- a/luda-editor/client/src/pages/sequence_list_page/mod.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/mod.rs
@@ -47,10 +47,6 @@ impl Component for SequenceListPage {
             })
         };
 
-        let on_manage_graphic_assets_button_click = move || {
-            super::router::move_to(super::router::Route::GraphicAssetManage { project_id });
-        };
-
         let on_add_button_click = move || {
             set_is_loading.set(true);
             spawn_local(async move {
@@ -143,7 +139,26 @@ impl Component for SequenceListPage {
                                 mouse_buttons: vec![MouseButton::Left],
                                 // TODO: unwrap box
                                 on_mouse_up_in: Box::new(|_| {
-                                    on_manage_graphic_assets_button_click()
+                                    super::router::move_to(
+                                        super::router::Route::GraphicAssetManage { project_id },
+                                    );
+                                }),
+                            });
+                        }),
+                        table::hooks::fixed(ITEM_HEIGHT, |wh, ctx| {
+                            ctx.add(button::TextButton {
+                                rect: Rect::from_xy_wh(Xy::single(0.px()), wh),
+                                text: "Manage Project ACL",
+                                text_color: Color::WHITE,
+                                stroke_color: Color::grayscale_f01(0.5),
+                                stroke_width: 1.px(),
+                                fill_color: Color::BLACK,
+                                mouse_buttons: vec![MouseButton::Left],
+                                // TODO: unwrap box
+                                on_mouse_up_in: Box::new(|_| {
+                                    super::router::move_to(super::router::Route::ProjectAclManage {
+                                        project_id,
+                                    })
                                 }),
                             });
                         }),

--- a/luda-editor/rpc/src/lib.rs
+++ b/luda-editor/rpc/src/lib.rs
@@ -264,6 +264,25 @@ define_rpc! {
                 Unknown(String),
             }
         },
+        list_user_acls: {
+            struct Request {
+                pub project_id: crate::Uuid,
+                pub last_key: Option<crate::Uuid>,
+            }
+            struct Response {
+                pub user_acls: Vec<UserAcl>,
+                pub next_key: Option<crate::Uuid>,
+            }
+            struct UserAcl {
+                pub user_id: crate::Uuid,
+                pub user_name: String,
+                pub permission: crate::types::ProjectAclUserPermission,
+            }
+            enum Error {
+                Unauthorized,
+                Unknown(String),
+            }
+        },
         update_server_project_shared_data: {
             struct Request {
                 pub project_id: crate::Uuid,

--- a/luda-editor/server/server-core/src/apis/mod.rs
+++ b/luda-editor/server/server-core/src/apis/mod.rs
@@ -158,6 +158,14 @@ pub async fn handle_api(
             let response = project::edit_user_acl(session, api_request).await;
             Ok(serde_json::to_vec(&response).unwrap())
         }
+        "list_user_acls" => {
+            let Ok(api_request) = serde_json::from_slice::<rpc::list_user_acls::Request>(body)
+            else {
+                return Err("Fail to parse body".into());
+            };
+            let response = project::list_user_acls(session, api_request).await;
+            Ok(serde_json::to_vec(&response).unwrap())
+        }
         "update_server_project_shared_data" => {
             let Ok(api_request) =
                 serde_json::from_slice::<rpc::update_server_project_shared_data::Request>(body)

--- a/luda-editor/server/server-core/src/apis/project/edit_user_acl.rs
+++ b/luda-editor/server/server-core/src/apis/project/edit_user_acl.rs
@@ -33,21 +33,15 @@ pub async fn edit_user_acl(
     match permission {
         Some(permission) => crate::dynamo_db()
             .transact()
-            .update_item(UserInProjectAclDocumentUpdate {
-                pk_project_id: project.id,
-                sk_user_id: user_id,
-                update: move |mut document: UserInProjectAclDocument| async move {
-                    document.permission = permission;
-                    Ok(document)
-                },
+            .put_item(UserInProjectAclDocument {
+                project_id,
+                user_id,
+                permission,
             })
-            .update_item(ProjectAclUserInDocumentUpdate {
-                pk_user_id: session.user_id,
-                sk_project_id: project.id,
-                update: move |mut document: ProjectAclUserInDocument| async move {
-                    document.permission = permission;
-                    Ok(document)
-                },
+            .put_item(ProjectAclUserInDocument {
+                user_id,
+                project_id,
+                permission,
             })
             .send()
             .await
@@ -57,10 +51,10 @@ pub async fn edit_user_acl(
             .transact()
             .delete_item(UserInProjectAclDocumentDelete {
                 pk_project_id: project.id,
-                sk_user_id: session.user_id,
+                sk_user_id: user_id,
             })
             .delete_item(ProjectAclUserInDocumentDelete {
-                pk_user_id: session.user_id,
+                pk_user_id: user_id,
                 sk_project_id: project.id,
             })
             .send()

--- a/luda-editor/server/server-core/src/apis/project/list_editable_projects.rs
+++ b/luda-editor/server/server-core/src/apis/project/list_editable_projects.rs
@@ -38,13 +38,14 @@ pub async fn list_editable_projects(
         );
 
     let editable_projects = try_join_all(editable_project_ids.map(|project_id| async move {
-        match (ProjectDocumentGet { pk_id: project_id }).run().await {
-            Ok(project) => Ok(rpc::list_editable_projects::EditableProject {
+        (ProjectDocumentGet { pk_id: project_id })
+            .run()
+            .await
+            .map(|project| rpc::list_editable_projects::EditableProject {
                 id: project_id,
                 name: project.name,
-            }),
-            Err(error) => Err(Error::Unknown(error.to_string())),
-        }
+            })
+            .map_err(|error| Error::Unknown(error.to_string()))
     }))
     .await;
     if let Err(error) = editable_projects {

--- a/luda-editor/server/server-core/src/apis/project/list_editable_projects.rs
+++ b/luda-editor/server/server-core/src/apis/project/list_editable_projects.rs
@@ -18,22 +18,34 @@ pub async fn list_editable_projects(
     .await
     .map_err(|error| Error::Unknown(error.to_string()))?;
 
-    let editable_projects = try_join_all(owner_project_query.documents.into_iter().map(
-        |owner_project_document| async move {
-            match (ProjectDocumentGet {
-                pk_id: owner_project_document.project_id,
-            })
-            .run()
-            .await
-            {
-                Ok(project) => Ok(rpc::list_editable_projects::EditableProject {
-                    id: owner_project_document.project_id,
-                    name: project.name,
-                }),
-                Err(error) => Err(Error::Unknown(error.to_string())),
-            }
-        },
-    ))
+    let project_acl_user_query = ProjectAclUserInDocumentQuery {
+        pk_user_id: session.user_id,
+        last_sk: None, // TODO
+    }
+    .run()
+    .await
+    .map_err(|error| Error::Unknown(error.to_string()))?;
+
+    let editable_project_ids = owner_project_query
+        .documents
+        .into_iter()
+        .map(|owner_project_document| owner_project_document.project_id)
+        .chain(
+            project_acl_user_query
+                .documents
+                .into_iter()
+                .map(|project_acl_user_document| project_acl_user_document.project_id),
+        );
+
+    let editable_projects = try_join_all(editable_project_ids.map(|project_id| async move {
+        match (ProjectDocumentGet { pk_id: project_id }).run().await {
+            Ok(project) => Ok(rpc::list_editable_projects::EditableProject {
+                id: project_id,
+                name: project.name,
+            }),
+            Err(error) => Err(Error::Unknown(error.to_string())),
+        }
+    }))
     .await;
     if let Err(error) = editable_projects {
         return Err(Error::Unknown(error.to_string()));

--- a/luda-editor/server/server-core/src/apis/project/list_user_acls.rs
+++ b/luda-editor/server/server-core/src/apis/project/list_user_acls.rs
@@ -1,0 +1,62 @@
+use crate::documents::*;
+use futures::future::try_join_all;
+use namui_type::Uuid;
+use rpc::list_user_acls::{Error, Request, Response};
+
+pub async fn list_user_acls(
+    session: Option<SessionDocument>,
+    Request {
+        project_id,
+        last_key,
+    }: Request,
+) -> rpc::list_user_acls::Result {
+    if session.is_none() {
+        return Err(Error::Unauthorized);
+    }
+    let session = session.unwrap();
+    let project = ProjectDocumentGet { pk_id: project_id }
+        .run()
+        .await
+        .map_err(|error| Error::Unknown(error.to_string()))?;
+
+    let session_is_project_owner = session.user_id == project.owner_id;
+    if !session_is_project_owner {
+        return Err(Error::Unauthorized);
+    }
+
+    let user_in_project_acl_document_query = UserInProjectAclDocumentQuery {
+        pk_project_id: project_id,
+        last_sk: last_key.map(|last_key| UserInProjectAclDocumentSortKey { user_id: last_key }),
+    }
+    .run()
+    .await
+    .map_err(|error| Error::Unknown(error.to_string()))?;
+    let user_acls = try_join_all(
+        user_in_project_acl_document_query
+            .documents
+            .into_iter()
+            .map(|document| async move {
+                let user_name = UserDocumentGet {
+                    pk_id: document.user_id,
+                }
+                .run()
+                .await
+                .map(|user| user.name)
+                .unwrap_or("Unknown".to_string());
+                Ok(rpc::list_user_acls::UserAcl {
+                    user_id: document.user_id,
+                    user_name,
+                    permission: document.permission,
+                })
+            }),
+    )
+    .await?;
+    let next_key = user_in_project_acl_document_query
+        .next_page_key
+        .map(|next_key| Uuid::try_parse(&next_key).unwrap());
+
+    Ok(Response {
+        user_acls,
+        next_key,
+    })
+}

--- a/luda-editor/server/server-core/src/apis/project/mod.rs
+++ b/luda-editor/server/server-core/src/apis/project/mod.rs
@@ -3,6 +3,7 @@
 mod create_project;
 mod edit_user_acl;
 mod list_editable_projects;
+mod list_user_acls;
 pub mod shared;
 mod update_client_project_shared_data;
 mod update_server_project_shared_data;
@@ -10,5 +11,6 @@ mod update_server_project_shared_data;
 pub use create_project::create_project;
 pub use edit_user_acl::edit_user_acl;
 pub use list_editable_projects::list_editable_projects;
+pub use list_user_acls::list_user_acls;
 pub use update_client_project_shared_data::update_client_project_shared_data;
 pub use update_server_project_shared_data::update_server_project_shared_data;


### PR DESCRIPTION
We need better solution for adding user to project editor. #711

## Features
- Manage acl
  - ![image](https://github.com/NamseEnt/namseent/assets/38313680/38876a5a-493d-4c48-aa53-e242c1e2e021)
- Copy user id
  - ![image](https://github.com/NamseEnt/namseent/assets/38313680/3f7b0ffc-d472-4f22-a5e7-3fd43a0c3bf9)
- List editor granted project also
  - Previously, only projects owned were listed
- `update or create` command in db.

Closes #407