### PR TITLE
Don't panic on fill_path_with_paint

### DIFF
--- a/namui/skia/skia/src/native/path.rs
+++ b/namui/skia/skia/src/native/path.rs
@@ -110,7 +110,7 @@ fn apply_command_to_skia_path(skia_path: &mut skia_safe::Path, path: &Path) {
                     None,
                     skia_safe::Matrix::scale((precision, precision)),
                 ) {
-                    panic!("stroke failed");
+                    // Nothing applied because of Paint.
                 }
             }
             PathCommand::MoveTo { xy } => {


### PR DESCRIPTION
`fill_path_with_paint` can return false but that's expected behavior.

That's commented on `fill_path_with_paint`.

/// Returns: `true` if the dst path was updated, `false` if it was not (e.g. if the path
///                  represents hairline and cannot be filled).