### PR TITLE
Add WASI_SYSROOT for wasi env

### DIFF
--- a/namui/namui-cli/src/services/wasi_cargo_envs.rs
+++ b/namui/namui-cli/src/services/wasi_cargo_envs.rs
@@ -1,7 +1,7 @@
 use crate::util::get_cli_root_path;
 use std::path::PathBuf;
 
-pub fn wasi_cargo_envs() -> [(&'static str, PathBuf); 8] {
+pub fn wasi_cargo_envs() -> [(&'static str, PathBuf); 9] {
     let cli_root_path = get_cli_root_path();
 
     [
@@ -10,6 +10,10 @@ pub fn wasi_cargo_envs() -> [(&'static str, PathBuf); 8] {
         ("CC", cli_root_path.join("wasi-sdk/bin/clang")),
         ("CXX", cli_root_path.join("wasi-sdk/bin/clang++")),
         ("WASI_SDK", cli_root_path.join("wasi-sdk")),
+        (
+            "WASI_SYSROOT",
+            cli_root_path.join("wasi-sdk/share/wasi-sysroot"),
+        ),
         (
             "EMSDK_SYSTEM_INCLUDE",
             cli_root_path.join("emscripten/system/include"),


### PR DESCRIPTION
latest cc crate need that environment variable for wasi target.

https://github.com/rust-lang/cc-rs/blob/bffb5c009699bdf85c27bfedf60ed631fb679efd/src/lib.rs#L3932-L3941
https://github.com/rust-lang/cc-rs/issues/1109