### PR TITLE
Remove type_derives, use hash lru cache

### DIFF
--- a/namui/namui-drawer/Cargo.lock
+++ b/namui/namui-drawer/Cargo.lock
@@ -808,11 +808,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derivative",
- "derive-macro",
  "namui-type",
  "num",
  "ordered-float",
- "serde",
  "skia-safe",
  "textwrap",
  "tokio",

--- a/namui/namui-hooks/Cargo.lock
+++ b/namui/namui-hooks/Cargo.lock
@@ -832,11 +832,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derivative",
- "derive-macro",
  "namui-type",
  "num",
  "ordered-float",
- "serde",
  "skia-safe",
  "textwrap",
  "tokio",

--- a/namui/namui-prebuilt/Cargo.lock
+++ b/namui/namui-prebuilt/Cargo.lock
@@ -1465,11 +1465,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derivative",
- "derive-macro",
  "namui-type",
  "num",
  "ordered-float",
- "serde",
  "skia-safe",
  "textwrap",
  "tokio 1.38.0",

--- a/namui/namui/Cargo.lock
+++ b/namui/namui/Cargo.lock
@@ -1457,11 +1457,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derivative",
- "derive-macro",
  "namui-type",
  "num",
  "ordered-float",
- "serde",
  "skia-safe",
  "textwrap",
  "tokio 1.38.0",

--- a/namui/skia/Cargo.lock
+++ b/namui/skia/Cargo.lock
@@ -807,12 +807,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derivative",
- "derive-macro",
  "float-cmp",
  "namui-type",
  "num",
  "ordered-float",
- "serde",
  "skia-safe",
  "textwrap",
  "tokio",

--- a/namui/skia/Cargo.toml
+++ b/namui/skia/Cargo.toml
@@ -9,10 +9,8 @@ targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 [dependencies]
 anyhow = { version = "1.0.75", features = ["backtrace"] }
 namui-type = { path = "../namui-type", features = ["skia"] }
-derive-macro = { path = "../namui-type/derive-macro" }
-serde = { version = "1.0", features = ["derive", "rc"] }
 num = { version = "0.4.0", features = ["std"] }
-ordered-float = { version = "4.2.0", features = ["serde"] }
+ordered-float = { version = "4.2.0" }
 textwrap = "0.16.0"
 unicode-segmentation = "1.10.1"
 derivative = "2.2.0"

--- a/namui/skia/src/lib.rs
+++ b/namui/skia/src/lib.rs
@@ -5,7 +5,6 @@ mod traits;
 mod xy_in;
 
 pub use bounding_box::*;
-use derive_macro::type_derives;
 use namui_type::*;
 pub use native::*;
 use ordered_float::OrderedFloat;

--- a/namui/skia/src/native/color_filter.rs
+++ b/namui/skia/src/native/color_filter.rs
@@ -8,7 +8,7 @@ pub(crate) struct NativeColorFilter {
 
 impl NativeColorFilter {
     pub(crate) fn get(color_filter: ColorFilter) -> Arc<NativeColorFilter> {
-        static CACHE: SerdeLruCache<ColorFilter, NativeColorFilter> = SerdeLruCache::new();
+        static CACHE: LruCache<ColorFilter, NativeColorFilter> = LruCache::new();
 
         CACHE.get_or_create(&color_filter, |color_filter| NativeColorFilter {
             skia_color_filter: {

--- a/namui/skia/src/native/path.rs
+++ b/namui/skia/src/native/path.rs
@@ -8,7 +8,7 @@ pub(crate) struct NativePath {
 
 impl NativePath {
     pub(crate) fn get(path: &Path) -> Arc<Self> {
-        static CACHE: SerdeLruCache<Path, NativePath> = SerdeLruCache::new();
+        static CACHE: LruCache<Path, NativePath> = LruCache::new();
         CACHE.get_or_create(path, NativePath::new)
     }
     pub fn new(path: &Path) -> Self {

--- a/namui/skia/src/native/text_blob.rs
+++ b/namui/skia/src/native/text_blob.rs
@@ -14,12 +14,12 @@ impl NativeTextBlob {
         }
     }
     pub fn from_glyph_ids(glyph_ids: GlyphIds, font: &Font) -> Option<Arc<Self>> {
-        #[derive(serde::Serialize)]
+        #[derive(Clone, PartialEq, Eq, Hash)]
         struct CacheKey {
             glyph_ids: GlyphIds,
             font: Font,
         }
-        static CACHE: SerdeLruCache<CacheKey, NativeTextBlob> = SerdeLruCache::new();
+        static CACHE: LruCache<CacheKey, NativeTextBlob> = LruCache::new();
         let cache_key = CacheKey {
             glyph_ids: glyph_ids.clone(),
             font: font.clone(),

--- a/namui/skia/src/render/command/image.rs
+++ b/namui/skia/src/render/command/image.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Hash, Eq,-serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct ImageDrawCommand {
     pub rect: Rect<Px>,
     pub image: Image,

--- a/namui/skia/src/render/command/mod.rs
+++ b/namui/skia/src/render/command/mod.rs
@@ -2,12 +2,11 @@ mod image;
 mod path;
 mod text;
 
-use crate::*;
 pub use image::*;
 pub use path::*;
 pub use text::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum DrawCommand {
     Path { command: Box<PathDrawCommand> },
     Text { command: Box<TextDrawCommand> },

--- a/namui/skia/src/render/command/path.rs
+++ b/namui/skia/src/render/command/path.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct PathDrawCommand {
     pub path: Path,
     pub paint: Paint,

--- a/namui/skia/src/render/command/text.rs
+++ b/namui/skia/src/render/command/text.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct TextDrawCommand {
     pub text: String,
     pub font: Font,

--- a/namui/skia/src/render/font.rs
+++ b/namui/skia/src/render/font.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub struct Font {
     pub size: IntPx,
     pub name: String,

--- a/namui/skia/src/render/image.rs
+++ b/namui/skia/src/render/image.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::*;
 use std::{fmt::Debug, hash::Hash};
 
-#[type_derives(-PartialEq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Image {
     pub info: ImageInfo,
     pub skia_image: std::sync::Arc<skia_safe::Image>,
@@ -35,7 +35,7 @@ impl Hash for Image {
     }
 }
 
-#[type_derives(Copy, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash)]
 pub struct ImageInfo {
     pub alpha_type: AlphaType,
     pub color_type: ColorType,

--- a/namui/skia/src/render/image_filter.rs
+++ b/namui/skia/src/render/image_filter.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum ImageFilter {
     Blur {
         sigma_xy: Xy<OrderedFloat<f32>>,

--- a/namui/skia/src/render/mask_filter.rs
+++ b/namui/skia/src/render/mask_filter.rs
@@ -1,7 +1,6 @@
-use crate::*;
 use std::hash::Hash;
 
-#[type_derives(Copy, -PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub enum MaskFilter {
     Blur { blur_style: BlurStyle, sigma: f32 },
 }
@@ -33,7 +32,7 @@ impl PartialEq for MaskFilter {
 }
 impl Eq for MaskFilter {}
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum BlurStyle {
     /// Fuzzy inside and outside
     Normal,

--- a/namui/skia/src/render/mod.rs
+++ b/namui/skia/src/render/mod.rs
@@ -14,7 +14,6 @@ mod types;
 
 pub use codes::*;
 pub use command::*;
-use derive_macro::type_derives;
 pub use event::*;
 pub use font::*;
 pub use image::*;

--- a/namui/skia/src/render/paint.rs
+++ b/namui/skia/src/render/paint.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Default, Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Default, Hash, Eq)]
 pub struct Paint {
     pub color: Color,
     pub paint_style: Option<PaintStyle>,

--- a/namui/skia/src/render/paragraph/caret.rs
+++ b/namui/skia/src/render/paragraph/caret.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(-PartialEq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Caret<'a> {
     pub line_index: usize,
     pub caret_index_in_line: usize,
@@ -61,7 +61,7 @@ pub(crate) fn get_caret(selection_index: usize, paragraph: &Paragraph) -> Caret<
     }
 }
 
-#[type_derives(Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum CaretKey {
     ArrowUp,
     ArrowDown,

--- a/namui/skia/src/render/paragraph/mod.rs
+++ b/namui/skia/src/render/paragraph/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use textwrap::{core::Fragment, word_splitters::split_words, wrap_algorithms::wrap_first_fit, *};
 use unicode_segmentation::UnicodeSegmentation;
 
-#[type_derives(-PartialEq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Paragraph {
     pub vec: Vec<Line>,
     pub group_glyph: Arc<dyn GroupGlyph>,
@@ -275,14 +275,14 @@ pub fn get_multiline_y_baseline_offset(
     }
 }
 
-#[type_derives(Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum NewLineBy {
     Wrap,
     /// `\n`
     LineFeed,
 }
 
-#[type_derives(-serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Line {
     /// Should not have `\n`
     pub chars: Vec<char>,

--- a/namui/skia/src/render/path.rs
+++ b/namui/skia/src/render/path.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[type_derives(Default, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Default, Eq, Hash)]
 pub struct Path {
     commands: Vec<PathCommand>,
 }
@@ -95,7 +95,7 @@ impl Path {
     }
 }
 
-#[type_derives(Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub enum PathCommand {
     AddRect {
         rect: Rect<Px>,

--- a/namui/skia/src/render/rendering_tree/mod.rs
+++ b/namui/skia/src/render/rendering_tree/mod.rs
@@ -3,7 +3,7 @@ mod special;
 use crate::*;
 pub use special::*;
 
-#[type_derives(Default, Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Default, Hash, Eq)]
 pub enum RenderingTree {
     #[default]
     Empty,

--- a/namui/skia/src/render/rendering_tree/special/absolute.rs
+++ b/namui/skia/src/render/rendering_tree/special/absolute.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct AbsoluteNode {
     pub x: Px,
     pub y: Px,

--- a/namui/skia/src/render/rendering_tree/special/clip.rs
+++ b/namui/skia/src/render/rendering_tree/special/clip.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct ClipNode {
     pub path: Path,
     pub clip_op: ClipOp,

--- a/namui/skia/src/render/rendering_tree/special/mod.rs
+++ b/namui/skia/src/render/rendering_tree/special/mod.rs
@@ -19,7 +19,7 @@ pub use transform::*;
 pub use translate::*;
 pub use with_id::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum SpecialRenderingNode {
     Translate(TranslateNode),
     Clip(ClipNode),

--- a/namui/skia/src/render/rendering_tree/special/mouse_cursor.rs
+++ b/namui/skia/src/render/rendering_tree/special/mouse_cursor.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum MouseCursor {
     TopBottomResize,
     LeftRightResize,

--- a/namui/skia/src/render/rendering_tree/special/on_top.rs
+++ b/namui/skia/src/render/rendering_tree/special/on_top.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// `OnTopNode` ignores clip and draw on top of other nodes.
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct OnTopNode {
     pub rendering_tree: Box<RenderingTree>,
 }

--- a/namui/skia/src/render/rendering_tree/special/rotate.rs
+++ b/namui/skia/src/render/rendering_tree/special/rotate.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct RotateNode {
     pub angle: Angle,
     pub rendering_tree: Box<RenderingTree>,

--- a/namui/skia/src/render/rendering_tree/special/scale.rs
+++ b/namui/skia/src/render/rendering_tree/special/scale.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct ScaleNode {
     pub x: OrderedFloat<f32>,
     pub y: OrderedFloat<f32>,

--- a/namui/skia/src/render/rendering_tree/special/transform.rs
+++ b/namui/skia/src/render/rendering_tree/special/transform.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct TransformNode {
     pub matrix: TransformMatrix,
     pub rendering_tree: Box<RenderingTree>,

--- a/namui/skia/src/render/rendering_tree/special/translate.rs
+++ b/namui/skia/src/render/rendering_tree/special/translate.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct TranslateNode {
     pub x: Px,
     pub y: Px,

--- a/namui/skia/src/render/rendering_tree/special/with_id.rs
+++ b/namui/skia/src/render/rendering_tree/special/with_id.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[type_derives(Hash, Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct WithIdNode {
     pub rendering_tree: Box<RenderingTree>,
     pub id: crate::Uuid,

--- a/namui/skia/src/render/shader.rs
+++ b/namui/skia/src/render/shader.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use std::hash::Hash;
 
-#[type_derives(Eq, -serde::Serialize, -serde::Deserialize)]
+#[derive(Debug, PartialEq, Clone, Eq)]
 pub enum Shader {
     Image {
         src: Image,

--- a/namui/skia/src/render/types.rs
+++ b/namui/skia/src/render/types.rs
@@ -4,7 +4,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[type_derives(Copy, Default)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 pub struct FontMetrics {
     /// suggested space above the baseline. < 0
     pub ascent: Px,
@@ -20,7 +20,7 @@ impl FontMetrics {
     }
 }
 
-#[type_derives(Copy, Default, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Default, Hash, Eq)]
 pub struct Color {
     pub r: u8,
     pub g: u8,
@@ -201,7 +201,7 @@ impl From<Color> for skia_safe::Color {
     }
 }
 
-#[type_derives(Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 struct Hsl01 {
     hue: f32,
     saturation: f32,
@@ -209,7 +209,7 @@ struct Hsl01 {
     alpha: f32,
 }
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum PaintStyle {
     Fill,
     Stroke,
@@ -224,7 +224,7 @@ impl From<PaintStyle> for skia_safe::PaintStyle {
     }
 }
 
-#[type_derives(Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
 pub enum StrokeCap {
     Butt,
     Round,
@@ -241,7 +241,7 @@ impl From<StrokeCap> for skia_safe::PaintCap {
     }
 }
 
-#[type_derives(Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
 pub enum StrokeJoin {
     Bevel,
     Miter,
@@ -258,7 +258,7 @@ impl From<StrokeJoin> for skia_safe::PaintJoin {
     }
 }
 
-#[type_derives(Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
 pub struct StrokeOptions {
     pub width: Option<Px>,
     pub miter_limit: Option<Px>,
@@ -271,7 +271,7 @@ pub struct StrokeOptions {
     pub cap: Option<StrokeCap>,
 }
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum ClipOp {
     Intersect,
     Difference,
@@ -286,7 +286,7 @@ impl From<ClipOp> for skia_safe::ClipOp {
     }
 }
 
-#[type_derives(Copy, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash)]
 pub enum AlphaType {
     Opaque,
     Premul,
@@ -318,7 +318,7 @@ impl From<AlphaType> for skia_safe::AlphaType {
     }
 }
 
-#[type_derives(Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
 pub enum ColorType {
     Alpha8,
     Rgb565,
@@ -445,7 +445,7 @@ impl From<ColorType> for skia_safe::ColorType {
     }
 }
 
-#[type_derives(Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum FilterMode {
     Linear,
     Nearest,
@@ -460,7 +460,7 @@ impl From<FilterMode> for skia_safe::FilterMode {
     }
 }
 
-#[type_derives(Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum MipmapMode {
     None,
     Nearest,
@@ -477,7 +477,7 @@ impl From<MipmapMode> for skia_safe::MipmapMode {
     }
 }
 
-#[type_derives(Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
 pub enum BlendMode {
     Clear,
     Src,
@@ -546,7 +546,7 @@ impl From<BlendMode> for skia_safe::BlendMode {
     }
 }
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 /// Explain: https://developer.android.com/reference/android/graphics/Shader.TileMode#summary
 pub enum TileMode {
     /// Replicate the edge color if the shader draws outside of its original bounds
@@ -570,21 +570,21 @@ impl From<TileMode> for skia_safe::TileMode {
     }
 }
 
-#[type_derives(Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ColorSpace {
     Srgb,
     DisplayP3,
     AdobeRgb,
 }
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum TextAlign {
     Left,
     Center,
     Right,
 }
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum TextBaseline {
     Top,
     Middle,
@@ -592,7 +592,7 @@ pub enum TextBaseline {
 }
 
 /// Example: https://developer.mozilla.org/ko/docs/Web/CSS/object-fit
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum ImageFit {
     /// The replaced content is sized to fill the element's content box.
     /// The entire object will completely fill the box.
@@ -612,7 +612,7 @@ pub enum ImageFit {
     None,
 }
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub struct ColorFilter {
     pub color: Color,
     pub blend_mode: BlendMode,
@@ -621,7 +621,7 @@ pub struct ColorFilter {
 pub type GlyphId = skia_safe::GlyphId;
 pub type GlyphIds = Vec<GlyphId>;
 
-#[type_derives(Copy, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
 pub enum MouseButton {
     Left,
     Middle,


### PR DESCRIPTION
namui/skia doesn't use serde, and there is no benefit to use derive-macro.
And also most of type support hash, so I changed using `serde lru cache` to `hash cache`.