### PR TITLE
Use Iterator for list_view

### DIFF
--- a/namui/namui-prebuilt/src/dropdown/mod.rs
+++ b/namui/namui-prebuilt/src/dropdown/mod.rs
@@ -75,40 +75,35 @@ impl Component for Dropdown<'_> {
                         height: body_height,
                         scroll_bar_width: 5.px(),
                         item_wh: rect.wh(),
-                        items: items
-                            .into_iter()
-                            .enumerate()
-                            .map(|(item_index, item)| {
-                                let is_mouse_over =
-                                    mouse_over_item_index.deref() == &Some(item_index);
-                                let is_selected = item.is_selected;
+                        items: items.into_iter().enumerate().map(|(item_index, item)| {
+                            let is_mouse_over = mouse_over_item_index.deref() == &Some(item_index);
+                            let is_selected = item.is_selected;
 
-                                let item_component = InternalItem {
-                                    wh: rect.wh(),
-                                    text: item.text,
-                                    is_selected,
-                                    is_mouse_over,
+                            let item_component = InternalItem {
+                                wh: rect.wh(),
+                                text: item.text,
+                                is_selected,
+                                is_mouse_over,
+                            }
+                            .attach_event(move |event| match event {
+                                Event::MouseDown { event } => {
+                                    if event.is_local_xy_in() {
+                                        set_mouse_over_item_index.set(Some(item_index));
+                                    }
                                 }
-                                .attach_event(move |event| match event {
-                                    Event::MouseDown { event } => {
-                                        if event.is_local_xy_in() {
-                                            set_mouse_over_item_index.set(Some(item_index));
+                                Event::MouseMove { event } => {
+                                    if event.is_local_xy_in() {
+                                        event.stop_propagation();
+                                        if !is_selected {
+                                            (item.on_select_item)();
                                         }
+                                        set_is_opened.set(false);
                                     }
-                                    Event::MouseMove { event } => {
-                                        if event.is_local_xy_in() {
-                                            event.stop_propagation();
-                                            if !is_selected {
-                                                (item.on_select_item)();
-                                            }
-                                            set_is_opened.set(false);
-                                        }
-                                    }
-                                    _ => {}
-                                });
-                                (item_index.to_string(), item_component)
-                            })
-                            .collect(),
+                                }
+                                _ => {}
+                            });
+                            (item_index.to_string().into(), item_component)
+                        }),
                     })
                     .add(simple_rect(
                         Wh {

--- a/namui/namui-prebuilt/src/list_view.rs
+++ b/namui/namui-prebuilt/src/list_view.rs
@@ -1,14 +1,23 @@
 use crate::scroll_view::{self};
 use namui::*;
+use std::borrow::Cow;
 
-pub struct AutoListView<C: Component> {
+pub struct AutoListView<'a, Items, C>
+where
+    C: Component,
+    Items: ExactSizeIterator<Item = (Cow<'a, str>, C)>,
+{
     pub height: Px,
     pub scroll_bar_width: Px,
     pub item_wh: Wh<Px>,
-    pub items: Vec<(String, C)>,
+    pub items: Items,
 }
 
-impl<C: Component> Component for AutoListView<C> {
+impl<'a, Items, C> Component for AutoListView<'a, Items, C>
+where
+    C: Component,
+    Items: ExactSizeIterator<Item = (Cow<'a, str>, C)>,
+{
     fn render(self, ctx: &RenderCtx) {
         let Self {
             height,
@@ -29,16 +38,24 @@ impl<C: Component> Component for AutoListView<C> {
     }
 }
 
-pub struct ListView<C: Component> {
+pub struct ListView<'a, Items, C>
+where
+    C: Component,
+    Items: ExactSizeIterator<Item = (Cow<'a, str>, C)>,
+{
     pub height: Px,
     pub scroll_bar_width: Px,
     pub item_wh: Wh<Px>,
-    pub items: Vec<(String, C)>,
+    pub items: Items,
     pub scroll_y: Px,
     pub set_scroll_y: SetState<Px>,
 }
 
-impl<C: Component> Component for ListView<C> {
+impl<'a, Items, C> Component for ListView<'a, Items, C>
+where
+    C: Component,
+    Items: ExactSizeIterator<Item = (Cow<'a, str>, C)>,
+{
     fn render(self, ctx: &RenderCtx) {
         let Self {
             height,
@@ -64,14 +81,22 @@ impl<C: Component> Component for ListView<C> {
     }
 }
 
-struct ListViewInner<C: Component> {
+struct ListViewInner<'a, Items, C>
+where
+    C: Component,
+    Items: ExactSizeIterator<Item = (Cow<'a, str>, C)>,
+{
     height: Px,
     item_wh: Wh<Px>,
-    items: Vec<(String, C)>,
+    items: Items,
     scroll_y: Px,
 }
 
-impl<C: Component> Component for ListViewInner<C> {
+impl<'a, Items, C> Component for ListViewInner<'a, Items, C>
+where
+    C: Component,
+    Items: ExactSizeIterator<Item = (Cow<'a, str>, C)>,
+{
     fn render(self, ctx: &RenderCtx) {
         let Self {
             height,
@@ -125,7 +150,7 @@ impl<C: Component> Component for ListViewInner<C> {
 
         ctx.compose(|ctx| {
             for (index, (key, visible_item)) in visible_items.into_iter().enumerate() {
-                ctx.compose_with_key(key, |ctx| {
+                ctx.compose_with_key(key.as_ref(), |ctx| {
                     ctx.translate((0.px(), item_wh.height * (index + visible_item_start_index)))
                         .add(visible_item);
                 });


### PR DESCRIPTION
This can reduce the memory usage because it doesn't use Vec.
I'm not sure actually 'into_iter' or 'iter' allocate memory on heap. ahaha