### PR TITLE
ctx.spawn(future) and Clean up

### DIFF
--- a/namui/namui-hooks/Cargo.toml
+++ b/namui/namui-hooks/Cargo.toml
@@ -16,7 +16,6 @@ rustc-hash = "1.1.0"
 smol_str = "0.2.1"
 tokio = { path = "../third-party-forks/tokio/tokio", features = ["rt"] }
 
-# for test
 [dev-dependencies]
 tokio = { path = "../third-party-forks/tokio/tokio", features = [
     "rt",

--- a/namui/namui-hooks/src/component/ctx/public_crate.rs
+++ b/namui/namui-hooks/src/component/ctx/public_crate.rs
@@ -347,4 +347,16 @@ impl ComponentCtx<'_> {
 
         (sig, set_state)
     }
+    pub fn spawn<Fut>(&self, future: Fut)
+    where
+        Fut: std::future::Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        let handle = tokio::spawn(future);
+
+        self.instance
+            .abort_handle_list
+            .borrow_mut()
+            .push(handle.abort_handle())
+    }
 }

--- a/namui/namui-hooks/src/render_ctx/mod.rs
+++ b/namui/namui-hooks/src/render_ctx/mod.rs
@@ -82,6 +82,15 @@ impl<'a, 'rt> RenderCtx<'a, 'rt> {
     ) -> (Sig<T, &T>, SetState<T>) {
         self.component_ctx.atom(atom)
     }
+    /// This method just keep JoinHandle to abort when the component is unmounted.
+    /// This is not the replacement of `async_effect`, but `tokio::spawn`.
+    pub fn spawn<Fut>(&self, future: Fut)
+    where
+        Fut: std::future::Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        self.component_ctx.spawn(future)
+    }
 }
 
 pub(crate) fn run<'a>(


### PR DESCRIPTION
1. Add `ctx.spawn` which automatically abort future on component unmount.
2. I forgot implement effect clean up call. Add that feature.