### PR TITLE
Support 2,3,4 tuple set_state mutate

### DIFF
--- a/namui/namui-hooks/src/component/instance.rs
+++ b/namui/namui-hooks/src/component/instance.rs
@@ -1,12 +1,15 @@
 use crate::*;
-use elsa::FrozenVec;
-use std::{cell::RefCell, rc::Rc, sync::atomic::AtomicBool};
+use std::{
+    cell::{RefCell, UnsafeCell},
+    rc::Rc,
+    sync::atomic::AtomicBool,
+};
 
 /// the state of component.
 pub(crate) struct Instance {
     pub(crate) id: InstanceId,
     rendered_flag: AtomicBool,
-    pub(crate) state_list: FrozenVec<Box<dyn Value>>,
+    pub(crate) state_list: UnsafeCell<Vec<Box<dyn Value>>>,
     pub(crate) memo_list: RefCell<Vec<Memo>>,
     pub(crate) track_eq_list: RefCell<Vec<Rc<dyn Value>>>,
     pub(crate) track_eq_tuple_list: RefCell<Vec<()>>,

--- a/namui/namui-hooks/src/ids.rs
+++ b/namui/namui-hooks/src/ids.rs
@@ -16,7 +16,8 @@ impl ComposerId {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
+#[repr(transparent)]
 pub(crate) struct InstanceId {
     id: usize,
 }

--- a/namui/namui-hooks/src/set_state.rs
+++ b/namui/namui-hooks/src/set_state.rs
@@ -1,12 +1,20 @@
 use crate::*;
 use std::{fmt::Debug, sync::mpsc};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct SetState<State: 'static + Send> {
     sig_id: SigId,
     set_state_tx: &'static mpsc::Sender<SetStateItem>,
     _state: std::marker::PhantomData<State>,
 }
+
+impl<State: 'static + Send> Clone for SetState<State> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<State: 'static + Send> Copy for SetState<State> {}
 
 impl<State: 'static + Send> SetState<State> {
     pub(crate) fn new(sig_id: SigId, set_state_tx: &'static mpsc::Sender<SetStateItem>) -> Self {
@@ -24,15 +32,11 @@ impl<State: 'static + Send> SetState<State> {
             })
             .unwrap();
     }
-
     pub fn mutate(&self, mutate: impl FnOnce(&mut State) + 'static + Send) {
         self.set_state_tx
             .send(SetStateItem::Mutate {
                 sig_id: self.sig_id,
-                mutate: Box::new(move |value| {
-                    let value = value.as_any_mut().downcast_mut::<State>().unwrap();
-                    mutate(value);
-                }),
+                mutate: Box::new(move |value| mutate(value.as_any_mut().downcast_mut().unwrap())),
             })
             .unwrap();
     }
@@ -47,5 +51,97 @@ pub(crate) enum SetStateItem {
         sig_id: SigId,
         mutate: MutateFnOnce,
     },
+    Mutate2 {
+        sig_ids: (SigId, SigId),
+        mutate: MutateFnOnce2,
+    },
+    Mutate3 {
+        sig_ids: (SigId, SigId, SigId),
+        mutate: MutateFnOnce3,
+    },
+    Mutate4 {
+        sig_ids: (SigId, SigId, SigId, SigId),
+        mutate: MutateFnOnce4,
+    },
 }
 pub(crate) type MutateFnOnce = Box<dyn FnOnce(&mut (dyn Value)) + Send>;
+pub(crate) type MutateFnOnce2 = Box<dyn FnOnce((&mut (dyn Value), &mut (dyn Value))) + Send>;
+pub(crate) type MutateFnOnce3 =
+    Box<dyn FnOnce((&mut (dyn Value), &mut (dyn Value), &mut (dyn Value))) + Send>;
+pub(crate) type MutateFnOnce4 = Box<
+    dyn FnOnce(
+            (
+                &mut (dyn Value),
+                &mut (dyn Value),
+                &mut (dyn Value),
+                &mut (dyn Value),
+            ),
+        ) + Send,
+>;
+
+pub trait MutateState2<S1, S2> {
+    fn mutate(&self, mutate: impl FnOnce((&mut S1, &mut S2)) + 'static + Send);
+}
+impl<S1: 'static + Send, S2: 'static + Send> MutateState2<S1, S2> for (SetState<S1>, SetState<S2>) {
+    fn mutate(&self, mutate: impl FnOnce((&mut S1, &mut S2)) + 'static + Send) {
+        self.0
+            .set_state_tx
+            .send(SetStateItem::Mutate2 {
+                sig_ids: (self.0.sig_id, self.1.sig_id),
+                mutate: Box::new(move |(value1, value2)| {
+                    mutate((
+                        value1.as_any_mut().downcast_mut().unwrap(),
+                        value2.as_any_mut().downcast_mut().unwrap(),
+                    ))
+                }),
+            })
+            .unwrap();
+    }
+}
+
+pub trait MutateState3<S1, S2, S3> {
+    fn mutate(&self, mutate: impl FnOnce((&mut S1, &mut S2, &mut S3)) + 'static + Send);
+}
+impl<S1: 'static + Send, S2: 'static + Send, S3: 'static + Send> MutateState3<S1, S2, S3>
+    for (SetState<S1>, SetState<S2>, SetState<S3>)
+{
+    fn mutate(&self, mutate: impl FnOnce((&mut S1, &mut S2, &mut S3)) + 'static + Send) {
+        self.0
+            .set_state_tx
+            .send(SetStateItem::Mutate3 {
+                sig_ids: (self.0.sig_id, self.1.sig_id, self.2.sig_id),
+                mutate: Box::new(move |(value1, value2, value3)| {
+                    mutate((
+                        value1.as_any_mut().downcast_mut().unwrap(),
+                        value2.as_any_mut().downcast_mut().unwrap(),
+                        value3.as_any_mut().downcast_mut().unwrap(),
+                    ))
+                }),
+            })
+            .unwrap();
+    }
+}
+
+pub trait MutateState4<S1, S2, S3, S4> {
+    fn mutate(&self, mutate: impl FnOnce((&mut S1, &mut S2, &mut S3, &mut S4)) + 'static + Send);
+}
+impl<S1: 'static + Send, S2: 'static + Send, S3: 'static + Send, S4: 'static + Send>
+    MutateState4<S1, S2, S3, S4> for (SetState<S1>, SetState<S2>, SetState<S3>, SetState<S4>)
+{
+    fn mutate(&self, mutate: impl FnOnce((&mut S1, &mut S2, &mut S3, &mut S4)) + 'static + Send) {
+        self.0
+            .set_state_tx
+            .send(SetStateItem::Mutate4 {
+                sig_ids: (self.0.sig_id, self.1.sig_id, self.2.sig_id, self.3.sig_id),
+                mutate: Box::new(move |(value1, value2, value3, value4)| {
+                    mutate((
+                        value1.as_any_mut().downcast_mut().unwrap(),
+                        value2.as_any_mut().downcast_mut().unwrap(),
+                        value3.as_any_mut().downcast_mut().unwrap(),
+                        value4.as_any_mut().downcast_mut().unwrap(),
+                    ))
+                }),
+            })
+            .unwrap();
+    }
+}

--- a/namui/namui-hooks/src/world/mod.rs
+++ b/namui/namui-hooks/src/world/mod.rs
@@ -69,9 +69,10 @@ impl World {
                     .instance_id_map
                     .insert(child_key.clone(), child_instance_id.into());
 
-                let child_instance = self
-                    .instances
-                    .insert(child_instance_id, Instance::new(child_instance_id).into());
+                let child_instance = self.instances.insert(
+                    child_instance_id,
+                    Box::new(Instance::new(child_instance_id)),
+                );
 
                 child_instance
             }
@@ -84,7 +85,7 @@ impl World {
                 SetStateItem::Set { sig_id, value } => match sig_id {
                     SigId::State { instance_id, index } => {
                         let instance = self.instances.as_mut().get_mut(&instance_id).unwrap();
-                        instance.state_list.as_mut()[index] = value;
+                        instance.state_list.get_mut()[index] = value;
                         self.add_sig_updated(sig_id);
                     }
                     SigId::Atom { index } => {
@@ -97,7 +98,7 @@ impl World {
                 SetStateItem::Mutate { sig_id, mutate } => match sig_id {
                     SigId::State { instance_id, index } => {
                         let instance = self.instances.as_mut().get_mut(&instance_id).unwrap();
-                        let value = instance.state_list.as_mut().get_mut(index).unwrap();
+                        let value = instance.state_list.get_mut().get_mut(index).unwrap();
                         mutate(value.as_mut());
                         self.add_sig_updated(sig_id);
                     }
@@ -109,6 +110,138 @@ impl World {
                     SigId::Memo { .. } => unreachable!(),
                     SigId::TrackEq { .. } => todo!(),
                 },
+                SetStateItem::Mutate2 { sig_ids, mutate } => {
+                    let (sig_id1, sig_id2) = sig_ids;
+                    assert_ne!(sig_id1, sig_id2);
+
+                    match (sig_id1, sig_id2) {
+                        (
+                            SigId::State {
+                                instance_id: instance_id1,
+                                index: index1,
+                            },
+                            SigId::State {
+                                instance_id: instance_id2,
+                                index: index2,
+                            },
+                        ) => {
+                            let instance_1 = self.instances.get(&instance_id1).unwrap();
+                            let instance_2 = self.instances.get(&instance_id2).unwrap();
+
+                            let state_list1 = unsafe { &mut *instance_1.state_list.get() };
+                            let state_list2 = unsafe { &mut *instance_2.state_list.get() };
+
+                            let value1 = state_list1.get_mut(index1).unwrap();
+                            let value2 = state_list2.get_mut(index2).unwrap();
+
+                            mutate((value1.as_mut(), value2.as_mut()));
+
+                            self.add_sig_updated(sig_id1);
+                            self.add_sig_updated(sig_id2);
+                        }
+                        _ => todo!(),
+                    }
+                }
+                SetStateItem::Mutate3 { sig_ids, mutate } => {
+                    let (sig_id1, sig_id2, sig_id3) = sig_ids;
+                    assert_ne!(sig_id1, sig_id2);
+                    assert_ne!(sig_id1, sig_id3);
+                    assert_ne!(sig_id2, sig_id3);
+
+                    match (sig_id1, sig_id2, sig_id3) {
+                        (
+                            SigId::State {
+                                instance_id: instance_id1,
+                                index: index1,
+                            },
+                            SigId::State {
+                                instance_id: instance_id2,
+                                index: index2,
+                            },
+                            SigId::State {
+                                instance_id: instance_id3,
+                                index: index3,
+                            },
+                        ) => {
+                            let instance_1 = self.instances.get(&instance_id1).unwrap();
+                            let instance_2 = self.instances.get(&instance_id2).unwrap();
+                            let instance_3 = self.instances.get(&instance_id3).unwrap();
+
+                            let state_list1 = unsafe { &mut *instance_1.state_list.get() };
+                            let state_list2 = unsafe { &mut *instance_2.state_list.get() };
+                            let state_list3 = unsafe { &mut *instance_3.state_list.get() };
+
+                            let value1 = state_list1.get_mut(index1).unwrap();
+                            let value2 = state_list2.get_mut(index2).unwrap();
+                            let value3 = state_list3.get_mut(index3).unwrap();
+
+                            mutate((value1.as_mut(), value2.as_mut(), value3.as_mut()));
+
+                            self.add_sig_updated(sig_id1);
+                            self.add_sig_updated(sig_id2);
+                            self.add_sig_updated(sig_id3);
+                        }
+                        _ => todo!(),
+                    }
+                }
+                SetStateItem::Mutate4 { sig_ids, mutate } => {
+                    let (sig_id1, sig_id2, sig_id3, sig_id4) = sig_ids;
+                    assert_ne!(sig_id1, sig_id2);
+                    assert_ne!(sig_id1, sig_id3);
+                    assert_ne!(sig_id1, sig_id4);
+                    assert_ne!(sig_id2, sig_id3);
+                    assert_ne!(sig_id2, sig_id4);
+                    assert_ne!(sig_id3, sig_id4);
+
+                    match (sig_id1, sig_id2, sig_id3, sig_id4) {
+                        (
+                            SigId::State {
+                                instance_id: instance_id1,
+                                index: index1,
+                            },
+                            SigId::State {
+                                instance_id: instance_id2,
+                                index: index2,
+                            },
+                            SigId::State {
+                                instance_id: instance_id3,
+                                index: index3,
+                            },
+                            SigId::State {
+                                instance_id: instance_id4,
+                                index: index4,
+                            },
+                        ) => {
+                            let instance_1 = self.instances.get(&instance_id1).unwrap();
+                            let instance_2 = self.instances.get(&instance_id2).unwrap();
+                            let instance_3 = self.instances.get(&instance_id3).unwrap();
+                            let instance_4 = self.instances.get(&instance_id4).unwrap();
+
+                            let state_list1 = unsafe { &mut *instance_1.state_list.get() };
+                            let state_list2 = unsafe { &mut *instance_2.state_list.get() };
+                            let state_list3 = unsafe { &mut *instance_3.state_list.get() };
+                            let state_list4 = unsafe { &mut *instance_4.state_list.get() };
+
+                            let value1 = state_list1.get_mut(index1).unwrap();
+                            let value2 = state_list2.get_mut(index2).unwrap();
+                            let value3 = state_list3.get_mut(index3).unwrap();
+                            let value4 = state_list4.get_mut(index4).unwrap();
+
+                            mutate((
+                                value1.as_mut(),
+                                value2.as_mut(),
+                                value3.as_mut(),
+                                value4.as_mut(),
+                            ));
+
+                            self.add_sig_updated(sig_id1);
+                            self.add_sig_updated(sig_id2);
+                            self.add_sig_updated(sig_id3);
+                            self.add_sig_updated(sig_id4);
+                        }
+                        _ => todo!(),
+                    }
+                }
             }
         }
     }

--- a/namui/namui-hooks/src/world/public.rs
+++ b/namui/namui-hooks/src/world/public.rs
@@ -54,9 +54,10 @@ impl World {
 
         let root_instance = match self.instances.get(&InstanceId::root()) {
             Some(instance) => instance,
-            None => self
-                .instances
-                .insert(InstanceId::root(), Instance::new(InstanceId::root()).into()),
+            None => self.instances.insert(
+                InstanceId::root(),
+                Box::new(Instance::new(InstanceId::root())),
+            ),
         };
 
         self.raw_event = event;


### PR DESCRIPTION
Changes
1. Size of `SetStateItem` become 56 bytes to support multiple sig ids, but I think it's ok.
2. Multi-mutate only works with state for now. No support for atom yet.
3. unsafe code added for short and low overhead code. it's on getting multiple states' reference.


Usage

```rust
(set_state1, set_state2).mutate(|(state1, state2) { ... });
```