### PR TITLE
Remove nalgebra for performance reason

### DIFF
--- a/hololive-beat/hololive-beat/Cargo.lock
+++ b/hololive-beat/hololive-beat/Cargo.lock
@@ -124,15 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,16 +1401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,34 +1460,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1602,7 +1555,6 @@ dependencies = [
  "auto_ops",
  "derive-macro",
  "lru 0.11.1",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -1737,7 +1689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2195,12 +2146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,15 +2365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "safer-bytes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,19 +2551,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -3077,12 +3000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,16 +3369,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/hololive-beat/note-register/Cargo.lock
+++ b/hololive-beat/note-register/Cargo.lock
@@ -124,15 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,16 +1392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,34 +1445,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1587,7 +1540,6 @@ dependencies = [
  "auto_ops",
  "derive-macro",
  "lru 0.11.1",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -1732,7 +1684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2189,12 +2140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,15 +2359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "safer-bytes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,19 +2532,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -3058,12 +2981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,16 +3369,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/namui/namui-drawer/sys/Cargo.lock
+++ b/namui/namui-drawer/sys/Cargo.lock
@@ -68,15 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +128,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.32",
+ "syn",
  "which",
 ]
 
@@ -191,12 +182,6 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
-name = "bytemuck"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -272,7 +257,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -511,16 +496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,34 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -595,7 +542,6 @@ dependencies = [
  "auto_ops",
  "derive-macro",
  "lru",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -651,7 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -756,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -782,12 +727,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -904,15 +843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "safer-bytes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +901,7 @@ checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -999,19 +929,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -1065,17 +982,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1133,7 +1039,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -1184,12 +1090,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -1284,7 +1184,7 @@ checksum = "f7e1ba1f333bd65ce3c9f27de592fcbc256dafe3af2717f56d7c87761fbaccf4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -1320,7 +1220,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1342,7 +1242,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1369,16 +1269,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/namui/namui-prebuilt/Cargo.lock
+++ b/namui/namui-prebuilt/Cargo.lock
@@ -123,15 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,15 +1426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
-dependencies = [
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,34 +1480,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1622,7 +1576,6 @@ dependencies = [
  "auto_ops",
  "derive-macro",
  "lru 0.11.0",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -1757,7 +1710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2214,12 +2166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,15 +2392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
-name = "safe_arch"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "safer-bytes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,19 +2565,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -3071,12 +2995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3469,16 +3387,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.28",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c11d2adfe89e9da42f01023d2c2998c53aa916ef4d26ca716dbb983725c0d2"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/namui/namui-type/Cargo.lock
+++ b/namui/namui-type/Cargo.lock
@@ -53,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,7 +113,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.32",
+ "syn",
  "which",
 ]
 
@@ -143,12 +134,6 @@ name = "bumpalo"
 version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
-
-[[package]]
-name = "bytemuck"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -228,7 +213,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -464,16 +449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,34 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "namui-type"
 version = "0.1.0"
 dependencies = [
@@ -531,7 +478,6 @@ dependencies = [
  "derive-macro",
  "float-cmp",
  "lru",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -588,7 +534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -658,12 +603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -713,12 +652,6 @@ checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -835,15 +768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,7 +821,7 @@ checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -925,19 +849,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -991,17 +902,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1084,12 +984,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -1184,7 +1078,7 @@ checksum = "18d884370cccfad1f913e67c7362f9c00357844bc9f3cfce86faa2241cabd166"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
 ]
 
 [[package]]
@@ -1220,7 +1114,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1254,7 +1148,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1315,16 +1209,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/namui/namui-type/Cargo.toml
+++ b/namui/namui-type/Cargo.toml
@@ -25,7 +25,6 @@ uuid = { version = "1.1", features = [
     "serde",
 ] }
 siphasher = "0.3"
-nalgebra = { version = "0.31", features = ["serde-serialize"] }
 url = { version = "2.4.0", features = ["serde"] }
 derive-macro = { path = "./derive-macro" }
 postcard = { version = "1.0.6", features = ["use-std"] }

--- a/namui/namui-type/src/types/units/matrix.rs
+++ b/namui/namui-type/src/types/units/matrix.rs
@@ -49,16 +49,16 @@ impl Matrix3x3 {
         ]
     }
 
-    pub fn transform_xy(&self, xy: crate::Xy<Px>) -> crate::Xy<Px> {
-        let x = xy.x.as_f32();
-        let y = xy.y.as_f32();
+    pub fn transform_xy<T: Into<f32> + From<f32>>(&self, xy: crate::Xy<T>) -> crate::Xy<T> {
+        let x: f32 = xy.x.into();
+        let y: f32 = xy.y.into();
 
         let x = x * self.values[0][0] + y * self.values[0][1] + self.values[0][2];
-        let y = x * self.values[1][3] + y * self.values[1][4] + self.values[1][5];
+        let y = x * self.values[1][0] + y * self.values[1][1] + self.values[1][2];
 
         crate::Xy {
-            x: x.px(),
-            y: y.px(),
+            x: x.into(),
+            y: y.into(),
         }
     }
 

--- a/namui/namui-type/src/types/units/matrix.rs
+++ b/namui/namui-type/src/types/units/matrix.rs
@@ -2,32 +2,20 @@ use crate::*;
 
 #[type_derives(Copy)]
 pub struct Matrix3x3 {
-    values: nalgebra::Matrix3<f32>,
+    values: [[f32; 3]; 3],
 }
 
 impl Default for Matrix3x3 {
     fn default() -> Self {
         Matrix3x3 {
-            values: nalgebra::Matrix3::identity(),
+            values: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
         }
     }
 }
 
 impl Matrix3x3 {
     pub fn from_slice(values: [[f32; 3]; 3]) -> Self {
-        Matrix3x3 {
-            values: nalgebra::Matrix3::new(
-                values[0][0],
-                values[0][1],
-                values[0][2],
-                values[1][0],
-                values[1][1],
-                values[1][2],
-                values[2][0],
-                values[2][1],
-                values[2][2],
-            ),
-        }
+        Matrix3x3 { values }
     }
     pub fn from_translate(x: f32, y: f32) -> Self {
         Self::from_slice([[1.0, 0.0, x], [0.0, 1.0, y], [0.0, 0.0, 1.0]])
@@ -45,45 +33,32 @@ impl Matrix3x3 {
     }
 
     pub fn into_slice(self) -> [[f32; 3]; 3] {
-        [
-            [
-                *self.values.index((0, 0)),
-                *self.values.index((0, 1)),
-                *self.values.index((0, 2)),
-            ],
-            [
-                *self.values.index((1, 0)),
-                *self.values.index((1, 1)),
-                *self.values.index((1, 2)),
-            ],
-            [
-                *self.values.index((2, 0)),
-                *self.values.index((2, 1)),
-                *self.values.index((2, 2)),
-            ],
-        ]
+        self.values
     }
     pub fn into_linear_slice(self) -> [f32; 9] {
         [
-            *self.values.index((0, 0)),
-            *self.values.index((0, 1)),
-            *self.values.index((0, 2)),
-            *self.values.index((1, 0)),
-            *self.values.index((1, 1)),
-            *self.values.index((1, 2)),
-            *self.values.index((2, 0)),
-            *self.values.index((2, 1)),
-            *self.values.index((2, 2)),
+            self.values[0][0],
+            self.values[0][1],
+            self.values[0][2],
+            self.values[1][0],
+            self.values[1][1],
+            self.values[1][2],
+            self.values[2][0],
+            self.values[2][1],
+            self.values[2][2],
         ]
     }
 
     pub fn transform_xy(&self, xy: crate::Xy<Px>) -> crate::Xy<Px> {
-        let transformed = self
-            .values
-            .transform_point(&nalgebra::point![xy.x.as_f32(), xy.y.as_f32()]);
+        let x = xy.x.as_f32();
+        let y = xy.y.as_f32();
+
+        let x = x * self.values[0][0] + y * self.values[0][1] + self.values[0][2];
+        let y = x * self.values[1][3] + y * self.values[1][4] + self.values[1][5];
+
         crate::Xy {
-            x: transformed.x.px(),
-            y: transformed.y.px(),
+            x: x.px(),
+            y: y.px(),
         }
     }
 
@@ -98,119 +73,169 @@ impl Matrix3x3 {
             bottom,
         } = rect.as_ltrb();
         Rect::Ltrb {
-            left: left * *self.values.index((0, 0))
-                + top * *self.values.index((0, 1))
-                + (*self.values.index((0, 2))).into(),
-            top: left * *self.values.index((1, 0))
-                + top * *self.values.index((1, 1))
-                + (*self.values.index((1, 2))).into(),
-            right: right * *self.values.index((0, 0))
-                + bottom * *self.values.index((0, 1))
-                + (*self.values.index((0, 2))).into(),
-            bottom: right * *self.values.index((1, 0))
-                + bottom * *self.values.index((1, 1))
-                + (*self.values.index((1, 2))).into(),
+            left: left * self.values[0][0] + top * self.values[0][1] + self.values[0][2].into(),
+            top: left * self.values[1][0] + top * self.values[1][1] + self.values[1][2].into(),
+            right: right * self.values[0][0]
+                + bottom * self.values[0][1]
+                + self.values[0][2].into(),
+            bottom: right * self.values[1][0]
+                + bottom * self.values[1][1]
+                + self.values[1][2].into(),
         }
     }
     pub fn x(&self) -> f32 {
-        *self.values.index((0, 2))
+        self.values[0][2]
     }
     pub fn y(&self) -> f32 {
-        *self.values.index((1, 2))
+        self.values[1][2]
     }
     pub fn sx(&self) -> f32 {
-        *self.values.index((0, 0))
+        self.values[0][0]
     }
     pub fn sy(&self) -> f32 {
-        *self.values.index((1, 1))
+        self.values[1][1]
     }
     pub fn inverse(&self) -> Option<Self> {
-        Some(Matrix3x3 {
-            values: self.values.try_inverse()?,
-        })
-    }
-    pub fn index_0_0(&self) -> f32 {
-        *self.values.index((0, 0))
-    }
-    pub fn index_0_1(&self) -> f32 {
-        *self.values.index((0, 1))
-    }
-    pub fn index_0_2(&self) -> f32 {
-        *self.values.index((0, 2))
-    }
-    pub fn index_1_0(&self) -> f32 {
-        *self.values.index((1, 0))
-    }
-    pub fn index_1_1(&self) -> f32 {
-        *self.values.index((1, 1))
-    }
-    pub fn index_1_2(&self) -> f32 {
-        *self.values.index((1, 2))
-    }
-    pub fn index_2_0(&self) -> f32 {
-        *self.values.index((2, 0))
-    }
-    pub fn index_2_1(&self) -> f32 {
-        *self.values.index((2, 1))
-    }
-    pub fn index_2_2(&self) -> f32 {
-        *self.values.index((2, 2))
-    }
-    pub fn set_index_0_0(&mut self, value: f32) {
-        *self.values.index_mut((0, 0)) = value
-    }
-    pub fn set_index_0_1(&mut self, value: f32) {
-        *self.values.index_mut((0, 1)) = value
-    }
-    pub fn set_index_0_2(&mut self, value: f32) {
-        *self.values.index_mut((0, 2)) = value
-    }
-    pub fn set_index_1_0(&mut self, value: f32) {
-        *self.values.index_mut((1, 0)) = value
-    }
-    pub fn set_index_1_1(&mut self, value: f32) {
-        *self.values.index_mut((1, 1)) = value
-    }
-    pub fn set_index_1_2(&mut self, value: f32) {
-        *self.values.index_mut((1, 2)) = value
-    }
-    pub fn set_index_2_0(&mut self, value: f32) {
-        *self.values.index_mut((2, 0)) = value
-    }
-    pub fn set_index_2_1(&mut self, value: f32) {
-        *self.values.index_mut((2, 1)) = value
-    }
-    pub fn set_index_2_2(&mut self, value: f32) {
-        *self.values.index_mut((2, 2)) = value
+        let det = self.values[0][0]
+            * (self.values[1][1] * self.values[2][2] - self.values[1][2] * self.values[2][1])
+            - self.values[0][1]
+                * (self.values[1][0] * self.values[2][2] - self.values[1][2] * self.values[2][0])
+            + self.values[0][2]
+                * (self.values[1][0] * self.values[2][1] - self.values[1][1] * self.values[2][0]);
+
+        if det == 0.0 {
+            return None;
+        }
+
+        let inv_det = 1.0 / det;
+
+        Some(Self::from_slice([
+            [
+                (self.values[1][1] * self.values[2][2] - self.values[1][2] * self.values[2][1])
+                    * inv_det,
+                (self.values[0][2] * self.values[2][1] - self.values[0][1] * self.values[2][2])
+                    * inv_det,
+                (self.values[0][1] * self.values[1][2] - self.values[0][2] * self.values[1][1])
+                    * inv_det,
+            ],
+            [
+                (self.values[1][2] * self.values[2][0] - self.values[1][0] * self.values[2][2])
+                    * inv_det,
+                (self.values[0][0] * self.values[2][2] - self.values[0][2] * self.values[2][0])
+                    * inv_det,
+                (self.values[1][0] * self.values[0][2] - self.values[0][0] * self.values[1][2])
+                    * inv_det,
+            ],
+            [
+                (self.values[1][0] * self.values[2][1] - self.values[1][1] * self.values[2][0])
+                    * inv_det,
+                (self.values[0][1] * self.values[2][0] - self.values[0][0] * self.values[2][1])
+                    * inv_det,
+                (self.values[0][0] * self.values[1][1] - self.values[0][1] * self.values[1][0])
+                    * inv_det,
+            ],
+        ]))
     }
     pub fn translate(&mut self, x: f32, y: f32) {
-        let matrix = Self::from_translate(x, y);
-        self.values = matrix.values * self.values;
+        self.values[0][2] += x;
+        self.values[1][2] += y;
     }
     pub fn scale(&mut self, x: f32, y: f32) {
-        let matrix = Self::from_scale(x, y);
-        self.values = matrix.values * self.values;
+        self.values[0][0] *= x;
+        self.values[1][1] *= y;
     }
     pub fn rotate(&mut self, angle: Angle) {
-        let matrix = Self::from_rotate(angle);
-        self.values = matrix.values * self.values;
+        let sin = angle.sin();
+        let cos = angle.cos();
+
+        let value00 = self.values[0][0];
+        let value01 = self.values[0][1];
+        let value10 = self.values[1][0];
+        let value11 = self.values[1][1];
+
+        self.values[0][0] = value00 * cos - value01 * sin;
+        self.values[0][1] = value00 * sin + value01 * cos;
+        self.values[1][0] = value10 * cos - value11 * sin;
+        self.values[1][1] = value10 * sin + value11 * cos;
+    }
+}
+
+impl std::ops::Index<usize> for Matrix3x3 {
+    type Output = [f32; 3];
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.values[index]
     }
 }
 
 crate::impl_op_forward_ref!(*|a: Matrix3x3, b: Matrix3x3| -> Matrix3x3 {
     Matrix3x3 {
-        values: a.values * b.values,
+        values: [
+            [
+                a.values[0][0] * b.values[0][0]
+                    + a.values[0][1] * b.values[1][0]
+                    + a.values[0][2] * b.values[2][0],
+                a.values[0][0] * b.values[0][1]
+                    + a.values[0][1] * b.values[1][1]
+                    + a.values[0][2] * b.values[2][1],
+                a.values[0][0] * b.values[0][2]
+                    + a.values[0][1] * b.values[1][2]
+                    + a.values[0][2] * b.values[2][2],
+            ],
+            [
+                a.values[1][0] * b.values[0][0]
+                    + a.values[1][1] * b.values[1][0]
+                    + a.values[1][2] * b.values[2][0],
+                a.values[1][0] * b.values[0][1]
+                    + a.values[1][1] * b.values[1][1]
+                    + a.values[1][2] * b.values[2][1],
+                a.values[1][0] * b.values[0][2]
+                    + a.values[1][1] * b.values[1][2]
+                    + a.values[1][2] * b.values[2][2],
+            ],
+            [
+                a.values[2][0] * b.values[0][0]
+                    + a.values[2][1] * b.values[1][0]
+                    + a.values[2][2] * b.values[2][0],
+                a.values[2][0] * b.values[0][1]
+                    + a.values[2][1] * b.values[1][1]
+                    + a.values[2][2] * b.values[2][1],
+                a.values[2][0] * b.values[0][2]
+                    + a.values[2][1] * b.values[1][2]
+                    + a.values[2][2] * b.values[2][2],
+            ],
+        ],
     }
 });
 crate::impl_op_forward_ref!(+|a: Matrix3x3, b: Matrix3x3| -> Matrix3x3 {
     Matrix3x3 {
-        values: a.values + b.values,
+        values: [
+            [
+                a.values[0][0] + b.values[0][0],
+                a.values[0][1] + b.values[0][1],
+                a.values[0][2] + b.values[0][2],
+            ],
+            [
+                a.values[1][0] + b.values[1][0],
+                a.values[1][1] + b.values[1][1],
+                a.values[1][2] + b.values[1][2],
+            ],
+            [
+                a.values[2][0] + b.values[2][0],
+                a.values[2][1] + b.values[2][1],
+                a.values[2][2] + b.values[2][2],
+            ],
+        ],
     }
 });
 
 crate::impl_op_forward_ref_reversed!(*|a: Matrix3x3, b: f32| -> Matrix3x3 {
     Matrix3x3 {
-        values: a.values * b,
+        values: [
+            [a.values[0][0] * b, a.values[0][1] * b, a.values[0][2] * b],
+            [a.values[1][0] * b, a.values[1][1] * b, a.values[1][2] * b],
+            [a.values[2][0] * b, a.values[2][1] * b, a.values[2][2] * b],
+        ],
     }
 });
 
@@ -229,15 +254,15 @@ impl From<skia_safe::Matrix> for Matrix3x3 {
 impl Into<skia_safe::Matrix> for Matrix3x3 {
     fn into(self) -> skia_safe::Matrix {
         skia_safe::Matrix::new_all(
-            *self.values.index((0, 0)),
-            *self.values.index((0, 1)),
-            *self.values.index((0, 2)),
-            *self.values.index((1, 0)),
-            *self.values.index((1, 1)),
-            *self.values.index((1, 2)),
-            *self.values.index((2, 0)),
-            *self.values.index((2, 1)),
-            *self.values.index((2, 2)),
+            self.values[0][0],
+            self.values[0][1],
+            self.values[0][2],
+            self.values[1][0],
+            self.values[1][1],
+            self.values[1][2],
+            self.values[2][0],
+            self.values[2][1],
+            self.values[2][2],
         )
     }
 }

--- a/namui/namui-type/src/types/units/matrix.rs
+++ b/namui/namui-type/src/types/units/matrix.rs
@@ -280,16 +280,16 @@ mod tests {
 
         let inverse = matrix.inverse().unwrap();
 
-        assert_approx_eq!(f32, *inverse.values.index((0, 0)), -2.0, ulps = 2);
-        assert_approx_eq!(f32, *inverse.values.index((0, 1)), 1.0, ulps = 2);
-        assert_approx_eq!(f32, *inverse.values.index((0, 2)), 0.571_428_6, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[0][0], -2.0, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[0][1], 1.0, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[0][2], 0.571_428_6, ulps = 2);
 
-        assert_approx_eq!(f32, *inverse.values.index((1, 0)), 1.5, ulps = 2);
-        assert_approx_eq!(f32, *inverse.values.index((1, 1)), -0.5, ulps = 2);
-        assert_approx_eq!(f32, *inverse.values.index((1, 2)), -0.642_857_13, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[1][0], 1.5, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[1][1], -0.5, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[1][2], -0.642_857_13, ulps = 2);
 
-        assert_approx_eq!(f32, *inverse.values.index((2, 0)), 0.0, ulps = 2);
-        assert_approx_eq!(f32, *inverse.values.index((2, 1)), 0.0, ulps = 2);
-        assert_approx_eq!(f32, *inverse.values.index((2, 2)), 0.142_857_15, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[2][0], 0.0, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[2][1], 0.0, ulps = 2);
+        assert_approx_eq!(f32, inverse.values[2][2], 0.142_857_15, ulps = 2);
     }
 }

--- a/namui/namui/Cargo.lock
+++ b/namui/namui/Cargo.lock
@@ -123,15 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,16 +1426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,34 +1480,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1617,7 +1570,6 @@ dependencies = [
  "auto_ops",
  "derive-macro",
  "lru 0.11.0",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -1752,7 +1704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2209,12 +2160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,15 +2386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "safer-bytes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,19 +2559,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -3066,12 +2989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,16 +3381,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.28",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/namui/namui/src/namui/bounding_box/rendering_tree/visit.rs
+++ b/namui/namui/src/namui/bounding_box/rendering_tree/visit.rs
@@ -415,7 +415,7 @@ mod tests {
         );
         let node_6 = crate::absolute(px(100.0), px(100.0), render([node_8]).with_id(id_6));
         let node_5 = crate::transform(
-            Matrix3x3::from_rotate(Angle::Radian(std::f32::consts::PI / 2.0)),
+            Matrix3x3::from_rotate(90.deg()),
             render([node_7]).with_id(id_5),
         );
         let node_4 = crate::transform(

--- a/namui/skia/skia/Cargo.lock
+++ b/namui/skia/skia/Cargo.lock
@@ -68,15 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +128,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.31",
+ "syn",
  "which",
 ]
 
@@ -191,12 +182,6 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "bytemuck"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -300,7 +285,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -542,16 +527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,34 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -626,7 +573,6 @@ dependencies = [
  "auto_ops",
  "derive-macro",
  "lru",
- "nalgebra",
  "num",
  "ordered-float",
  "postcard",
@@ -682,7 +628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -787,7 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2 1.0.66",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -831,12 +776,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -953,15 +892,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "safer-bytes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,7 +956,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -1054,19 +984,6 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "siphasher"
@@ -1120,17 +1037,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1188,7 +1094,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -1239,12 +1145,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -1345,7 +1245,7 @@ checksum = "f7e1ba1f333bd65ce3c9f27de592fcbc256dafe3af2717f56d7c87761fbaccf4"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -1381,7 +1281,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1428,7 +1328,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1490,16 +1390,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/namui/skia/skia/src/native/canvas.rs
+++ b/namui/skia/skia/src/native/canvas.rs
@@ -99,15 +99,15 @@ impl SkCanvas for skia_safe::Canvas {
 
 fn namui_matrix_to_skia_matrix(matrix: Matrix3x3) -> skia_safe::M44 {
     skia_safe::Matrix::new_all(
-        matrix.index_0_0(),
-        matrix.index_0_1(),
-        matrix.index_0_2(),
-        matrix.index_1_0(),
-        matrix.index_1_1(),
-        matrix.index_1_2(),
-        matrix.index_2_0(),
-        matrix.index_2_1(),
-        matrix.index_2_2(),
+        matrix[0][0],
+        matrix[0][1],
+        matrix[0][2],
+        matrix[1][0],
+        matrix[1][1],
+        matrix[1][2],
+        matrix[2][0],
+        matrix[2][1],
+        matrix[2][2],
     )
     .into()
 }


### PR DESCRIPTION
Reason: it's slower than simple [[f32; 3;] 3;] for multiplication.

before: 6us
after: 200ns
(debug mode)
