### PR TITLE
nimg: Jpg and Zstd as main codec

### DIFF
--- a/luda-editor/nimg/Cargo.lock
+++ b/luda-editor/nimg/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,29 +42,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
 name = "cc"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -81,123 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cmake"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
-dependencies = [
- "derive_builder_core",
- "syn",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
-name = "half"
-version = "2.4.1"
+name = "jobserver"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "image"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "num-traits",
+ "libc",
 ]
 
 [[package]]
@@ -205,39 +78,6 @@ name = "jpeg-encoder"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fefe5a4fb12fa836172dc53cc36c37af693f6197ae702f931faad8774caf926"
-
-[[package]]
-name = "jpegxl-rs"
-version = "0.10.4+libjxl-0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1052dcf751c8df05c3b2dc07cf584dfda99c3f83090483c527bada9be6fb934"
-dependencies = [
- "byteorder",
- "derive_builder",
- "half",
- "image",
- "jpegxl-sys",
- "thiserror",
-]
-
-[[package]]
-name = "jpegxl-src"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c58789939a9c46b13020c15ddfd0d9f5fb326b685ae35dece42e639126d43b"
-dependencies = [
- "cmake",
-]
-
-[[package]]
-name = "jpegxl-sys"
-version = "0.10.4+libjxl-0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b759db2808767bb744dc780ceb76a235759855e94ff59d98372065abd6ac01"
-dependencies = [
- "jpegxl-src",
- "pkg-config",
-]
 
 [[package]]
 name = "libc"
@@ -266,17 +106,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "jpeg-encoder",
- "jpegxl-rs",
+ "zstd",
  "zune-jpeg",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -295,24 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,47 +138,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
+name = "zstd"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "2.0.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "zstd-safe",
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.63"
+name = "zstd-safe"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
- "thiserror-impl",
+ "zstd-sys",
 ]
 
 [[package]]
-name = "thiserror-impl"
-version = "1.0.63"
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "cc",
+ "pkg-config",
 ]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "zune-core"

--- a/luda-editor/nimg/Cargo.toml
+++ b/luda-editor/nimg/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.86", features = ["backtrace"] }
-jpegxl-rs = { version = "0.10.4", features = ["threads"] }
+zstd = "0.13.2"
 zune-jpeg = "0.4.13"
 
 [target.'cfg(target_feature = "avx2")'.dependencies]

--- a/luda-editor/nimg/src/lib.rs
+++ b/luda-editor/nimg/src/lib.rs
@@ -3,6 +3,9 @@ mod test;
 
 use anyhow::Result;
 
+const ZSTD_ENCODE_LEVEL: i32 = 9;
+const JPEG_QUALITY: u8 = 80;
+
 #[derive(Debug, Clone)]
 
 pub struct Nimg {
@@ -12,22 +15,44 @@ pub struct Nimg {
 
 #[derive(Debug, Clone, Copy)]
 pub enum ColorType {
-    RgbA8888,
+    Rgba8888,
     A8,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[allow(clippy::enum_variant_names)]
 enum Encoded {
-    Rgb8A8 { rgb: Vec<u8>, a: Vec<u8> },
-    A8 { a: Vec<u8> },
+    Rgba8888Zstd { rgba_zstd: Vec<u8> },
+    Rgb888JpegA8Zstd { rgb_jpeg: Vec<u8>, a_zstd: Vec<u8> },
+    A8Zstd { a_zstd: Vec<u8> },
 }
 
-/// alpha channel ignored
-pub fn encode_rgba8(width: usize, height: usize, pixels: &[u8]) -> Result<Nimg> {
-    let rgb = {
+impl std::fmt::Debug for Encoded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Encoded::Rgba8888Zstd { rgba_zstd } => f
+                .debug_struct("Rgba8888Zstd")
+                .field("rgba", &rgba_zstd.len())
+                .finish(),
+            Encoded::Rgb888JpegA8Zstd { rgb_jpeg, a_zstd } => f
+                .debug_struct("Rgb888JpegA8Zstd")
+                .field("rgb", &rgb_jpeg.len())
+                .field("a", &a_zstd.len())
+                .finish(),
+            Encoded::A8Zstd { a_zstd } => {
+                f.debug_struct("A8Zstd").field("a", &a_zstd.len()).finish()
+            }
+        }
+    }
+}
+
+pub fn encode_rgba8888(width: usize, height: usize, pixels: &[u8]) -> Result<Nimg> {
+    assert_eq!(pixels.len(), width * height * 4);
+
+    let rgb_jpeg = {
         let mut output = Vec::with_capacity(width * height * 3);
 
-        jpeg_encoder::Encoder::new(&mut output, 80).encode(
+        jpeg_encoder::Encoder::new(&mut output, JPEG_QUALITY).encode(
             pixels,
             width as u16,
             height as u16,
@@ -37,82 +62,86 @@ pub fn encode_rgba8(width: usize, height: usize, pixels: &[u8]) -> Result<Nimg> 
         output
     };
 
-    let a = {
+    let a_zstd = {
         let a_pixels = pixels
             .chunks_exact(4)
             .map(|rgba| rgba[3])
             .collect::<Vec<_>>();
 
-        encode_a8_impl(width, height, &a_pixels)?
+        zstd::encode_all(a_pixels.as_slice(), ZSTD_ENCODE_LEVEL)?
     };
 
-    Ok(Nimg {
-        color_type: ColorType::RgbA8888,
-        encoded: Encoded::Rgb8A8 { rgb, a },
-    })
+    let rgba_zstd = zstd::encode_all(pixels, ZSTD_ENCODE_LEVEL)?;
+
+    if rgb_jpeg.len() + a_zstd.len() < rgba_zstd.len() {
+        Ok(Nimg {
+            color_type: ColorType::Rgba8888,
+            encoded: Encoded::Rgb888JpegA8Zstd { rgb_jpeg, a_zstd },
+        })
+    } else {
+        Ok(Nimg {
+            color_type: ColorType::Rgba8888,
+            encoded: Encoded::Rgba8888Zstd { rgba_zstd },
+        })
+    }
 }
 
-pub fn encode_a8(width: usize, height: usize, data: &[u8]) -> Result<Nimg> {
+pub fn encode_a8(data: &[u8]) -> Result<Nimg> {
     Ok(Nimg {
         color_type: ColorType::A8,
-        encoded: Encoded::A8 {
-            a: encode_a8_impl(width, height, data)?,
+        encoded: Encoded::A8Zstd {
+            a_zstd: zstd::encode_all(data, ZSTD_ENCODE_LEVEL)?,
         },
     })
-}
-
-fn encode_a8_impl(width: usize, height: usize, data: &[u8]) -> Result<Vec<u8>> {
-    let mut encoder = jpegxl_rs::encoder_builder()
-        .color_encoding(jpegxl_rs::encode::ColorEncoding::SrgbLuma)
-        .has_alpha(false)
-        .lossless(true)
-        .uses_original_profile(true)
-        .speed(jpegxl_rs::encode::EncoderSpeed::Lightning)
-        .decoding_speed(4)
-        .build()?;
-
-    let frame = jpegxl_rs::encode::EncoderFrame::new(data).num_channels(1);
-
-    Ok(encoder
-        .encode_frame::<u8, u8>(&frame, width as _, height as _)?
-        .data)
 }
 
 impl Nimg {
     pub fn decode(&self) -> Result<Vec<u8>> {
         let Self { encoded, .. } = self;
         match encoded {
-            Encoded::Rgb8A8 { rgb, a } => {
-                let a_pixels = decode_a8(a)?;
-
+            Encoded::Rgba8888Zstd { rgba_zstd } => Ok(zstd::decode_all(rgba_zstd.as_slice())?),
+            Encoded::Rgb888JpegA8Zstd { rgb_jpeg, a_zstd } => {
                 let mut rgba = {
-                    use zune_jpeg::zune_core::*;
-                    let mut decoder = zune_jpeg::JpegDecoder::new(rgb);
+                    let mut decoder = zune_jpeg::JpegDecoder::new(rgb_jpeg.as_slice());
+
                     decoder.set_options(
-                        options::DecoderOptions::default()
-                            .jpeg_set_out_colorspace(colorspace::ColorSpace::RGBA),
+                        zune_jpeg::zune_core::options::DecoderOptions::default()
+                            .jpeg_set_out_colorspace(
+                                zune_jpeg::zune_core::colorspace::ColorSpace::RGBA,
+                            ),
                     );
 
                     decoder.decode()?
                 };
+                let a = zstd::decode_all(a_zstd.as_slice())?;
 
                 rgba.chunks_exact_mut(4)
-                    .zip(a_pixels.iter())
+                    .zip(a.iter())
                     .for_each(|(rgba, a)| rgba[3] = *a);
 
                 Ok(rgba)
             }
-            Encoded::A8 { a } => Ok(decode_a8(a)?),
+            Encoded::A8Zstd { a_zstd } => Ok(zstd::decode_all(a_zstd.as_slice())?),
         }
     }
-}
 
-fn decode_a8(data: &[u8]) -> Result<Vec<u8>> {
-    let (_, pixels) = jpegxl_rs::decoder_builder().build()?.decode(data)?;
+    pub fn image_encoded_byte_size(&self) -> usize {
+        let Self { encoded, .. } = self;
+        match encoded {
+            Encoded::Rgba8888Zstd { rgba_zstd } => rgba_zstd.len(),
+            Encoded::Rgb888JpegA8Zstd { rgb_jpeg, a_zstd } => rgb_jpeg.len() + a_zstd.len(),
+            Encoded::A8Zstd { a_zstd } => a_zstd.len(),
+        }
+    }
 
-    if let jpegxl_rs::decode::Pixels::Uint8(pixels) = pixels {
-        Ok(pixels)
-    } else {
-        unreachable!()
+    pub fn image_encoded_bytes(&self) -> Vec<Vec<u8>> {
+        let Self { encoded, .. } = self;
+        match encoded {
+            Encoded::Rgba8888Zstd { rgba_zstd } => vec![rgba_zstd.clone()],
+            Encoded::Rgb888JpegA8Zstd { rgb_jpeg, a_zstd } => {
+                vec![rgb_jpeg.clone(), a_zstd.clone()]
+            }
+            Encoded::A8Zstd { a_zstd } => vec![a_zstd.clone()],
+        }
     }
 }

--- a/luda-editor/psd-sprite-render/Cargo.lock
+++ b/luda-editor/psd-sprite-render/Cargo.lock
@@ -318,12 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
 name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,15 +396,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -519,51 +504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.75",
-]
 
 [[package]]
 name = "dashmap"
@@ -606,37 +550,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.75",
 ]
 
@@ -1015,16 +928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,12 +1113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,17 +1120,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "image"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "num-traits",
 ]
 
 [[package]]
@@ -1309,39 +1195,6 @@ name = "jpeg-encoder"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fefe5a4fb12fa836172dc53cc36c37af693f6197ae702f931faad8774caf926"
-
-[[package]]
-name = "jpegxl-rs"
-version = "0.10.4+libjxl-0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1052dcf751c8df05c3b2dc07cf584dfda99c3f83090483c527bada9be6fb934"
-dependencies = [
- "byteorder",
- "derive_builder",
- "half",
- "image",
- "jpegxl-sys",
- "thiserror",
-]
-
-[[package]]
-name = "jpegxl-src"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c58789939a9c46b13020c15ddfd0d9f5fb326b685ae35dece42e639126d43b"
-dependencies = [
- "cmake",
-]
-
-[[package]]
-name = "jpegxl-sys"
-version = "0.10.4+libjxl-0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b759db2808767bb744dc780ceb76a235759855e94ff59d98372065abd6ac01"
-dependencies = [
- "jpegxl-src",
- "pkg-config",
-]
 
 [[package]]
 name = "js-sys"
@@ -1523,13 +1376,9 @@ name = "namui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bumpalo",
  "dashmap",
- "derivative",
- "elsa",
  "ffmpeg-next",
  "futures",
- "indexmap",
  "lazy_static",
  "namui-cfg",
  "namui-drawer",
@@ -1540,17 +1389,12 @@ dependencies = [
  "opener",
  "percent-encoding",
  "rand",
+ "rayon",
  "reqwest",
  "rusqlite",
- "rustc-hash",
  "serde",
  "serde_json",
  "shader-macro",
- "slab",
- "smallvec",
- "smol_str",
- "stable_deref_trait",
- "static-tree",
  "tokio 1.38.0",
  "url",
  "wasapi",
@@ -1686,7 +1530,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "jpeg-encoder",
- "jpegxl-rs",
+ "zstd",
  "zune-jpeg",
 ]
 
@@ -2096,6 +1940,7 @@ dependencies = [
  "rayon",
  "schema-0",
  "skia-safe",
+ "zstd",
 ]
 
 [[package]]
@@ -2701,25 +2546,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static-tree"
-version = "0.1.0"
-dependencies = [
- "elsa",
- "rustc-hash",
- "slab",
-]
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -3882,6 +3712,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.75",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/luda-editor/psd-sprite-render/Cargo.toml
+++ b/luda-editor/psd-sprite-render/Cargo.toml
@@ -11,3 +11,6 @@ skia-safe = { path = "../../namui/third-party-forks/rust-skia/skia-safe" }
 schema-0 = { version = "0.0.1", path = "../new-server/database/schema/0" }
 namui = { version = "0.1.0", path = "../../namui/namui" }
 psd-sprite = { version = "0.1.0", path = "../psd-sprite" }
+
+[dev-dependencies]
+zstd = "0.13.2"

--- a/luda-editor/psd-sprite-render/src/render_psd_sprite.rs
+++ b/luda-editor/psd-sprite-render/src/render_psd_sprite.rs
@@ -262,6 +262,21 @@ mod test {
         let psd_sprite = PsdSprite::from_psd_bytes(psd_bytes).unwrap();
         println!("PsdSprite::from_psd_bytes: {:?}", now.elapsed());
 
+        println!(
+            "psd_sprite.image_encoded_byte_size: {}",
+            psd_sprite.image_encoded_byte_size()
+        );
+
+        let bytes = psd_sprite.image_encoded_bytes().concat();
+        println!("before zstd: {}", bytes.len());
+
+        let full_encoded = zstd::encode_all(bytes.as_slice(), 9).unwrap();
+        println!("full_encoded.len(): {}", full_encoded.len());
+
+        let now = std::time::Instant::now();
+        zstd::decode_all(full_encoded.as_slice()).unwrap();
+        println!("zstd::decode_all: {:?}", now.elapsed());
+
         let now = std::time::Instant::now();
         let scene_sprite = SceneSprite {
             sprite_id: None,

--- a/luda-editor/psd-sprite-render/src/sprite_image_ext.rs
+++ b/luda-editor/psd-sprite-render/src/sprite_image_ext.rs
@@ -13,14 +13,14 @@ impl SpriteImageExt for SpriteImage {
         let height = self.dest_rect.height().as_f32() as i32;
 
         let image_info = match color_type {
-            psd_sprite::ColorType::RgbA8888 => {
+            psd_sprite::ColorType::Rgba8888 => {
                 skia_safe::ImageInfo::new_n32((width, height), skia_safe::AlphaType::Unpremul, None)
             }
             psd_sprite::ColorType::A8 { .. } => skia_safe::ImageInfo::new_a8((width, height)),
         };
 
         let row_bytes = match color_type {
-            psd_sprite::ColorType::RgbA8888 => width * 4,
+            psd_sprite::ColorType::Rgba8888 => width * 4,
             psd_sprite::ColorType::A8 { .. } => width,
         } as usize;
 
@@ -30,7 +30,7 @@ impl SpriteImageExt for SpriteImage {
                     ImageInfo {
                         alpha_type: namui::AlphaType::Unpremul,
                         color_type: match color_type {
-                            psd_sprite::ColorType::RgbA8888 => namui::ColorType::Rgba8888,
+                            psd_sprite::ColorType::Rgba8888 => namui::ColorType::Rgba8888,
                             psd_sprite::ColorType::A8 { .. } => namui::ColorType::Alpha8,
                         },
                         height: (height as f32).px(),

--- a/luda-editor/psd-sprite/src/encode.rs
+++ b/luda-editor/psd-sprite/src/encode.rs
@@ -24,8 +24,8 @@ pub(crate) fn encode_image(image: &Image) -> Result<nimg::Nimg> {
     );
 
     Ok(match dest_color_type {
-        skia_safe::ColorType::Alpha8 => nimg::encode_a8(width, height, &pixels)?,
-        skia_safe::ColorType::RGBA8888 => nimg::encode_rgba8(width, height, &pixels)?,
+        skia_safe::ColorType::Alpha8 => nimg::encode_a8(&pixels)?,
+        skia_safe::ColorType::RGBA8888 => nimg::encode_rgba8888(width, height, &pixels)?,
         _ => unreachable!(),
     })
 }


### PR DESCRIPTION
```
PsdSprite::from_psd_bytes: 527.779713ms
psd_sprite.image_encoded_byte_size: 1,176,055
before zstd: 1,176,055
full_encoded.len(): 1,027,876
zstd::decode_all: 405.731µs
create_image_filter: 31.124447ms
```

fast enough. I'm gonna do about streaming decoding next.