### PR TITLE
Remove reference for path

### DIFF
--- a/namui/namui/src/namui/system/media/audio/full_load_once_audio.rs
+++ b/namui/namui/src/namui/system/media/audio/full_load_once_audio.rs
@@ -13,7 +13,7 @@ pub struct FullLoadOnceAudio {
 impl FullLoadOnceAudio {
     pub(crate) async fn new(
         audio_context: Arc<AudioContext>,
-        path: &impl AsRef<Path>,
+        path: impl AsRef<Path>,
     ) -> Result<Self> {
         let output_config = audio_context.output_config;
         let path = path.as_ref().to_path_buf();


### PR DESCRIPTION
Below code doesn't work,

```rust

 let audio_futures = ["no_drums", "cymbals", "toms", "snare", "kick"].map(|file_name| {
    FullLoadOnceAudio ::load(
        &namui::system::file::bundle::to_real_path(format!(
            "bundle:resources/{file_name}.opus"
        ))
        .unwrap(),
        Some(SAMPLE_RATE),
    )
});
```
Because of lifetime.
No need for refernece. I removed it.