### PR TITLE
Full-load-once audio with slice support

### DIFF
--- a/namui/namui/src/namui/mod.rs
+++ b/namui/namui/src/namui/mod.rs
@@ -25,7 +25,7 @@ pub use render::*;
 pub use render::{text_input, TextInput, TextInputInstance};
 pub use serde;
 pub use shader_macro::shader;
-pub use system::media::MediaHandle;
+pub use system::media::{FullLoadOnceAudio, MediaHandle};
 pub use system::*;
 
 #[cfg(not(target_family = "wasm"))]

--- a/namui/namui/src/namui/system/media/audio/full_load_once_audio.rs
+++ b/namui/namui/src/namui/system/media/audio/full_load_once_audio.rs
@@ -1,0 +1,133 @@
+use crate::media::audio::{self, AudioConfig, AudioConsume, AudioContext};
+use anyhow::{bail, Result};
+use namui_type::*;
+use std::{path::Path, sync::Arc};
+
+#[derive(Debug, Clone)]
+pub struct FullLoadOnceAudio {
+    audio_context: Arc<AudioContext>,
+    audio_config: AudioConfig,
+    buffer: Vec<f32>,
+}
+
+impl FullLoadOnceAudio {
+    pub(crate) async fn new(
+        audio_context: Arc<AudioContext>,
+        path: &impl AsRef<Path>,
+    ) -> Result<Self> {
+        let output_config = audio_context.output_config;
+        let path = path.as_ref().to_path_buf();
+        let buffer = tokio::task::spawn_blocking(move || -> Result<Vec<f32>> {
+            let mut input_ctx = ffmpeg_next::format::input(&path)?;
+
+            let audio_stream = input_ctx
+                .streams()
+                .find(|stream| stream.parameters().medium() == ffmpeg_next::media::Type::Audio)
+                .ok_or_else(|| anyhow::anyhow!("No audio stream found."))?;
+
+            let context_decoder =
+                ffmpeg_next::codec::context::Context::from_parameters(audio_stream.parameters())?;
+
+            let mut decoder = context_decoder.decoder().audio()?;
+
+            let input_config = AudioConfig {
+                sample_rate: decoder.rate(),
+                sample_format: decoder.format(),
+                channel_layout: decoder.channel_layout(),
+                channel_count: decoder.channel_layout().channels() as usize,
+            };
+
+            let mut resampler = audio::get_resampler(input_config, output_config)?;
+
+            let mut output: Vec<f32> = Vec::new();
+
+            let mut receive_frame =
+                |decoder: &mut ffmpeg_next::codec::decoder::Audio, eof: bool| -> Result<()> {
+                    let mut decoded = ffmpeg_next::frame::Audio::empty();
+                    if let Err(err) = decoder.receive_frame(&mut decoded) {
+                        if eof && std::ffi::c_int::from(err) == ffmpeg_next::ffi::AVERROR_EOF {
+                            return Ok(());
+                        }
+                        bail!("[namui-media] error while decoding audio: {:?}", err);
+                    }
+
+                    let mut resampled = ffmpeg_next::frame::Audio::empty();
+                    if let Some(delay) = resampler.run(&decoded, &mut resampled)? {
+                        eprintln!("[namui-media] unexpected delay: {:?}", delay);
+                    }
+
+                    assert!(resampled.is_packed());
+                    const PACKED_DATA_INDEX: usize = 0;
+
+                    let slice_with_extra = resampled.data(PACKED_DATA_INDEX);
+                    let slice = &slice_with_extra
+                        [..slice_with_extra.len() - slice_with_extra.len() % resampled.samples()];
+
+                    let f32_slice = unsafe {
+                        std::slice::from_raw_parts(
+                            slice.as_ptr() as *const f32,
+                            slice.len() / std::mem::size_of::<f32>(),
+                        )
+                    };
+
+                    output.extend_from_slice(f32_slice);
+
+                    Ok(())
+                };
+
+            let stream_index = audio_stream.index();
+
+            for (_, packet) in input_ctx
+                .packets()
+                .filter(|(stream, _)| stream.index() == stream_index)
+            {
+                decoder.send_packet(&packet)?;
+                receive_frame(&mut decoder, false)?;
+            }
+            decoder.send_eof()?;
+            receive_frame(&mut decoder, true)?;
+
+            Ok(output)
+        })
+        .await??;
+
+        Ok(Self {
+            audio_context,
+            buffer,
+            audio_config: output_config,
+        })
+    }
+
+    /// It doesn't support pause and seek.
+    pub fn play(self) -> Result<()> {
+        self.audio_context.clone().load_audio(self)
+    }
+
+    pub fn slice(&self, range: std::ops::Range<Duration>) -> Result<Self> {
+        let start = range.start.as_secs_f64() * self.audio_config.sample_rate as f64;
+        let end = range.end.as_secs_f64() * self.audio_config.sample_rate as f64;
+        let start = start as usize;
+        let end = end as usize;
+        let buffer = self.buffer[start..end].to_vec();
+        Ok(Self {
+            audio_context: self.audio_context.clone(),
+            audio_config: self.audio_config,
+            buffer,
+        })
+    }
+}
+
+impl AudioConsume for FullLoadOnceAudio {
+    fn consume(&mut self, output: &mut [f32]) {
+        self.buffer
+            .drain(..output.len())
+            .zip(output)
+            .for_each(|(src, dst)| {
+                *dst += src;
+            });
+    }
+
+    fn is_end(&self) -> bool {
+        self.buffer.is_empty()
+    }
+}

--- a/namui/namui/src/namui/system/media/audio/mod.rs
+++ b/namui/namui/src/namui/system/media/audio/mod.rs
@@ -3,8 +3,16 @@ mod audio_buffer;
 mod audio_config;
 mod audio_context;
 mod audio_resampling;
+mod full_load_once_audio;
 
 pub(crate) use audio_buffer::*;
 pub(crate) use audio_config::*;
 pub(crate) use audio_context::*;
 pub(crate) use audio_resampling::*;
+pub use full_load_once_audio::*;
+use std::fmt::Debug;
+
+pub(crate) trait AudioConsume: Debug + Send {
+    fn consume(&mut self, output: &mut [f32]);
+    fn is_end(&self) -> bool;
+}

--- a/namui/namui/src/namui/system/media/core/media_core.rs
+++ b/namui/namui/src/namui/system/media/core/media_core.rs
@@ -30,11 +30,10 @@ impl MediaCore {
         audio_context: Arc<AudioContext>,
         path: &impl AsRef<std::path::Path>,
     ) -> Result<Self> {
-        let input_ctx = ffmpeg_next::format::input(&path)?;
         let (command_tx, command_rx) = std::sync::mpsc::sync_channel(32);
 
         let (video_framer, audio_buffer, media_duration) =
-            open_media(input_ctx, command_rx, audio_context.output_config)?;
+            open_media(path, command_rx, audio_context.output_config)?;
 
         if let Some(audio_buffer) = audio_buffer {
             audio_context.load_audio(audio_buffer)?;

--- a/namui/namui/src/namui/system/media/core/open_media.rs
+++ b/namui/namui/src/namui/system/media/core/open_media.rs
@@ -9,10 +9,12 @@ use anyhow::Result;
 use namui_type::*;
 
 pub(crate) fn open_media(
-    input_ctx: ffmpeg_next::format::context::Input,
+    path: &impl AsRef<std::path::Path>,
     command_rx: std::sync::mpsc::Receiver<WithInstant<DecodingThreadCommand>>,
     audio_output_config: AudioConfig,
 ) -> Result<(Option<VideoFramer>, Option<AudioBuffer>, Duration)> {
+    let input_ctx = ffmpeg_next::format::input(&path)?;
+
     let mut video_framer = None;
     let mut audio_buffer = None;
     let duration = Duration::from_secs_f64(

--- a/namui/namui/src/namui/system/media/media_context.rs
+++ b/namui/namui/src/namui/system/media/media_context.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use std::{path::Path, sync::Arc};
 
 pub struct MediaContext {
-    audio_context: Arc<AudioContext>,
+    pub(crate) audio_context: Arc<AudioContext>,
 }
 
 impl MediaContext {

--- a/namui/namui/src/namui/system/media/mod.rs
+++ b/namui/namui/src/namui/system/media/mod.rs
@@ -8,10 +8,11 @@ mod media_handle;
 mod video;
 mod with_instant;
 
-use self::media_context::MediaContext;
-pub use self::media_handle::MediaHandle;
 use super::InitResult;
 use anyhow::*;
+pub use audio::FullLoadOnceAudio;
+use media_context::MediaContext;
+pub use media_handle::MediaHandle;
 use std::{path::Path, sync::OnceLock};
 
 const AUDIO_CHANNEL_BOUND: usize = 128;
@@ -40,4 +41,8 @@ pub fn set_volume(zero_to_one: f32) {
 /// Volume value range is 0.0 ~ 1.0.
 pub fn volume() -> f32 {
     MEDIA_SYSTEM.get().unwrap().volume()
+}
+
+pub async fn new_full_load_once_audio(path: &impl AsRef<Path>) -> Result<FullLoadOnceAudio> {
+    Ok(FullLoadOnceAudio::new(MEDIA_SYSTEM.get().unwrap().audio_context.clone(), path).await?)
 }


### PR DESCRIPTION
FullLoadOnceAudio is the audio which load all at creation and support slice by duration.

I made it instead of media because media support video, and clipping video could be not that much accurate. To make it more accurate, I made audio-only simple version.

Check media sample to know how to use.