### PR TITLE
Remove prelude for namui

### DIFF
--- a/hololive-beat/hololive-beat/src/app/components/backdrop.rs
+++ b/hololive-beat/hololive-beat/src/app/components/backdrop.rs
@@ -1,5 +1,5 @@
 use crate::app::theme::THEME;
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct Backdrop {

--- a/hololive-beat/hololive-beat/src/app/components/frame.rs
+++ b/hololive-beat/hololive-beat/src/app/components/frame.rs
@@ -1,5 +1,5 @@
 use crate::app::theme::THEME;
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct DarkFrame {

--- a/hololive-beat/hololive-beat/src/app/mod.rs
+++ b/hololive-beat/hololive-beat/src/app/mod.rs
@@ -20,7 +20,7 @@ use self::{
     play_state::{PlayState, PLAY_STATE_ATOM},
     setting_overlay::{SettingOverlay, SETTING_OVERLAY_OPEN_ATOM},
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 pub static MUSIC_SPEED_MAP_ATOM: Atom<Option<MusicSpeedMap>> = Atom::uninitialized();

--- a/hololive-beat/hololive-beat/src/app/music_play_page/game_ender.rs
+++ b/hololive-beat/hololive-beat/src/app/music_play_page/game_ender.rs
@@ -1,5 +1,5 @@
 use crate::app::play_state::{stop_game, PlayState, PlayTimeState, PLAY_STATE_ATOM};
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct GameEnder {

--- a/hololive-beat/hololive-beat/src/app/music_play_page/game_result_overlay/mod.rs
+++ b/hololive-beat/hololive-beat/src/app/music_play_page/game_result_overlay/mod.rs
@@ -4,7 +4,7 @@ use crate::app::{
     theme::THEME,
     MUSIC_BEST_SCORE_MAP_ATOM,
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::typography::{self, adjust_font_size, effect::glow};
 
 const PADDING: Px = px(32.0);

--- a/hololive-beat/hololive-beat/src/app/music_play_page/mod.rs
+++ b/hololive-beat/hololive-beat/src/app/music_play_page/mod.rs
@@ -19,7 +19,7 @@ use crate::app::{
     play_state::pause_game,
     setting_overlay::open_setting_overlay,
 };
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct MusicPlayPage<'a> {

--- a/hololive-beat/hololive-beat/src/app/music_play_page/note_judge.rs
+++ b/hololive-beat/hololive-beat/src/app/music_play_page/note_judge.rs
@@ -3,7 +3,7 @@ use crate::app::{
     note::{Direction, Note},
     play_state::{PlayState, PlayTimeState, PLAY_STATE_ATOM},
 };
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct NoteJudge<'a> {

--- a/hololive-beat/hololive-beat/src/app/music_play_page/video_player.rs
+++ b/hololive-beat/hololive-beat/src/app/music_play_page/video_player.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 #[component]

--- a/hololive-beat/hololive-beat/src/app/music_select_page/music_carousel.rs
+++ b/hololive-beat/hololive-beat/src/app/music_select_page/music_carousel.rs
@@ -4,7 +4,7 @@ use crate::app::{
     theme::THEME,
 };
 use keyframe::num_traits::Signed;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, table::hooks::*, typography::adjust_font_size};
 use std::f32::consts::PI;
 

--- a/hololive-beat/hololive-beat/src/app/music_select_page/speed_dropdown.rs
+++ b/hololive-beat/hololive-beat/src/app/music_select_page/speed_dropdown.rs
@@ -4,7 +4,7 @@ use crate::app::{
     theme::THEME,
     MUSIC_SPEED_MAP_ATOM,
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{table::hooks::*, typography::adjust_font_size};
 
 #[component]

--- a/hololive-beat/hololive-beat/src/app/music_select_page/top_bar.rs
+++ b/hololive-beat/hololive-beat/src/app/music_select_page/top_bar.rs
@@ -5,7 +5,7 @@ use crate::app::{
     setting_overlay::open_setting_overlay,
     theme::THEME,
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, table::hooks::*, typography};
 
 #[component]

--- a/hololive-beat/hololive-beat/src/app/setting_overlay/slider.rs
+++ b/hololive-beat/hololive-beat/src/app/setting_overlay/slider.rs
@@ -1,5 +1,5 @@
 use crate::app::theme::THEME;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 const THUMB_WIDTH: Px = px(16.0);

--- a/hololive-beat/hololive-beat/src/app/setting_overlay/volume_setting.rs
+++ b/hololive-beat/hololive-beat/src/app/setting_overlay/volume_setting.rs
@@ -1,5 +1,5 @@
 use crate::app::{setting_overlay::slider::Slider, theme::THEME};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{table::hooks::*, typography::adjust_font_size};
 
 #[component]

--- a/hololive-beat/note-register/src/app/mod.rs
+++ b/hololive-beat/note-register/src/app/mod.rs
@@ -5,7 +5,7 @@ mod player;
 use self::{color::THEME, player::Player};
 use crate::app::note::load_notes;
 use futures::join;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 #[namui::component]

--- a/hololive-beat/note-register/src/app/player/note_judge.rs
+++ b/hololive-beat/note-register/src/app/player/note_judge.rs
@@ -1,6 +1,6 @@
 use super::{State, JUDGE_CONTEXT, STATE};
 use crate::app::note::{Direction, Note};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 use std::collections::HashSet;
 

--- a/hololive-beat/note-register/src/app/player/note_plotter.rs
+++ b/hololive-beat/note-register/src/app/player/note_plotter.rs
@@ -2,7 +2,7 @@ use crate::app::{
     color::THEME,
     note::{Direction, Note},
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, typography};
 
 #[namui::component]

--- a/hololive-beat/note-register/src/app/player/slider.rs
+++ b/hololive-beat/note-register/src/app/player/slider.rs
@@ -1,5 +1,5 @@
 use crate::app::color::THEME;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 const THUMB_WIDTH: Px = px(32.0);

--- a/luda-adventure/src/app/game/game.rs
+++ b/luda-adventure/src/app/game/game.rs
@@ -1,7 +1,7 @@
 use super::{
     known_id::object::PLAYER_CHARACTER, render::render_background, save_load::SaveLoad, *,
 };
-use namui::prelude::*;
+use namui::*;
 use std::collections::HashSet;
 
 pub struct Game {

--- a/luda-adventure/src/app/game/image_loader.rs
+++ b/luda-adventure/src/app/game/image_loader.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use std::sync::{Arc, Mutex};
 
 pub struct ImageLoader {

--- a/luda-adventure/src/app/game/interaction/nearest_entity_id.rs
+++ b/luda-adventure/src/app/game/interaction/nearest_entity_id.rs
@@ -4,7 +4,7 @@ use crate::{
     component::{Interactor, Positioner, Renderer},
     ecs::Entity,
 };
-use namui::prelude::*;
+use namui::*;
 
 pub fn nearest_entity(
     interactive_object_list: &Vec<((&Entity, (&Interactor, &Positioner, &Renderer)), Tile)>,

--- a/luda-adventure/src/app/game/known_id/object.rs
+++ b/luda-adventure/src/app/game/known_id/object.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub const PLAYER_CHARACTER: Uuid = uuid!("efbd99d3-b2ce-4404-a59c-f20af7a5af21");
 pub const FIRST_QUEST_OBJECT: Uuid = uuid!("9096b9c0-66b7-4d1b-954c-e7906fdd82b0");

--- a/luda-adventure/src/app/game/known_id/quest.rs
+++ b/luda-adventure/src/app/game/known_id/quest.rs
@@ -1,3 +1,3 @@
-use namui::prelude::*;
+use namui::*;
 
 pub const FIRST_QUEST: Uuid = uuid!("3c8029c2-5f2f-4c4f-8116-c9b466f6ebc7");

--- a/luda-adventure/src/app/game/map/map_object/map_object.rs
+++ b/luda-adventure/src/app/game/map/map_object/map_object.rs
@@ -1,5 +1,5 @@
 use super::Portal;
-use namui::prelude::*;
+use namui::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/luda-adventure/src/app/game/map/map_object/portal.rs
+++ b/luda-adventure/src/app/game/map/map_object/portal.rs
@@ -2,7 +2,7 @@ use crate::{
     app::game::{Tile, TileExt},
     component::{Interactor, Positioner, RenderType, Renderer, Sprite},
 };
-use namui::prelude::*;
+use namui::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/luda-adventure/src/app/game/map/try_create_new_polygon.rs
+++ b/luda-adventure/src/app/game/map/try_create_new_polygon.rs
@@ -1,5 +1,5 @@
 use geo::{coord, Area, Coord, EuclideanDistance, Line, LineString, Polygon};
-use namui::prelude::*;
+use namui::*;
 use std::collections::HashMap;
 
 pub(super) fn try_create_new_polygon(

--- a/luda-adventure/src/app/game/menu/menu.rs
+++ b/luda-adventure/src/app/game/menu/menu.rs
@@ -1,5 +1,5 @@
 use super::{render_in_game_menu, render_start_menu};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::event_trap;
 
 pub struct Menu {

--- a/luda-adventure/src/app/game/menu/render/render_in_game_menu.rs
+++ b/luda-adventure/src/app/game/menu/render/render_in_game_menu.rs
@@ -1,5 +1,5 @@
 use crate::app::game::{map::MapLoader, save_load::SaveLoad, TileExt};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{
     button::text_button_fit,
     simple_rect,

--- a/luda-adventure/src/app/game/menu/render/render_start_menu.rs
+++ b/luda-adventure/src/app/game/menu/render/render_start_menu.rs
@@ -1,6 +1,6 @@
 use crate::app::game::{image_loader::ImageLoader, map::MapLoader, menu, save_load, TileExt};
 use menu::Menu;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{
     button::text_button_fit,
     simple_rect,

--- a/luda-adventure/src/app/game/render/create_rendering_context.rs
+++ b/luda-adventure/src/app/game/render/create_rendering_context.rs
@@ -1,6 +1,6 @@
 use crate::app::game::*;
 use crate::component::*;
-use namui::prelude::*;
+use namui::*;
 
 impl Game {
     pub fn create_rendering_context(&self) -> RenderingContext {

--- a/luda-adventure/src/app/game/render/render_background.rs
+++ b/luda-adventure/src/app/game/render/render_background.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 pub fn render_background() -> namui::RenderingTree {

--- a/luda-adventure/src/app/game/render/render_in_screen_object_list.rs
+++ b/luda-adventure/src/app/game/render/render_in_screen_object_list.rs
@@ -1,6 +1,6 @@
 use crate::component::*;
 use crate::{app::game::*, ecs::Entity};
-use namui::prelude::*;
+use namui::*;
 use std::cmp::Ordering;
 
 impl Game {

--- a/luda-adventure/src/app/game/render/render_interaction_guide.rs
+++ b/luda-adventure/src/app/game/render/render_interaction_guide.rs
@@ -2,7 +2,7 @@ use crate::app::game::{
     interaction::{nearest_entity, MAX_INTERACTION_DISTANCE},
     Game, RenderingContext,
 };
-use namui::prelude::*;
+use namui::*;
 
 const ICON_SIZE: Px = px(36.0);
 const OFFSET_Y: Px = px(-4.0);

--- a/luda-adventure/src/app/game/render/render_quest_guide/render_guide_arrow.rs
+++ b/luda-adventure/src/app/game/render/render_quest_guide/render_guide_arrow.rs
@@ -1,7 +1,7 @@
 use crate::app::game::*;
 use crate::component::*;
 use crate::ecs::Entity;
-use namui::prelude::*;
+use namui::*;
 
 const ARROW_SIZE: f32 = 16.0;
 

--- a/luda-adventure/src/app/game/render/render_quest_guide/render_guide_icon.rs
+++ b/luda-adventure/src/app/game/render/render_quest_guide/render_guide_icon.rs
@@ -1,7 +1,7 @@
 use crate::app::game::*;
 use crate::component::*;
 use crate::ecs::Entity;
-use namui::prelude::*;
+use namui::*;
 
 pub fn render_guide_icon(
     quest_entity_list: &Vec<&Entity>,

--- a/luda-adventure/src/app/game/render/render_quest_guide/render_quest_guide.rs
+++ b/luda-adventure/src/app/game/render/render_quest_guide/render_quest_guide.rs
@@ -3,7 +3,7 @@ use crate::{
     app::game::*,
     component::{PlayerCharacter, Positioner, Renderer},
 };
-use namui::prelude::*;
+use namui::*;
 
 impl Game {
     pub fn render_quest_guide(&self, rendering_context: &RenderingContext) -> RenderingTree {

--- a/luda-adventure/src/app/game/render/translate_to_camera_screen.rs
+++ b/luda-adventure/src/app/game/render/translate_to_camera_screen.rs
@@ -1,5 +1,5 @@
 use crate::app::game::{Game, RenderingContext};
-use namui::prelude::*;
+use namui::*;
 
 impl Game {
     pub fn translate_to_camera_screen(

--- a/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
+++ b/luda-adventure/src/app/game/test/character_should_escape_edge_of_wall.rs
@@ -3,7 +3,7 @@ use crate::{
     component::*,
     ecs,
 };
-use namui::prelude::*;
+use namui::*;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[test]

--- a/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
+++ b/luda-adventure/src/app/game/test/character_should_not_move_on_cross_axis_when_collide.rs
@@ -4,7 +4,7 @@ use crate::{
     ecs,
 };
 use float_cmp::assert_approx_eq;
-use namui::prelude::*;
+use namui::*;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[test]

--- a/luda-adventure/src/app/game/types/game_object/floor.rs
+++ b/luda-adventure/src/app/game/types/game_object/floor.rs
@@ -1,6 +1,6 @@
 use crate::app::game::*;
 use crate::component::*;
-use namui::prelude::*;
+use namui::*;
 
 const VISUAL_WIDTH: Tile = tile(1.0);
 const VISUAL_HEIGHT: Tile = tile(1.0);

--- a/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
+++ b/luda-adventure/src/app/game/types/game_object/player_character/player_character.rs
@@ -1,6 +1,6 @@
 use crate::app::game::{known_id::object::PLAYER_CHARACTER, *};
 use crate::component::*;
-use namui::prelude::*;
+use namui::*;
 
 const VISUAL_WIDTH: Tile = tile(3.0);
 const VISUAL_HEIGHT: Tile = tile(4.0);

--- a/luda-adventure/src/app/game/types/game_object/player_character/render.rs
+++ b/luda-adventure/src/app/game/types/game_object/player_character/render.rs
@@ -2,7 +2,7 @@ use crate::{
     app::game::{tile, Tile},
     component::{Sprite, SpriteAnimation},
 };
-use namui::prelude::*;
+use namui::*;
 
 const VISUAL_WIDTH: Tile = tile(3.0);
 const VISUAL_HEIGHT: Tile = tile(4.0);

--- a/luda-adventure/src/app/game/types/game_object/wall.rs
+++ b/luda-adventure/src/app/game/types/game_object/wall.rs
@@ -1,6 +1,6 @@
 use crate::app::game::*;
 use crate::component::*;
-use namui::prelude::*;
+use namui::*;
 
 const VISUAL_WIDTH: Tile = tile(1.0);
 const VISUAL_HEIGHT: Tile = tile(1.0);

--- a/luda-adventure/src/app/game/types/game_state/quest/quest.rs
+++ b/luda-adventure/src/app/game/types/game_state/quest/quest.rs
@@ -1,6 +1,6 @@
 use super::QuestAction;
 use crate::app::game::known_id;
-use namui::prelude::*;
+use namui::*;
 
 pub struct Quest {
     pub id: Uuid,

--- a/luda-adventure/src/app/game/types/game_state/quest/quest_action.rs
+++ b/luda-adventure/src/app/game/types/game_state/quest/quest_action.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub enum QuestAction {
     WaitForUserInteractObject(Uuid),

--- a/luda-adventure/src/app/game/types/game_state/quest/quest_state.rs
+++ b/luda-adventure/src/app/game/types/game_state/quest/quest_state.rs
@@ -1,6 +1,6 @@
 use super::Quest;
 use crate::app::game::known_id;
-use namui::prelude::*;
+use namui::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 

--- a/luda-adventure/src/app/game/types/game_state/tick_state.rs
+++ b/luda-adventure/src/app/game/types/game_state/tick_state.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use serde::{Deserialize, Serialize};
 
 // 25 tick per second

--- a/luda-adventure/src/app/game/types/rendering_context.rs
+++ b/luda-adventure/src/app/game/types/rendering_context.rs
@@ -1,5 +1,5 @@
 use super::Tile;
-use namui::prelude::*;
+use namui::*;
 
 pub struct RenderingContext {
     pub px_per_tile: Per<Px, Tile>,

--- a/luda-adventure/src/app/game/update/evaluate_ticks/move_character.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/move_character.rs
@@ -1,6 +1,6 @@
 use crate::app::game::*;
 use crate::component::*;
-use namui::prelude::*;
+use namui::*;
 
 impl Game {
     pub fn move_character(&mut self, delta_time: Time) {

--- a/luda-adventure/src/app/game/update/evaluate_ticks/resolve_collision_about_character.rs
+++ b/luda-adventure/src/app/game/update/evaluate_ticks/resolve_collision_about_character.rs
@@ -3,7 +3,7 @@ use crate::{
     app::game::{known_id::object::PLAYER_CHARACTER, Game, Tile},
     ecs,
 };
-use namui::prelude::*;
+use namui::*;
 
 const MAX_COLLISION_RESOLVE_COUNT: i32 = 6;
 

--- a/luda-adventure/src/app/game/update/set_character_movement_according_to_user_input.rs
+++ b/luda-adventure/src/app/game/update/set_character_movement_according_to_user_input.rs
@@ -1,6 +1,6 @@
 use crate::app::game::*;
 use crate::component::*;
-use namui::prelude::*;
+use namui::*;
 use std::collections::{hash_map::RandomState, HashSet};
 
 impl Game {

--- a/luda-adventure/src/component/collider/collider.rs
+++ b/luda-adventure/src/component/collider/collider.rs
@@ -1,7 +1,7 @@
 use super::RigidBody;
 use crate::app::game::Tile;
 use geo::Polygon;
-use namui::prelude::*;
+use namui::*;
 
 #[ecs_macro::component]
 pub struct Collider {

--- a/luda-adventure/src/component/collider/collision_info.rs
+++ b/luda-adventure/src/component/collider/collision_info.rs
@@ -1,5 +1,5 @@
 use crate::app::game::Tile;
-use namui::prelude::*;
+use namui::*;
 use std::ops::Neg;
 
 #[derive(Clone, Copy)]

--- a/luda-adventure/src/component/collider/rigid_body/collide_circle_to_polygon.rs
+++ b/luda-adventure/src/component/collider/rigid_body/collide_circle_to_polygon.rs
@@ -1,7 +1,7 @@
 use super::Circle;
 use crate::{app::game::Tile, component::CollisionInfo};
 use geo::*;
-use namui::prelude::*;
+use namui::*;
 
 pub fn collide_circle_to_polygon(circle: &Circle, polygon: &Polygon) -> CollisionInfo {
     let lines = polygon.lines_iter().collect::<Vec<_>>();

--- a/luda-adventure/src/component/collider/rigid_body/rigid_body.rs
+++ b/luda-adventure/src/component/collider/rigid_body/rigid_body.rs
@@ -1,7 +1,7 @@
 use super::{collide_circle_to_polygon, collide_polygon_to_circle, Circle};
 use crate::{app::game::Tile, component::CollisionInfo};
 use geo::{coord, polygon, Polygon, Translate};
-use namui::prelude::*;
+use namui::*;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum RigidBody {

--- a/luda-adventure/src/component/mover.rs
+++ b/luda-adventure/src/component/mover.rs
@@ -1,5 +1,5 @@
 use crate::app::game::Tile;
-use namui::prelude::*;
+use namui::*;
 
 #[ecs_macro::component]
 #[derive(Debug)]

--- a/luda-adventure/src/component/player_character.rs
+++ b/luda-adventure/src/component/player_character.rs
@@ -1,5 +1,5 @@
 use crate::app::game::Heading;
-use namui::prelude::*;
+use namui::*;
 
 #[ecs_macro::component]
 pub struct PlayerCharacter {

--- a/luda-adventure/src/component/positioner.rs
+++ b/luda-adventure/src/component/positioner.rs
@@ -1,5 +1,5 @@
 use crate::app::game::Tile;
-use namui::prelude::*;
+use namui::*;
 
 #[ecs_macro::component]
 #[derive(Debug)]

--- a/luda-adventure/src/component/renderer/minimum_visual_rect_containing_sprites.rs
+++ b/luda-adventure/src/component/renderer/minimum_visual_rect_containing_sprites.rs
@@ -1,6 +1,6 @@
 use super::Sprite;
 use crate::app::game::Tile;
-use namui::prelude::*;
+use namui::*;
 
 pub fn minimum_visual_rect_containing_sprites(sprites: &Vec<Sprite>) -> Option<Rect<Tile>> {
     let first_visual_rect = sprites.first().map(|sprite| sprite.visual_rect);

--- a/luda-adventure/src/component/renderer/render_type.rs
+++ b/luda-adventure/src/component/renderer/render_type.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::app::game::{GameState, RenderingContext, Tile};
-use namui::prelude::*;
+use namui::*;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum RenderType {

--- a/luda-adventure/src/component/renderer/renderer.rs
+++ b/luda-adventure/src/component/renderer/renderer.rs
@@ -1,5 +1,5 @@
 use crate::{app::game::*, component::*};
-use namui::prelude::*;
+use namui::*;
 
 #[ecs_macro::component]
 pub struct Renderer {

--- a/luda-adventure/src/component/renderer/sprite.rs
+++ b/luda-adventure/src/component/renderer/sprite.rs
@@ -1,5 +1,5 @@
 use crate::app::game::{RenderingContext, Tile};
-use namui::prelude::*;
+use namui::*;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Sprite {

--- a/luda-adventure/src/component/renderer/sprite_animation.rs
+++ b/luda-adventure/src/component/renderer/sprite_animation.rs
@@ -1,6 +1,6 @@
 use super::{minimum_visual_rect_containing_sprites, Sprite};
 use crate::app::game::{GameState, RenderingContext, Tile};
-use namui::prelude::*;
+use namui::*;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct SpriteAnimation {

--- a/luda-adventure/src/component/renderer/sprite_batch.rs
+++ b/luda-adventure/src/component/renderer/sprite_batch.rs
@@ -1,6 +1,6 @@
 use super::{minimum_visual_rect_containing_sprites, Sprite};
 use crate::app::game::{RenderingContext, Tile};
-use namui::prelude::*;
+use namui::*;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct SpriteBatch {

--- a/luda-adventure/src/ecs/app/save/mod.rs
+++ b/luda-adventure/src/ecs/app/save/mod.rs
@@ -58,7 +58,7 @@ mod test {
     use super::*;
     use crate::app::game::*;
     use crate::component::*;
-    use namui::prelude::*;
+    use namui::*;
     use std::str::FromStr;
     use wasm_bindgen_test::wasm_bindgen_test;
 

--- a/luda-editor/client/src/app/login.rs
+++ b/luda-editor/client/src/app/login.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use namui::prelude::*;
+use namui::*;
 
 const DEV_CLIENT_ID: &str = "abd04a6aeba3e99f5b4b";
 const CLIENT_ID: Option<&str> = option_env!("GITHUB_CLIENT_ID");

--- a/luda-editor/client/src/app/mod.rs
+++ b/luda-editor/client/src/app/mod.rs
@@ -4,7 +4,7 @@ pub mod notification;
 use self::notification::NotificationRoot;
 use crate::{components::context_menu::ContextMenu, pages::router::Router};
 use anyhow::Result;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 
 #[namui::component]

--- a/luda-editor/client/src/app/notification/components/close_button.rs
+++ b/luda-editor/client/src/app/notification/components/close_button.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 #[component]

--- a/luda-editor/client/src/app/notification/components/copy_button.rs
+++ b/luda-editor/client/src/app/notification/components/copy_button.rs
@@ -1,5 +1,5 @@
 use crate::app::notification::{self};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 #[component]

--- a/luda-editor/client/src/app/notification/components/notification_indicator.rs
+++ b/luda-editor/client/src/app/notification/components/notification_indicator.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct LoadingIndicator {

--- a/luda-editor/client/src/app/notification/components/notification_root.rs
+++ b/luda-editor/client/src/app/notification/components/notification_root.rs
@@ -1,5 +1,5 @@
 use super::*;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, typography::text_fit};
 use std::ops::Deref;
 

--- a/luda-editor/client/src/app/notification/mod.rs
+++ b/luda-editor/client/src/app/notification/mod.rs
@@ -1,7 +1,7 @@
 mod components;
 
 pub use components::NotificationRoot;
-use namui::prelude::*;
+use namui::*;
 
 static NOTIFICATIONS_ATOM: Atom<Vec<Notification>> = Atom::uninitialized_new();
 fn atom(ctx: &RenderCtx) -> (Sig<Vec<Notification>>, SetState<Vec<Notification>>) {

--- a/luda-editor/client/src/components/cg_render.rs
+++ b/luda-editor/client/src/components/cg_render.rs
@@ -1,5 +1,5 @@
 use crate::storage::get_project_cg_part_variant_image_url;
-use namui::prelude::*;
+use namui::*;
 use rpc::data::*;
 
 #[component]

--- a/luda-editor/client/src/components/context_menu.rs
+++ b/luda-editor/client/src/components/context_menu.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use std::any::Any;
 

--- a/luda-editor/client/src/components/image_upload/mod.rs
+++ b/luda-editor/client/src/components/image_upload/mod.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use rpc::data::*;
 use rpc::utils::retry_on_error;
 

--- a/luda-editor/client/src/components/name_quick_slot.rs
+++ b/luda-editor/client/src/components/name_quick_slot.rs
@@ -1,5 +1,5 @@
 use crate::app::notification;
-use namui::prelude::*;
+use namui::*;
 use std::collections::HashMap;
 
 #[derive(Clone, Debug)]

--- a/luda-editor/client/src/components/sequence_player.rs
+++ b/luda-editor/client/src/components/sequence_player.rs
@@ -1,6 +1,6 @@
 use super::cg_render;
 use crate::storage::{get_project_cg_thumbnail_image_url, get_project_image_url};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::data::*;
 

--- a/luda-editor/client/src/components/tool_tip.rs
+++ b/luda-editor/client/src/components/tool_tip.rs
@@ -1,5 +1,5 @@
 use crate::color;
-use namui::prelude::*;
+use namui::*;
 
 #[derive(Clone)]
 #[component]

--- a/luda-editor/client/src/lib.rs
+++ b/luda-editor/client/src/lib.rs
@@ -11,7 +11,7 @@ mod storage;
 // mod share_preview;
 // mod viewer;
 
-use namui::prelude::*;
+use namui::*;
 
 #[cfg(test)]
 #[cfg(target_family = "wasm")]

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/auto_column_list.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/auto_column_list.rs
@@ -1,5 +1,5 @@
 use crate::color;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{scroll_view, simple_rect, table::hooks::*, typography};
 use std::fmt::Debug;
 

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/cg_list.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/cg_list.rs
@@ -1,6 +1,6 @@
 use super::{auto_column_list::AutoColumnList, CG_FILES_ATOM, SELECTED_ASSET_ATOM};
 use crate::{color, storage::get_project_cg_thumbnail_image_url};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 use rpc::data::{CgFile, ScreenCg};
 

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/cg_viewer/mod.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/cg_viewer/mod.rs
@@ -2,7 +2,7 @@ mod part_picker;
 
 use self::part_picker::PartPicker;
 use crate::{color, components::cg_render::CgRender, storage::get_project_cg_thumbnail_image_url};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{button, simple_rect, table::hooks::*, typography};
 use rpc::data::{CgFile, ScreenCg};
 use std::ops::Deref;

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/cg_viewer/part_picker.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/cg_viewer/part_picker.rs
@@ -1,6 +1,6 @@
 use super::Event;
 use crate::{color, components::tool_tip::ToolTip, storage::get_project_cg_part_variant_image_url};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{
     scroll_view, simple_rect,
     table::hooks::*,

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/image_list.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/image_list.rs
@@ -1,6 +1,6 @@
 use super::{auto_column_list::AutoColumnList, SelectedAsset, IMAGES_ATOM, SELECTED_ASSET_ATOM};
 use crate::{color, storage::get_project_image_url};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 use rpc::data::ImageWithLabels;
 

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/image_viewer.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/image_viewer.rs
@@ -1,5 +1,5 @@
 use crate::{color, storage::get_project_image_url};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{button, simple_rect, table::hooks::*, typography};
 
 const MODAL_MAX_WH: Wh<Px> = Wh {

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/mod.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 use futures::join;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, table::hooks::*};
 use rpc::data::{CgFile, ImageWithLabels, ScreenCg, ScreenCgPart};
 use std::ops::Deref;

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/side_bar.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/side_bar.rs
@@ -1,6 +1,6 @@
 use super::Tab;
 use crate::{color, pages::graphic_asset_manage_page::TAB_ATOM};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, table::hooks::*, typography};
 
 #[component]

--- a/luda-editor/client/src/pages/graphic_asset_manage_page/upload_asset.rs
+++ b/luda-editor/client/src/pages/graphic_asset_manage_page/upload_asset.rs
@@ -3,7 +3,7 @@ use crate::{
     app::notification::{self, remove_notification},
     components::{cg_upload::create_cg, image_upload::create_image},
 };
-use namui::prelude::*;
+use namui::*;
 use std::path::PathBuf;
 
 pub async fn upload_file(file: &File, project_id: Uuid) {

--- a/luda-editor/client/src/pages/project_acl_manage_page/mod.rs
+++ b/luda-editor/client/src/pages/project_acl_manage_page/mod.rs
@@ -4,7 +4,7 @@ use crate::app::notification;
 use crate::app::notification::Notification;
 use crate::color;
 use crate::RPC;
-use namui::prelude::*;
+use namui::*;
 use namui::text_input::Style;
 use namui_prebuilt::button::TextButton;
 use namui_prebuilt::list_view::AutoListView;

--- a/luda-editor/client/src/pages/project_acl_manage_page/top_bar.rs
+++ b/luda-editor/client/src/pages/project_acl_manage_page/top_bar.rs
@@ -2,7 +2,7 @@ use crate::{
     color,
     pages::router::{move_to, Route},
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{button::TextButtonFit, simple_rect, table::hooks::*, typography};
 
 #[component]

--- a/luda-editor/client/src/pages/project_list_page/mod.rs
+++ b/luda-editor/client/src/pages/project_list_page/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     RPC,
 };
 use futures::FutureExt;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::list_editable_projects::EditableProject;
 

--- a/luda-editor/client/src/pages/router.rs
+++ b/luda-editor/client/src/pages/router.rs
@@ -1,5 +1,5 @@
 use super::*;
-use namui::prelude::*;
+use namui::*;
 
 #[namui::component]
 pub struct Router {

--- a/luda-editor/client/src/pages/sequence_edit_page/atom/cg_files_atom.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/atom/cg_files_atom.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use rpc::data::CgFile;
 
 pub static CG_FILES_ATOM: Atom<Vec<CgFile>> = Atom::uninitialized_new();

--- a/luda-editor/client/src/pages/sequence_edit_page/atom/editing_graphic_index_atom.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/atom/editing_graphic_index_atom.rs
@@ -1,3 +1,3 @@
-use namui::prelude::*;
+use namui::*;
 
 pub static EDITING_GRAPHIC_INDEX_ATOM: Atom<Option<Uuid>> = Atom::uninitialized_new();

--- a/luda-editor/client/src/pages/sequence_edit_page/atom/focused_component.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/atom/focused_component.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub static FOCUSED_COMPONENT: Atom<Option<FocusableComponent>> = Atom::uninitialized_new();
 

--- a/luda-editor/client/src/pages/sequence_edit_page/atom/images_atom.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/atom/images_atom.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use rpc::data::ImageWithLabels;
 
 pub static IMAGES_ATOM: Atom<Vec<ImageWithLabels>> = Atom::uninitialized_new();

--- a/luda-editor/client/src/pages/sequence_edit_page/atom/name_quick_slot_atom.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/atom/name_quick_slot_atom.rs
@@ -1,4 +1,4 @@
 use crate::components::name_quick_slot::NameQuickSlot;
-use namui::prelude::*;
+use namui::*;
 
 pub static NAME_QUICK_SLOT: Atom<NameQuickSlot> = Atom::uninitialized_new();

--- a/luda-editor/client/src/pages/sequence_edit_page/atom/sequence_atom.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/atom/sequence_atom.rs
@@ -1,4 +1,4 @@
 use crate::pages::sequence_edit_page::sequence::SequenceWrapped;
-use namui::prelude::*;
+use namui::*;
 
 pub static SEQUENCE_ATOM: Atom<SequenceWrapped> = Atom::uninitialized_new();

--- a/luda-editor/client/src/pages/sequence_edit_page/components/auto_complete_text_input/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/auto_complete_text_input/mod.rs
@@ -2,7 +2,7 @@ mod decomposed_string;
 
 use crate::components::sequence_player;
 use decomposed_string::DecomposedString;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 
 #[namui::component]

--- a/luda-editor/client/src/pages/sequence_edit_page/components/character_editor/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/character_editor/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     components::tool_tip::ToolTip,
     pages::sequence_edit_page::atom::{CG_FILES_ATOM, SEQUENCE_ATOM},
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::data::{Cut, CutUpdateAction, ScreenCg, ScreenGraphic};
 use std::{ops::Deref, sync::atomic::AtomicBool};

--- a/luda-editor/client/src/pages/sequence_edit_page/components/cut_editor/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/cut_editor/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     pages::sequence_edit_page::atom::SEQUENCE_ATOM,
 };
 use background_with_event::*;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::data::{CgFile, Cut, CutUpdateAction, SequenceUpdateAction};
 use std::collections::BTreeSet;

--- a/luda-editor/client/src/pages/sequence_edit_page/components/cut_list_view/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/cut_list_view/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     pages::sequence_edit_page::atom::SEQUENCE_ATOM,
 };
 use cut_cell::*;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::data::{CgFile, Cut, Memo, MoveCutAction};
 use std::collections::HashMap;

--- a/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/graphic_list_item.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/graphic_list_item.rs
@@ -2,7 +2,7 @@ use crate::{
     color,
     pages::sequence_edit_page::components::graphic_list_view::graphic_thumbnail::GraphicThumbnail,
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, table};
 use rpc::data::ScreenGraphic;
 

--- a/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/graphic_thumbnail.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/graphic_thumbnail.rs
@@ -3,7 +3,7 @@ use crate::{
     pages::sequence_edit_page::atom::CG_FILES_ATOM,
     storage::{get_project_cg_thumbnail_image_url, get_project_image_url},
 };
-use namui::prelude::*;
+use namui::*;
 use rpc::data::ScreenGraphic;
 
 #[component]

--- a/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/header.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/header.rs
@@ -1,5 +1,5 @@
 use crate::color;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, table};
 
 #[component]

--- a/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/graphic_list_view/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         components::graphic_list_view::{graphic_list_item::GraphicListItem, header::Header},
     },
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{scroll_view, simple_rect, table};
 use rpc::data::ChangeGraphicOrderAction;
 

--- a/luda-editor/client/src/pages/sequence_edit_page/components/image_picker/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/image_picker/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     pages::sequence_edit_page::atom::{IMAGES_ATOM, SEQUENCE_ATOM},
     storage::get_project_image_url,
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{table::hooks::TableCell, *};
 use rpc::data::{Cut, ImageWithLabels};
 

--- a/luda-editor/client/src/pages/sequence_edit_page/components/memo_list_view/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/memo_list_view/mod.rs
@@ -1,5 +1,5 @@
 use crate::color;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::button::TextButtonFitAlign;
 use namui_prebuilt::scroll_view::{self};
 use namui_prebuilt::{simple_rect, table, transparent_rect};

--- a/luda-editor/client/src/pages/sequence_edit_page/components/side_bar/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/side_bar/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::color;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{
     button::{self},
     simple_rect,

--- a/luda-editor/client/src/pages/sequence_edit_page/components/wysiwyg_editor/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/wysiwyg_editor/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     storage::{get_project_cg_thumbnail_image_url, get_project_image_url},
 };
 use mover::Mover;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use resizer::Resizer;
 use rotator::Rotator;

--- a/luda-editor/client/src/pages/sequence_edit_page/components/wysiwyg_editor/resizer.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/wysiwyg_editor/resizer.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use rpc::data::Circumscribed;
 
 #[namui::component]

--- a/luda-editor/client/src/pages/sequence_edit_page/components/wysiwyg_editor/rotator.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/components/wysiwyg_editor/rotator.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 #[namui::component]
 pub struct Rotator<'a> {

--- a/luda-editor/client/src/pages/sequence_edit_page/loaded.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/loaded.rs
@@ -8,7 +8,7 @@ use crate::{
         character_editor::EditTarget, name_quick_slot_modal::NameQuickSlotModal,
     },
 };
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::data::*;
 use std::collections::HashMap;

--- a/luda-editor/client/src/pages/sequence_edit_page/mod.rs
+++ b/luda-editor/client/src/pages/sequence_edit_page/mod.rs
@@ -6,7 +6,7 @@ mod sequence;
 use crate::components::name_quick_slot::NameQuickSlot;
 use ::futures::try_join;
 use loaded::LoadedSequenceEditorPage;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::data::{CgFile, ImageWithLabels, Memo, ProjectSharedData, Sequence};
 use std::collections::HashMap;

--- a/luda-editor/client/src/pages/sequence_list_page/mod.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/mod.rs
@@ -2,7 +2,7 @@ mod rename_modal;
 
 use self::rename_modal::RenameModal;
 use crate::components::context_menu::{if_context_menu_for, open_context_menu};
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::*;
 use rpc::list_project_sequences::SequenceNameAndId;
 

--- a/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
+++ b/luda-editor/client/src/pages/sequence_list_page/rename_modal.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 
 #[namui::component]

--- a/luda-editor/client/src/share_preview.rs
+++ b/luda-editor/client/src/share_preview.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub struct SharePreview {
     pub sequence_id: Uuid,

--- a/luda-editor/client/src/viewer/mod.rs
+++ b/luda-editor/client/src/viewer/mod.rs
@@ -1,5 +1,5 @@
 use crate::components::*;
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 use rpc::data::*;
 

--- a/namui/namui-prebuilt/src/button.rs
+++ b/namui/namui-prebuilt/src/button.rs
@@ -1,5 +1,5 @@
 use crate::{simple_rect, typography::center_text_full_height};
-use namui::prelude::*;
+use namui::*;
 
 fn attach_text_button_event(
     ctx: &ComposeCtx,

--- a/namui/namui-prebuilt/src/dropdown/mod.rs
+++ b/namui/namui-prebuilt/src/dropdown/mod.rs
@@ -1,5 +1,5 @@
 use crate::{list_view::AutoListView, simple_rect, typography};
-use namui::prelude::*;
+use namui::*;
 use std::{fmt::Debug, ops::Deref};
 
 const LEFT_PADDING: Px = px(10.0);

--- a/namui/namui-prebuilt/src/event_trap.rs
+++ b/namui/namui-prebuilt/src/event_trap.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct EventTrap;

--- a/namui/namui-prebuilt/src/list_view.rs
+++ b/namui/namui-prebuilt/src/list_view.rs
@@ -1,5 +1,5 @@
 use crate::scroll_view::{self};
-use namui::prelude::*;
+use namui::*;
 
 #[namui::component]
 pub struct AutoListView<C: Component> {

--- a/namui/namui-prebuilt/src/scroll_view.rs
+++ b/namui/namui-prebuilt/src/scroll_view.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 #[component]
 pub struct ScrollView<'a, C: Component> {

--- a/namui/namui-prebuilt/src/sheet/cell/clipboard_item.rs
+++ b/namui/namui-prebuilt/src/sheet/cell/clipboard_item.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 #[derive(Debug, Clone)]
 pub enum ClipboardItem {

--- a/namui/namui-prebuilt/src/sheet/mod.rs
+++ b/namui/namui-prebuilt/src/sheet/mod.rs
@@ -4,7 +4,7 @@
 
 // use crate::*;
 // use cell::*;
-// use namui::prelude::*;
+// use namui::*;
 // use std::collections::HashSet;
 
 // pub struct Sheet {

--- a/namui/namui-prebuilt/src/simple_rect.rs
+++ b/namui/namui-prebuilt/src/simple_rect.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn simple_rect(
     wh: Wh<Px>,

--- a/namui/namui-prebuilt/src/table/hooks.rs
+++ b/namui/namui-prebuilt/src/table/hooks.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use std::collections::HashMap;
 
 pub enum TableCell<'a> {

--- a/namui/namui-prebuilt/src/table/mod.rs
+++ b/namui/namui-prebuilt/src/table/mod.rs
@@ -1,6 +1,6 @@
 pub mod hooks;
 
-use namui::prelude::*;
+use namui::*;
 
 pub struct TableCell<'a> {
     unit: Unit,

--- a/namui/namui-prebuilt/src/typography/effect.rs
+++ b/namui/namui-prebuilt/src/typography/effect.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 #[allow(clippy::too_many_arguments)]
 pub fn glow(

--- a/namui/namui-prebuilt/src/typography/mod.rs
+++ b/namui/namui-prebuilt/src/typography/mod.rs
@@ -3,7 +3,7 @@ pub mod effect;
 pub mod title;
 
 use crate::*;
-use namui::prelude::*;
+use namui::*;
 
 pub fn center_text(
     wh: Wh<Px>,

--- a/namui/namui-prebuilt/src/vh_list_view.rs
+++ b/namui/namui-prebuilt/src/vh_list_view.rs
@@ -1,5 +1,5 @@
 use crate::scroll_view::ScrollView;
-use namui::prelude::*;
+use namui::*;
 use std::fmt::Debug;
 
 type ItemRenderFn<'a, TItem> = Box<dyn 'a + Fn(Wh<Px>, TItem, ComposeCtx)>;

--- a/namui/namui/src/lib.rs
+++ b/namui/namui/src/lib.rs
@@ -1,6 +1,6 @@
 // #![deny(warnings)]
 
-pub mod namui;
+mod namui;
 pub mod prelude;
 
 pub use namui::*;

--- a/namui/sample/bundle/src/lib.rs
+++ b/namui/sample/bundle/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::typography;
 
 pub fn main() {

--- a/namui/sample/image-fit/src/lib.rs
+++ b/namui/sample/image-fit/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(|| App)

--- a/namui/sample/image-load-background/src/lib.rs
+++ b/namui/sample/image-load-background/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(|| App)

--- a/namui/sample/media/src/lib.rs
+++ b/namui/sample/media/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::button::TextButton;
 
 pub fn main() {

--- a/namui/sample/mouse/src/lib.rs
+++ b/namui/sample/mouse/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{simple_rect, typography};
 
 pub fn main() {

--- a/namui/sample/multiline-text/src/lib.rs
+++ b/namui/sample/multiline-text/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     let namui_context = namui::init();

--- a/namui/sample/rect/src/lib.rs
+++ b/namui/sample/rect/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(|| RectExample)

--- a/namui/sample/register-font/src/lib.rs
+++ b/namui/sample/register-font/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(|| FontExample)

--- a/namui/sample/shader/src/lib.rs
+++ b/namui/sample/shader/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::{table::*, *};
 use std::f32::consts::PI;
 

--- a/namui/sample/tab-to-next-text-input/src/lib.rs
+++ b/namui/sample/tab-to-next-text-input/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(&mut TabToNextTextInputExample::new(), &()).await

--- a/namui/sample/text-input/src/lib.rs
+++ b/namui/sample/text-input/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(|| TextInputExample::new())

--- a/namui/sample/type_macro/src/lib.rs
+++ b/namui/sample/type_macro/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use namui::prelude::*;
+use namui::*;
 
 namui::common_for_f32_type!(Tile, tile, TileExt);
 

--- a/namui/sample/typography-effect/src/lib.rs
+++ b/namui/sample/typography-effect/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 
 pub fn main() {
     namui::start(|| TypographyEffectExample)

--- a/quick/sample/tui/src/lib.rs
+++ b/quick/sample/tui/src/lib.rs
@@ -1,4 +1,4 @@
-use namui::prelude::*;
+use namui::*;
 use namui_prebuilt::simple_rect;
 use quick::*;
 

--- a/quick/src/lib.rs
+++ b/quick/src/lib.rs
@@ -11,7 +11,7 @@ pub use consts::*;
 pub use group::*;
 pub use line::*;
 pub use link::*;
-use namui::prelude::*;
+use namui::*;
 
 #[cfg(test)]
 #[cfg(target_family = "wasm")]


### PR DESCRIPTION
Now we can use `namui::*` instead of `namui::prelude::*`.