### PR TITLE
Use pdb for backtrace

### DIFF
--- a/namui/namui-cli/src/services/resource_collect_service.rs
+++ b/namui/namui-cli/src/services/resource_collect_service.rs
@@ -99,6 +99,10 @@ fn collect_rust_build(
                 &build_dist_path.join("namui-runtime-x86_64-pc-windows-msvc.exe"),
                 &PathBuf::from(""),
             ));
+            ops.push(CollectOperation::new(
+                &build_dist_path.join("namui_runtime_x86_64_pc_windows_msvc.pdb"),
+                &PathBuf::from(""),
+            ));
         }
     }
     Ok(())


### PR DESCRIPTION
Without pdb file, backtrace shows `<unknown>` so I added it.