### PR TITLE
Turn on target feature based on steam hw survey

### DIFF
--- a/namui/namui-cli/src/services/runtime_project/wasm.rs
+++ b/namui/namui-cli/src/services/runtime_project/wasm.rs
@@ -1,14 +1,13 @@
 use super::{get_project_name, GenerateRuntimeProjectArgs};
-use crate::*;
+use crate::{util::recreate_dir_all, *};
 
 pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> {
     let project_name = get_project_name(args.project_path.clone());
 
-    let _ = std::fs::remove_dir_all(args.target_dir.join("src"));
-    std::fs::create_dir_all(args.target_dir.join("src"))?;
-
-    let cargo_toml = format!(
-        r#"[package]
+    std::fs::write(
+        args.target_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
 name = "namui-runtime-wasm"
 version = "0.0.1"
 edition = "2021"
@@ -30,12 +29,18 @@ opt-level = 3
 lto = true
 opt-level = 2
     "#,
-        project_path = args.project_path.display(),
-    );
-    std::fs::write(args.target_dir.join("Cargo.toml"), cargo_toml)?;
+            project_path = args.project_path.display(),
+        ),
+    )?;
 
-    let lib_rs = format!(
-        r#"use wasm_bindgen::prelude::*;
+    // src
+    {
+        recreate_dir_all(args.target_dir.join("src"))?;
+
+        std::fs::write(
+            args.target_dir.join("src/lib.rs"),
+            format!(
+                r#"use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub async fn start() {{
@@ -44,9 +49,23 @@ pub async fn start() {{
     {project_name_underscored}::main().await;
 }}
 "#,
-        project_name_underscored = project_name.replace('-', "_"),
-    );
-    std::fs::write(args.target_dir.join("src/lib.rs"), lib_rs)?;
+                project_name_underscored = project_name.replace('-', "_"),
+            ),
+        )?;
+    }
+
+    // .cargo
+    {
+        recreate_dir_all(args.target_dir.join(".cargo"))?;
+
+        std::fs::write(
+            args.target_dir.join(".cargo/config.toml"),
+            r#"[build]
+# NOTE: This may break build when user's platform doesn't support simd128.
+rustflags = ["-C", "target-feature=+simd128"]
+"#,
+        )?;
+    }
 
     Ok(())
 }

--- a/namui/namui-cli/src/services/runtime_project/wasm.rs
+++ b/namui/namui-cli/src/services/runtime_project/wasm.rs
@@ -4,6 +4,8 @@ use crate::{util::recreate_dir_all, *};
 pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> {
     let project_name = get_project_name(args.project_path.clone());
 
+    recreate_dir_all(&args.target_dir)?;
+
     std::fs::write(
         args.target_dir.join("Cargo.toml"),
         format!(

--- a/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
+++ b/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
@@ -7,6 +7,8 @@ pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> 
     let project_path_in_relative =
         pathdiff::diff_paths(&args.project_path, &args.target_dir).unwrap();
 
+    recreate_dir_all(&args.target_dir)?;
+
     std::fs::write(
         args.target_dir.join("Cargo.toml"),
         format!(

--- a/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
+++ b/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
@@ -1,5 +1,5 @@
 use super::{get_project_name, GenerateRuntimeProjectArgs};
-use crate::*;
+use crate::{util::recreate_dir_all, *};
 
 pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> {
     let project_name = get_project_name(args.project_path.clone());
@@ -7,11 +7,10 @@ pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> 
     let project_path_in_relative =
         pathdiff::diff_paths(&args.project_path, &args.target_dir).unwrap();
 
-    let _ = std::fs::remove_dir_all(args.target_dir.join("src"));
-    std::fs::create_dir_all(args.target_dir.join("src"))?;
-
-    let cargo_toml = format!(
-        r#"[package]
+    std::fs::write(
+        args.target_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
 name = "namui-runtime-x86_64-pc-windows-msvc"
 version = "0.0.1"
 edition = "2021"
@@ -27,23 +26,45 @@ opt-level = 3
 # lto = true
 # opt-level = 2
     "#,
-        project_path = project_path_in_relative
-            .to_str()
-            .unwrap()
-            .split('\\')
-            .collect::<Vec<&str>>()
-            .join("/"),
-    );
-    std::fs::write(args.target_dir.join("Cargo.toml"), cargo_toml)?;
+            project_path = project_path_in_relative
+                .to_str()
+                .unwrap()
+                .split('\\')
+                .collect::<Vec<&str>>()
+                .join("/"),
+        ),
+    )?;
 
-    let lib_rs = format!(
-        r#"fn main() {{
+    // src
+    {
+        recreate_dir_all(args.target_dir.join("src"))?;
+
+        std::fs::write(
+            args.target_dir.join("src/main.rs"),
+            format!(
+                r#"fn main() {{
     {project_name_underscored}::main()
 }}
 "#,
-        project_name_underscored = project_name.replace('-', "_"),
-    );
-    std::fs::write(args.target_dir.join("src/main.rs"), lib_rs)?;
+                project_name_underscored = project_name.replace('-', "_"),
+            ),
+        )?;
+    }
+
+    // .cargo
+    {
+        recreate_dir_all(args.target_dir.join(".cargo"))?;
+
+        std::fs::write(
+            args.target_dir.join(".cargo/config.toml"),
+            r#"
+[build]
+# https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam
+# support 99%, 2024-01-04
+rustflags = ["-C", "target-feature=+sse,+sse2,+sse3,+cmpxchg16b,+ssse3,+sse4.1,+sse4.2"]
+"#,
+        )?;
+    }
 
     Ok(())
 }

--- a/namui/namui-cli/src/services/rust_build_service.rs
+++ b/namui/namui-cli/src/services/rust_build_service.rs
@@ -253,9 +253,6 @@ fn get_envs(build_option: &BuildOption) -> Vec<(&str, &str)> {
         envs.push(("NAMUI_CFG_WATCH_RELOAD", ""));
     }
 
-    // NOTE: This may break build when user's platform doesn't support simd128.
-    envs.push(("-C", "target-feature=+simd128"));
-
     envs
 }
 

--- a/namui/namui-cli/src/util/mod.rs
+++ b/namui/namui-cli/src/util/mod.rs
@@ -3,6 +3,7 @@ mod debug_println;
 mod get_cli_root_path;
 mod get_electron_root_path;
 mod print_build_result;
+mod recreate_dir_all;
 mod user_config;
 
 #[allow(unused_imports)]
@@ -10,4 +11,5 @@ pub use debug_println::*;
 pub use get_cli_root_path::*;
 pub use get_electron_root_path::*;
 pub use print_build_result::*;
+pub use recreate_dir_all::*;
 pub use user_config::*;

--- a/namui/namui-cli/src/util/recreate_dir_all.rs
+++ b/namui/namui-cli/src/util/recreate_dir_all.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use std::path::Path;
+
+pub fn recreate_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    if path.exists() {
+        std::fs::remove_dir_all(path)?;
+    }
+    std::fs::create_dir_all(path)?;
+    Ok(())
+}


### PR DESCRIPTION
Previously I turned on target feature in wrong way so it doesn't worked when we do wasm platform.

I turned on target features, which supported by 99% of steam users' cpu.

Only once tested.

tested code
```rust
fn consume(&mut self, output: &mut [f32]) {
    self.buffer
        .drain(..output.len())
        .zip(output)
        .for_each(|(src, dst)| {
            *dst += src;
        });
}
```

### Debug, no target feature

avg: 45.824µs

### Debug, with target feature

avg: 49.48µs // what!? but it's possible because I only tested once.

### Release without target feature

avg: 8.42µs

### Release with target feature

avg: 7.828µs


