### PR TITLE
Expose `Atom::is_initialized`

### DIFF
--- a/namui/namui-hooks/src/atom.rs
+++ b/namui/namui-hooks/src/atom.rs
@@ -23,7 +23,7 @@ impl<State: 'static + Send + Sync> Atom<State> {
         *self.index.get().unwrap()
     }
 
-    pub(crate) fn is_initialized(&self) -> bool {
+    pub fn is_initialized(&self) -> bool {
         self.index.get().is_some()
     }
 


### PR DESCRIPTION
I believe it's ok to expose that.

I'm using server connection as atom, so I need to check whether atom(connection) is initialized or not, to try connect to server.