### PR TITLE
Remove lto, but use opt for debug

### DIFF
--- a/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
+++ b/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
@@ -21,12 +21,10 @@ edition = "2021"
 {project_name} = {{ path = "{project_path}" }}
 
 [profile.release]
-lto = true
 opt-level = 3
 
 # [profile.dev]
-# lto = true
-# opt-level = 2
+opt-level = 2
     "#,
             project_path = project_path_in_relative
                 .to_str()


### PR DESCRIPTION
1. LTO doesn't make our game faster than I expected. it really not works.
2. opt-2 for debug makes pretty good performance and re-build time is really good (5sec)