### PR TITLE
Namui New http wrapping

### DIFF
--- a/namui/namui-cli/webCode/src/bufferPool.ts
+++ b/namui/namui-cli/webCode/src/bufferPool.ts
@@ -1,0 +1,63 @@
+import { sendMessageToMainThread } from "./interWorkerProtocol";
+import { NewEventSystemHandleOnMainThread } from "./newEventSystem";
+
+export type PooledBuffer = {
+    ptr: number;
+    view: Uint8Array;
+};
+
+export function bufferPoolImports({ memory }: { memory: WebAssembly.Memory }) {
+    return {
+        _buffer_pool_new_buffer: (ptr: number, len: number) => {
+            if (!(memory.buffer instanceof SharedArrayBuffer)) {
+                throw new Error("memory.buffer must be SharedArrayBuffer");
+            }
+
+            sendMessageToMainThread({
+                type: "buffer-pool-new-buffer",
+                ptr,
+                len,
+            });
+        },
+    };
+}
+
+export class BufferPoolHandleOnMainThread {
+    readonly bufferPool: PooledBuffer[] = [];
+    readonly bufferWaiters: Array<(buffer: PooledBuffer) => void> = [];
+
+    constructor(
+        private readonly newEventSystemHandle: NewEventSystemHandleOnMainThread,
+    ) {
+        for (let i = 0; i < 128; i++) {
+            this.requestBuffer();
+        }
+    }
+
+    public pushBuffer(buffer: PooledBuffer) {
+        const waiter = this.bufferWaiters.shift();
+        if (waiter) {
+            return waiter(buffer);
+        }
+        this.bufferPool.push(buffer);
+    }
+
+    public async getBuffer(): Promise<PooledBuffer> {
+        this.requestBuffer();
+
+        const buffer = this.bufferPool.pop();
+        if (buffer) {
+            return buffer;
+        }
+
+        return await new Promise<PooledBuffer>((resolve) => {
+            this.bufferWaiters.push(resolve);
+        });
+    }
+
+    private requestBuffer() {
+        this.newEventSystemHandle.sendEvent({
+            type: "buffer-pool/request-buffer",
+        });
+    }
+}

--- a/namui/namui-cli/webCode/src/httpFetch/httpFetch.ts
+++ b/namui/namui-cli/webCode/src/httpFetch/httpFetch.ts
@@ -1,0 +1,259 @@
+import { BufferPoolHandleOnMainThread } from "../bufferPool";
+import { sendMessageToMainThread } from "../interWorkerProtocol";
+import { NoStreamHttpFetchHandle } from "./noStream";
+import { YesStreamHttpFetchHandle } from "./yesStream";
+import {
+    NewEventSystemHandleOnMainThread,
+    NewSystemEvent,
+} from "../newEventSystem";
+
+export function httpFetchImports({ memory }: { memory: WebAssembly.Memory }) {
+    return {
+        _http_fetch_init(
+            urlPtr: number,
+            urlLen: number,
+            methodPtr: number,
+            methodLen: number,
+        ): number {
+            const urlBuffer = new Uint8Array(urlLen);
+            urlBuffer.set(new Uint8Array(memory.buffer, urlPtr, urlLen));
+            const url = new TextDecoder().decode(urlBuffer);
+
+            const methodBuffer = new Uint8Array(methodLen);
+            methodBuffer.set(
+                new Uint8Array(memory.buffer, methodPtr, methodLen),
+            );
+            const method = new TextDecoder().decode(methodBuffer);
+
+            const idBuffer = new SharedArrayBuffer(4);
+            sendMessageToMainThread({
+                type: "new-http-fetch",
+                url,
+                method,
+                idBuffer,
+            });
+
+            Atomics.wait(new Int32Array(idBuffer), 0, 0);
+            const id = new Uint32Array(idBuffer)[0];
+            return id;
+        },
+        _http_fetch_set_header(
+            fetchId: number,
+            keyPtr: number,
+            keyLen: number,
+            valuePtr: number,
+            valueLen: number,
+        ) {
+            const keyBuffer = new Uint8Array(keyLen);
+            keyBuffer.set(new Uint8Array(memory.buffer, keyPtr, keyLen));
+            const key = new TextDecoder().decode(keyBuffer);
+
+            const valueBuffer = new Uint8Array(valueLen);
+            valueBuffer.set(new Uint8Array(memory.buffer, valuePtr, valueLen));
+            const value = new TextDecoder().decode(valueBuffer);
+
+            sendMessageToMainThread({
+                type: "http-fetch-set-header",
+                fetchId,
+                key,
+                value,
+            });
+        },
+        _http_fetch_start(fetchId: number) {
+            sendMessageToMainThread({
+                type: "http-fetch-start",
+                fetchId,
+            });
+        },
+        _http_fetch_push_request_body_chunk(
+            fetchId: number,
+            dataPtr: number,
+            dataLen: number,
+        ) {
+            // TODO: Reduce this copy, just passing ptr and tracking lifetime
+            const data = new Uint8Array(dataLen);
+            data.set(new Uint8Array(memory.buffer, dataPtr, dataLen));
+            sendMessageToMainThread(
+                {
+                    type: "http-fetch-push-request-body-chunk",
+                    fetchId,
+                    data: data.buffer,
+                },
+                [data.buffer],
+            );
+        },
+        _http_fetch_finish_request_body_stream(fetchId: number) {
+            sendMessageToMainThread({
+                type: "http-fetch-finish-request-body-stream",
+                fetchId,
+            });
+        },
+        _http_fetch_error_on_rust_side(fetchId: number) {
+            sendMessageToMainThread({
+                type: "http-fetch-error-on-rust-side",
+                fetchId,
+            });
+        },
+    };
+}
+
+export interface HttpFetchHandle {
+    onHttpFetchErrorOnRustSide(fetchId: number): void;
+    onNewHttpFetch({
+        url,
+        method,
+        idBuffer,
+    }: {
+        url: string;
+        method: string;
+        idBuffer: SharedArrayBuffer;
+    }): void;
+    onHttpFetchSetHeader({
+        fetchId,
+        key,
+        value,
+    }: {
+        fetchId: number;
+        key: string;
+        value: string;
+    }): void;
+    onHttpFetchStart({ fetchId }: { fetchId: number }): void;
+    onHttpFetchPushRequestBodyChunk({
+        fetchId,
+        data,
+    }: {
+        fetchId: number;
+        data: ArrayBuffer;
+    }): void;
+    onHttpFetchFinishRequestBodyStream({ fetchId }: { fetchId: number }): void;
+}
+
+export async function isSupportsRequestStreams() {
+    const url = "data:a/a;charset=utf-8,";
+    const supportsStreamsInRequestObjects = !new Request(url, {
+        body: new ReadableStream(),
+        // @ts-ignore
+        duplex: "half",
+        method: "POST",
+    }).headers.has("Content-Type");
+
+    if (!supportsStreamsInRequestObjects) return false;
+
+    return fetch(url, {
+        method: "POST",
+        // @ts-ignore
+        duplex: "half",
+        body: new ReadableStream(),
+    }).then(
+        () => true,
+        () => false,
+    );
+}
+
+export function httpFetchHandleOnMainThread(
+    supportsRequestStreams: boolean,
+    newEventSystemHandle: NewEventSystemHandleOnMainThread,
+    bufferPoolManager: BufferPoolHandleOnMainThread,
+): HttpFetchHandle {
+    function responseToEvent(
+        fetchId: number,
+        response: Response,
+    ): NewSystemEvent {
+        const headerEntries = Array.from(response.headers.entries());
+        return {
+            type: "http-fetch/on-response",
+            fetchId: ["u32", fetchId],
+            status: ["u16", response.status],
+            headerCount: ["u16", headerEntries.length],
+            headers: headerEntries.map(([key, value]) => {
+                const keyBuffer = new TextEncoder().encode(key);
+                const valueBuffer = new TextEncoder().encode(value);
+                return {
+                    keyByteLength: ["u16", keyBuffer.length],
+                    key: ["bytes", keyBuffer],
+                    valueByteLength: ["u16", valueBuffer.length],
+                    value: ["bytes", valueBuffer],
+                };
+            }),
+        };
+    }
+    function onResponse(fetchId: number, response: Response): void {
+        newEventSystemHandle.sendEvent(responseToEvent(fetchId, response));
+    }
+    function onError(fetchId: number, error: unknown): void {
+        const message = String(error);
+        const messageBuffer = new TextEncoder().encode(message);
+        newEventSystemHandle.sendEvent({
+            type: "http-fetch/on-error",
+            fetchId: ["u32", fetchId],
+            messageByteLength: ["u32", messageBuffer.length],
+            message: ["bytes", messageBuffer],
+        });
+    }
+
+    if (supportsRequestStreams) {
+        return new YesStreamHttpFetchHandle(
+            onResponse,
+            async function getResponseBodyBuffer(): Promise<{
+                pooledBufferPtr: number;
+                buffer: Uint8Array;
+            }> {
+                const buffer = await bufferPoolManager.getBuffer();
+                return {
+                    pooledBufferPtr: buffer.ptr,
+                    buffer: buffer.view,
+                };
+            },
+            function onResponseBodyChunk(
+                fetchId: number,
+                pooledBufferPtr: number,
+                written: number,
+            ): void {
+                newEventSystemHandle.sendEvent({
+                    type: "http-fetch/on-response-body-chunk",
+                    fetchId: ["u32", fetchId],
+                    pooledBufferPtr: ["u32", pooledBufferPtr],
+                    written: ["u32", written],
+                });
+            },
+            function onResponseBodyDone(fetchId: number): void {
+                newEventSystemHandle.sendEvent({
+                    type: "http-fetch/on-response-body-done",
+                    fetchId: ["u32", fetchId],
+                });
+            },
+            onError,
+        );
+    }
+    return new NoStreamHttpFetchHandle(
+        onResponse,
+        async function onResponseBody(
+            fetchId: number,
+            body: Uint8Array,
+        ): Promise<void> {
+            let bodyWritten = 0;
+            while (bodyWritten < body.length) {
+                const buffer = await bufferPoolManager.getBuffer();
+                buffer.view.set(body.slice(bodyWritten));
+                const written = Math.min(
+                    body.length - bodyWritten,
+                    buffer.view.length,
+                );
+
+                newEventSystemHandle.sendEvent({
+                    type: "http-fetch/on-response-body-chunk",
+                    fetchId: ["u32", fetchId],
+                    pooledBufferPtr: ["u32", buffer.ptr],
+                    written: ["u32", written],
+                });
+
+                bodyWritten += written;
+            }
+            newEventSystemHandle.sendEvent({
+                type: "http-fetch/on-response-body-done",
+                fetchId: ["u32", fetchId],
+            });
+        },
+        onError,
+    );
+}

--- a/namui/namui-cli/webCode/src/httpFetch/noStream.ts
+++ b/namui/namui-cli/webCode/src/httpFetch/noStream.ts
@@ -1,0 +1,127 @@
+import { HttpFetchHandle } from "./httpFetch";
+
+export class NoStreamHttpFetchHandle implements HttpFetchHandle {
+    private nextId = 1;
+    private readonly requests = new Map<number, Request>();
+    private readonly requestBodies = new Map<
+        number,
+        {
+            written: number;
+            buffer: Uint8Array;
+        }
+    >();
+    private readonly abortControllers = new Map<number, AbortController>();
+
+    constructor(
+        private readonly onResponse: (
+            fetchId: number,
+            response: Response,
+        ) => void,
+        private readonly onResponseBody: (
+            fetchId: number,
+            body: Uint8Array,
+        ) => void,
+        private readonly onError: (fetchId: number, error: unknown) => void,
+    ) {}
+
+    onNewHttpFetch({
+        url,
+        method,
+        idBuffer,
+    }: {
+        url: string;
+        method: string;
+        idBuffer: SharedArrayBuffer;
+    }): void {
+        const request = new Request(url, { method });
+
+        const id = this.nextId++;
+        this.requests.set(id, request);
+
+        new Uint32Array(idBuffer)[0] = id;
+        Atomics.notify(new Int32Array(idBuffer), 0);
+    }
+
+    onHttpFetchSetHeader({
+        fetchId,
+        key,
+        value,
+    }: {
+        fetchId: number;
+        key: string;
+        value: string;
+    }): void {
+        const request = this.requests.get(fetchId);
+        if (!request) {
+            throw new Error(`Request not found: ${fetchId}`);
+        }
+        request.headers.set(key, value);
+    }
+
+    onHttpFetchStart({ fetchId }: { fetchId: number }): void {
+        const request = this.requests.get(fetchId);
+        if (!request) {
+            throw new Error(`Request not found: ${fetchId}`);
+        }
+        const contentLength = request.headers.get("content-length");
+        if (!contentLength) {
+            return;
+        }
+        const buffer = new Uint8Array(Number(contentLength));
+        this.requestBodies.set(fetchId, {
+            written: 0,
+            buffer,
+        });
+    }
+
+    onHttpFetchPushRequestBodyChunk({
+        fetchId,
+        data,
+    }: {
+        fetchId: number;
+        data: ArrayBuffer;
+    }): void {
+        const requestBody = this.requestBodies.get(fetchId);
+        if (!requestBody) {
+            throw new Error(`Request body not found: ${fetchId}`);
+        }
+        requestBody.buffer.set(new Uint8Array(data), requestBody.written);
+        requestBody.written += data.byteLength;
+    }
+
+    async onHttpFetchFinishRequestBodyStream({ fetchId }: { fetchId: number }) {
+        const requestBody = this.requestBodies.get(fetchId);
+
+        const abortController = new AbortController();
+        this.abortControllers.set(fetchId, abortController);
+
+        try {
+            const response = await fetch(this.requests.get(fetchId)!, {
+                body: requestBody?.buffer,
+                signal: abortController.signal,
+            });
+
+            this.onResponse(fetchId, response);
+            const responseBody = await response.arrayBuffer();
+            this.onResponseBody(fetchId, new Uint8Array(responseBody));
+        } catch (err) {
+            this.onError(fetchId, err);
+        } finally {
+            this.cleanUpFetch(fetchId);
+        }
+    }
+
+    cleanUpFetch(fetchId: number) {
+        this.requests.delete(fetchId);
+        this.requestBodies.delete(fetchId);
+        const abortController = this.abortControllers.get(fetchId);
+        if (abortController) {
+            abortController.abort();
+            this.abortControllers.delete(fetchId);
+        }
+    }
+
+    onHttpFetchErrorOnRustSide(fetchId: number): void {
+        this.cleanUpFetch(fetchId);
+    }
+}

--- a/namui/namui-cli/webCode/src/httpFetch/yesStream.ts
+++ b/namui/namui-cli/webCode/src/httpFetch/yesStream.ts
@@ -1,0 +1,216 @@
+import { HttpFetchHandle } from "./httpFetch";
+
+export class YesStreamHttpFetchHandle implements HttpFetchHandle {
+    private nextId = 1;
+    private readonly requests = new Map<number, Request>();
+    private readonly requestBodies = new Map<
+        number,
+        {
+            stream: WritableStream;
+            isSomeoneWriting: boolean;
+            queuedChunks: ArrayBuffer[];
+            isOver: boolean;
+        }
+    >();
+    private readonly abortControllers = new Map<number, AbortController>();
+
+    constructor(
+        private readonly onResponse: (
+            fetchId: number,
+            response: Response,
+        ) => void,
+        private readonly getResponseBodyBuffer: () => Promise<{
+            pooledBufferPtr: number;
+            buffer: Uint8Array;
+        }>,
+        private readonly onResponseBodyChunk: (
+            fetchId: number,
+            pooledBufferPtr: number,
+            written: number,
+        ) => void,
+        private readonly onResponseBodyDone: (fetchId: number) => void,
+        private readonly onError: (fetchId: number, error: unknown) => void,
+    ) {}
+
+    onNewHttpFetch({
+        url,
+        method,
+        idBuffer,
+    }: {
+        url: string;
+        method: string;
+        idBuffer: SharedArrayBuffer;
+    }): void {
+        const request = new Request(url, {
+            method,
+            // @ts-ignore
+            duplex: "half",
+        });
+
+        const id = this.nextId++;
+        this.requests.set(id, request);
+
+        new Uint32Array(idBuffer)[0] = id;
+        Atomics.notify(new Int32Array(idBuffer), 0);
+    }
+
+    onHttpFetchSetHeader({
+        fetchId,
+        key,
+        value,
+    }: {
+        fetchId: number;
+        key: string;
+        value: string;
+    }): void {
+        const request = this.requests.get(fetchId);
+        if (!request) {
+            throw new Error(`Request not found: ${fetchId}`);
+        }
+        request.headers.set(key, value);
+    }
+
+    onHttpFetchStart({ fetchId }: { fetchId: number }): void {
+        const request = this.requests.get(fetchId);
+        if (!request) {
+            throw new Error(`Request not found: ${fetchId}`);
+        }
+        const { readable, writable } = new TransformStream();
+
+        this.requestBodies.set(fetchId, {
+            isSomeoneWriting: false,
+            stream: writable,
+            queuedChunks: [],
+            isOver: false,
+        });
+
+        const abortController = new AbortController();
+        this.abortControllers.set(fetchId, abortController);
+
+        (async () => {
+            try {
+                const response = await fetch(request, {
+                    body: ["GET", "HEAD"].includes(request.method)
+                        ? undefined
+                        : readable,
+                    signal: abortController.signal,
+                });
+                this.onResponse(fetchId, response);
+
+                const { body } = response;
+                if (!body) {
+                    this.onResponseBodyDone(fetchId);
+                    return;
+                }
+
+                const reader = body.getReader({
+                    mode: "byob",
+                });
+
+                while (!this.isCleanedUp(fetchId)) {
+                    const { buffer, pooledBufferPtr } =
+                        await this.getResponseBodyBuffer();
+
+                    // NOTE: Currently byob doesn't support to write to shared buffer directly
+                    const tempBuffer = new Uint8Array(buffer.buffer.byteLength);
+
+                    const { value, done } = await reader.read(tempBuffer);
+
+                    if (!value) {
+                        throw new Error("Response Stream Canceled");
+                    }
+
+                    buffer.set(value);
+
+                    this.onResponseBodyChunk(
+                        fetchId,
+                        pooledBufferPtr,
+                        value.byteLength,
+                    );
+
+                    if (done) {
+                        this.onResponseBodyDone(fetchId);
+                        break;
+                    }
+                }
+            } catch (error) {
+                this.onError(fetchId, error);
+            } finally {
+                this.cleanUpFetch(fetchId);
+            }
+        })();
+    }
+
+    async onHttpFetchPushRequestBodyChunk({
+        fetchId,
+        data,
+    }: {
+        fetchId: number;
+        data: ArrayBuffer;
+    }): Promise<void> {
+        const requestBody = this.requestBodies.get(fetchId);
+        if (!requestBody) {
+            throw new Error(`Request body not found: ${fetchId}`);
+        }
+
+        requestBody.queuedChunks.push(data);
+
+        if (requestBody.isSomeoneWriting) {
+            return;
+        }
+        requestBody.isSomeoneWriting = true;
+        try {
+            const writer = requestBody.stream.getWriter();
+
+            while (requestBody.queuedChunks.length) {
+                const chunk = requestBody.queuedChunks.shift()!;
+                await writer.write(chunk);
+            }
+
+            if (requestBody.isOver) {
+                writer.close();
+            }
+
+            requestBody.isSomeoneWriting = false;
+        } catch (err) {
+            this.onError(fetchId, err);
+            this.cleanUpFetch(fetchId);
+        }
+    }
+
+    async onHttpFetchFinishRequestBodyStream({ fetchId }: { fetchId: number }) {
+        const requestBody = this.requestBodies.get(fetchId);
+        if (!requestBody) {
+            throw new Error(`Request body not found: ${fetchId}`);
+        }
+
+        requestBody.isOver = true;
+
+        if (!requestBody.isSomeoneWriting) {
+            try {
+                await requestBody.stream.getWriter().close();
+            } catch (err) {
+                this.onError(fetchId, err);
+                this.cleanUpFetch(fetchId);
+            }
+        }
+    }
+
+    cleanUpFetch(fetchId: number) {
+        this.requests.delete(fetchId);
+        this.requestBodies.delete(fetchId);
+        const abortController = this.abortControllers.get(fetchId);
+        if (abortController) {
+            abortController.abort();
+            this.abortControllers.delete(fetchId);
+        }
+    }
+
+    isCleanedUp(fetchId: number) {
+        return !this.requests.has(fetchId);
+    }
+
+    onHttpFetchErrorOnRustSide(fetchId: number): void {
+        this.cleanUpFetch(fetchId);
+    }
+}

--- a/namui/namui-cli/webCode/src/imports/importObject.ts
+++ b/namui/namui-cli/webCode/src/imports/importObject.ts
@@ -6,6 +6,9 @@ import { Exports } from "../exports";
 import { webSocketImports } from "../webSocket";
 import { insertJsImports } from "../insertJs";
 import { storageImports } from "../storage/imports";
+import { bufferPoolImports } from "../bufferPool";
+import { newEventSystemImports } from "../newEventSystem";
+import { httpFetchImports } from "../httpFetch/httpFetch";
 
 export function createImportObject({
     memory,
@@ -93,6 +96,9 @@ export function createImportObject({
                 memory,
                 storageProtocolBuffer,
             }),
+            ...bufferPoolImports({ memory }),
+            ...newEventSystemImports({ memory }),
+            ...httpFetchImports({ memory }),
             poll_event: (wasmBufferPtr: number): number => {
                 if (!eventSystem) {
                     eventSystem = new EventSystemOnWorker(eventBuffer, memory);

--- a/namui/namui-cli/webCode/src/insertJs.ts
+++ b/namui/namui-cli/webCode/src/insertJs.ts
@@ -91,10 +91,7 @@ export function insertJsHandleOnMainThread(): {
         }
     >();
 
-    (window as any).namui_onData = async (
-        id: number,
-        data: StrictArrayBuffer,
-    ) => {
+    (window as any).namui_onData = (id: number, data: StrictArrayBuffer) => {
         const js = jsMap.get(id);
         if (!js) {
             console.log(`No js for ${id} found but namui_onData is called.`);
@@ -112,7 +109,7 @@ export function insertJsHandleOnMainThread(): {
                 `Data byte length ${data.byteLength} is larger than 0xffff`,
             );
         }
-        await js.ringBuffer.write(["u16", data.byteLength], ["bytes", data]);
+        js.ringBuffer.write(["u16", data.byteLength], ["bytes", data]);
     };
 
     return {

--- a/namui/namui-cli/webCode/src/interWorkerProtocol.ts
+++ b/namui/namui-cli/webCode/src/interWorkerProtocol.ts
@@ -92,6 +92,49 @@ export type WorkerMessagePayload =
     | {
           type: "storage-thread-disconnect";
           threadId: number;
+      }
+    // Http Fetch
+    | {
+          type: "new-http-fetch";
+          url: string;
+          method: string;
+          idBuffer: SharedArrayBuffer;
+      }
+    | {
+          type: "http-fetch-set-header";
+          fetchId: number;
+          key: string;
+          value: string;
+      }
+    | {
+          type: "http-fetch-start";
+          fetchId: number;
+      }
+    | {
+          type: "http-fetch-push-request-body-chunk";
+          fetchId: number;
+          data: ArrayBuffer;
+      }
+    | {
+          type: "http-fetch-finish-request-body-stream";
+          fetchId: number;
+      }
+    | {
+          type: "http-fetch-error-on-rust-side";
+          fetchId: number;
+      }
+    // New Event System
+    | {
+          type: "init-new-event-system-thread";
+          wasmMemory: WebAssembly.Memory;
+          writtenBuffer: SharedArrayBuffer;
+          eventBufferPtr: number;
+          eventBufferLen: number;
+      }
+    | {
+          type: "buffer-pool-new-buffer";
+          ptr: number;
+          len: number;
       };
 
 export function sendMessageToMainThread(

--- a/namui/namui-cli/webCode/src/main.ts
+++ b/namui/namui-cli/webCode/src/main.ts
@@ -6,119 +6,182 @@ import { TextInput } from "./textInput";
 import ThreadWorker from "./thread-worker?worker";
 import { webSocketHandleOnMainThread } from "./webSocket";
 import StorageWorker from "./storage/worker?worker";
+import {
+    httpFetchHandleOnMainThread,
+    isSupportsRequestStreams,
+} from "./httpFetch/httpFetch";
+import { NewEventSystemHandleOnMainThread } from "./newEventSystem";
+import { BufferPoolHandleOnMainThread } from "./bufferPool";
 
-const canvas = document.createElement("canvas");
-canvas.width = window.innerWidth;
-canvas.height = window.innerHeight;
-document.body.appendChild(canvas);
+(async function main() {
+    const canvas = document.createElement("canvas");
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    document.body.appendChild(canvas);
 
-const bitmapCtx = canvas.getContext("bitmaprenderer")!;
-if (!bitmapCtx) {
-    throw new Error("Failed to get bitmap context");
-}
-
-const eventBuffer = new SharedArrayBuffer(512 * 1024);
-
-const { onTextInputEvent } = startEventSystemOnMainThread(eventBuffer);
-const textInput = new TextInput(onTextInputEvent);
-
-const wasmMemory = new WebAssembly.Memory({
-    initial: 128,
-    maximum: 16384,
-    shared: true,
-});
-
-const storageWorker = new StorageWorker();
-sendToWorker(storageWorker, {
-    type: "storage-init",
-    wasmMemory,
-});
-
-const mainWorker = new MainWorker();
-
-sendToWorker(mainWorker, {
-    type: "start-main-thread",
-    eventBuffer,
-    initialWindowWh: (window.innerWidth << 16) | window.innerHeight,
-    wasmMemory,
-});
-
-let webSocketHandle: ReturnType<typeof webSocketHandleOnMainThread>;
-const insertJsHandle = insertJsHandleOnMainThread();
-
-function onMessage(this: Worker, message: MessageEvent) {
-    const payload: WorkerMessagePayload = message.data;
-
-    switch (payload.type) {
-        case "thread-spawn": {
-            const threadWorker = new ThreadWorker();
-            threadWorker.onmessage = onMessage;
-            threadWorker.postMessage(payload);
-            break;
-        }
-        case "bitmap": {
-            bitmapCtx.transferFromImageBitmap(payload.bitmap);
-            break;
-        }
-        case "update-canvas-wh": {
-            if (canvas.width != payload.width) {
-                canvas.width = payload.width;
-            }
-            if (canvas.height != payload.height) {
-                canvas.height = payload.height;
-            }
-            break;
-        }
-        case "text-input-set-selection-range":
-        case "text-input-focus":
-        case "text-input-blur": {
-            textInput.onMessage(payload);
-            break;
-        }
-        // WebSocket
-        case "init-web-socket-thread": {
-            webSocketHandle = webSocketHandleOnMainThread(payload);
-            break;
-        }
-        case "new-web-socket": {
-            if (!webSocketHandle) {
-                throw new Error("WebSocket handle is not initialized");
-            }
-            webSocketHandle.onNewWebSocket(payload);
-            break;
-        }
-        case "web-socket-send": {
-            if (!webSocketHandle) {
-                throw new Error("WebSocket handle is not initialized");
-            }
-            webSocketHandle.send(payload);
-            break;
-        }
-        // Js Insert
-        case "insert-js": {
-            insertJsHandle.onInsertJs(payload);
-            break;
-        }
-        case "insert-js-drop": {
-            insertJsHandle.onInsertJsDrop(payload);
-            break;
-        }
-        // File System
-        case "storage-thread-connect": {
-            storageWorker.postMessage(payload);
-            break;
-        }
-        case "storage-thread-disconnect": {
-            storageWorker.postMessage(payload);
-            break;
-        }
-        default:
-            throw new Error(`Unexpected message type: ${payload.type}`);
+    const bitmapCtx = canvas.getContext("bitmaprenderer")!;
+    if (!bitmapCtx) {
+        throw new Error("Failed to get bitmap context");
     }
-}
 
-mainWorker.onmessage = onMessage;
+    const eventBuffer = new SharedArrayBuffer(512 * 1024);
 
-document.addEventListener("contextmenu", (e) => {
-    e.preventDefault();
-});
+    const { onTextInputEvent } = startEventSystemOnMainThread(eventBuffer);
+    const textInput = new TextInput(onTextInputEvent);
+
+    const wasmMemory = new WebAssembly.Memory({
+        initial: 128,
+        maximum: 16384,
+        shared: true,
+    });
+
+    const storageWorker = new StorageWorker();
+    sendToWorker(storageWorker, {
+        type: "storage-init",
+        wasmMemory,
+    });
+
+    const mainWorker = new MainWorker();
+    sendToWorker(mainWorker, {
+        type: "start-main-thread",
+        eventBuffer,
+        initialWindowWh: (window.innerWidth << 16) | window.innerHeight,
+        wasmMemory,
+    });
+
+    let webSocketHandle: ReturnType<typeof webSocketHandleOnMainThread>;
+    const insertJsHandle = insertJsHandleOnMainThread();
+    let newEventSystemHandle: NewEventSystemHandleOnMainThread;
+    let bufferPoolHandle: BufferPoolHandleOnMainThread;
+    const supportsRequestStreams = await isSupportsRequestStreams();
+    let httpFetchHandle: ReturnType<typeof httpFetchHandleOnMainThread>;
+
+    function onMessage(this: Worker, message: MessageEvent) {
+        const payload: WorkerMessagePayload = message.data;
+
+        switch (payload.type) {
+            case "thread-spawn": {
+                const threadWorker = new ThreadWorker();
+                threadWorker.onmessage = onMessage;
+                threadWorker.postMessage(payload);
+                break;
+            }
+            case "bitmap": {
+                bitmapCtx.transferFromImageBitmap(payload.bitmap);
+                break;
+            }
+            case "update-canvas-wh": {
+                if (canvas.width != payload.width) {
+                    canvas.width = payload.width;
+                }
+                if (canvas.height != payload.height) {
+                    canvas.height = payload.height;
+                }
+                break;
+            }
+            case "text-input-set-selection-range":
+            case "text-input-focus":
+            case "text-input-blur": {
+                textInput.onMessage(payload);
+                break;
+            }
+            // WebSocket
+            case "init-web-socket-thread": {
+                webSocketHandle = webSocketHandleOnMainThread(payload);
+                break;
+            }
+            case "new-web-socket": {
+                if (!webSocketHandle) {
+                    throw new Error("WebSocket handle is not initialized");
+                }
+                webSocketHandle.onNewWebSocket(payload);
+                break;
+            }
+            case "web-socket-send": {
+                if (!webSocketHandle) {
+                    throw new Error("WebSocket handle is not initialized");
+                }
+                webSocketHandle.send(payload);
+                break;
+            }
+            // Js Insert
+            case "insert-js": {
+                insertJsHandle.onInsertJs(payload);
+                break;
+            }
+            case "insert-js-drop": {
+                insertJsHandle.onInsertJsDrop(payload);
+                break;
+            }
+            // File System
+            case "storage-thread-connect": {
+                storageWorker.postMessage(payload);
+                break;
+            }
+            case "storage-thread-disconnect": {
+                storageWorker.postMessage(payload);
+                break;
+            }
+            // Http Fetch
+            case "new-http-fetch": {
+                httpFetchHandle.onNewHttpFetch(payload);
+                break;
+            }
+            case "http-fetch-set-header": {
+                httpFetchHandle.onHttpFetchSetHeader(payload);
+                break;
+            }
+            case "http-fetch-start": {
+                httpFetchHandle.onHttpFetchStart(payload);
+                break;
+            }
+            case "http-fetch-push-request-body-chunk": {
+                httpFetchHandle.onHttpFetchPushRequestBodyChunk(payload);
+                break;
+            }
+            case "http-fetch-finish-request-body-stream": {
+                httpFetchHandle.onHttpFetchFinishRequestBodyStream(payload);
+                break;
+            }
+            // Buffer Pool
+            case "buffer-pool-new-buffer": {
+                bufferPoolHandle.pushBuffer({
+                    ptr: payload.ptr,
+                    view: new Uint8Array(
+                        wasmMemory.buffer,
+                        payload.ptr,
+                        payload.len,
+                    ),
+                });
+                break;
+            }
+            case "http-fetch-error-on-rust-side": {
+                httpFetchHandle.onHttpFetchErrorOnRustSide(payload.fetchId);
+                break;
+            }
+            // New Event System
+            case "init-new-event-system-thread": {
+                newEventSystemHandle = new NewEventSystemHandleOnMainThread(
+                    payload,
+                );
+                bufferPoolHandle = new BufferPoolHandleOnMainThread(
+                    newEventSystemHandle,
+                );
+                httpFetchHandle = httpFetchHandleOnMainThread(
+                    supportsRequestStreams,
+                    newEventSystemHandle,
+                    bufferPoolHandle,
+                );
+                break;
+            }
+            default:
+                throw new Error(`Unexpected message type: ${payload.type}`);
+        }
+    }
+
+    mainWorker.onmessage = onMessage;
+
+    document.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+    });
+})();

--- a/namui/namui-cli/webCode/src/newEventSystem.ts
+++ b/namui/namui-cli/webCode/src/newEventSystem.ts
@@ -1,0 +1,152 @@
+import {
+    sendMessageToMainThread,
+    WorkerMessagePayload,
+} from "./interWorkerProtocol";
+import { RingBufferInputs, RingBufferWriter } from "./RingBufferWriter";
+
+// TODO: Move other event related code to this system.
+
+/*
+# eventBuffer protocol
+[message type: u8][message data: ...]
+*/
+
+type U8T<T extends number> = ["u8", T];
+// @ts-ignore unused
+type U8 = U8T<number>;
+type U16 = ["u16", number];
+type U32 = ["u32", number];
+type Bytes = ["bytes", Uint8Array];
+
+export type NewSystemEvent =
+    | {
+          type: "http-fetch/on-response";
+          fetchId: U32;
+          status: U16;
+          headerCount: U16;
+          headers: {
+              keyByteLength: U16;
+              key: Bytes;
+              valueByteLength: U16;
+              value: Bytes;
+          }[];
+      }
+    | {
+          type: "http-fetch/on-response-body-chunk";
+          fetchId: U32;
+          pooledBufferPtr: U32;
+          written: U32;
+      }
+    | {
+          type: "http-fetch/on-response-body-done";
+          fetchId: U32;
+      }
+    | {
+          type: "http-fetch/on-error";
+          fetchId: U32;
+          messageByteLength: U32;
+          message: Bytes;
+      }
+    | {
+          type: "buffer-pool/request-buffer";
+      };
+
+export function newEventSystemImports({
+    memory,
+}: {
+    memory: WebAssembly.Memory;
+}) {
+    const writtenBuffer = new SharedArrayBuffer(4);
+
+    return {
+        _new_event_system_init_thread: (
+            eventBufferPtr: number,
+            eventBufferLen: number,
+        ) => {
+            if (!(memory.buffer instanceof SharedArrayBuffer)) {
+                throw new Error("memory.buffer must be SharedArrayBuffer");
+            }
+
+            sendMessageToMainThread({
+                type: "init-new-event-system-thread",
+                wasmMemory: memory,
+                writtenBuffer,
+                eventBufferPtr,
+                eventBufferLen,
+            });
+        },
+        _new_event_system_event_poll: (): number => {
+            Atomics.wait(new Int32Array(writtenBuffer), 0, 0);
+            return Atomics.load(new Int32Array(writtenBuffer), 0);
+        },
+        _new_event_system_event_commit: (len: number) => {
+            Atomics.sub(new Int32Array(writtenBuffer), 0, len);
+        },
+    };
+}
+
+export class NewEventSystemHandleOnMainThread {
+    private readonly ringBuffer: RingBufferWriter;
+
+    constructor({
+        wasmMemory,
+        eventBufferPtr,
+        eventBufferLen,
+        writtenBuffer,
+    }: WorkerMessagePayload & {
+        type: "init-new-event-system-thread";
+    }) {
+        this.ringBuffer = new RingBufferWriter(
+            wasmMemory.buffer,
+            eventBufferPtr,
+            eventBufferLen,
+            writtenBuffer,
+        );
+    }
+
+    public sendEvent(event: NewSystemEvent) {
+        const input: RingBufferInputs = [];
+        switch (event.type) {
+            case "http-fetch/on-response": {
+                input.push(["u8", 1]);
+                input.push(event.fetchId);
+                input.push(event.status);
+                input.push(event.headerCount);
+                for (const header of event.headers) {
+                    input.push(header.keyByteLength);
+                    input.push(header.key);
+                    input.push(header.valueByteLength);
+                    input.push(header.value);
+                }
+                break;
+            }
+            case "http-fetch/on-response-body-chunk": {
+                input.push(["u8", 2]);
+                input.push(event.fetchId);
+                input.push(event.pooledBufferPtr);
+                input.push(event.written);
+                break;
+            }
+            case "http-fetch/on-response-body-done": {
+                input.push(["u8", 3]);
+                input.push(event.fetchId);
+                break;
+            }
+            case "http-fetch/on-error": {
+                input.push(["u8", 4]);
+                input.push(event.fetchId);
+                input.push(event.messageByteLength);
+                input.push(event.message);
+                break;
+            }
+            case "buffer-pool/request-buffer": {
+                input.push(["u8", 5]);
+                break;
+            }
+            default: {
+                throw new Error(`Unknown event! ${JSON.stringify(event)}`);
+            }
+        }
+        this.ringBuffer.write(...input);
+    }
+}

--- a/namui/namui-cli/webCode/tsconfig.json
+++ b/namui/namui-cli/webCode/tsconfig.json
@@ -10,7 +10,7 @@
       "Webworker.Iterable",
       "ESNext.AsyncIterable",
       "DOM.Iterable",
-      "dom.asynciterable"
+      "DOM.AsyncIterable"
     ],
     "skipLibCheck": true,
 

--- a/namui/namui/Cargo.lock
+++ b/namui/namui/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -611,15 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,12 +637,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ffmpeg-next"
@@ -714,21 +699,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -741,12 +717,6 @@ dependencies = [
  "quote",
  "syn 2.0.75",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -895,9 +865,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -907,7 +877,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.39.3",
+ "tokio 1.40.0",
  "tokio-util",
  "tracing",
 ]
@@ -1046,23 +1016,25 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "smallvec",
- "tokio 1.39.3",
+ "tokio 1.40.0",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
+name = "hyper-rustls"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
- "bytes",
- "http-body-util",
+ "futures-util",
+ "http",
  "hyper",
  "hyper-util",
- "native-tls",
- "tokio 1.39.3",
- "tokio-native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio 1.40.0",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1080,7 +1052,7 @@ dependencies = [
  "hyper",
  "pin-project-lite",
  "socket2",
- "tokio 1.39.3",
+ "tokio 1.40.0",
  "tower",
  "tower-service",
  "tracing",
@@ -1116,12 +1088,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -1294,12 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,10 +1291,17 @@ name = "namui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "dashmap",
  "ffmpeg-next",
  "float-cmp",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "lazy_static",
  "namui-cfg",
  "namui-drawer",
@@ -1346,7 +1313,6 @@ dependencies = [
  "percent-encoding",
  "rand",
  "rayon",
- "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1431,23 +1397,6 @@ dependencies = [
  "directories",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1653,48 +1602,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.75",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orbclient"
@@ -2032,39 +1943,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.4"
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "ipnet",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio 1.39.3",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "winreg",
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2152,6 +2042,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2083,17 @@ name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "ryu"
@@ -2289,18 +2217,6 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 
@@ -2438,6 +2354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,33 +2382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,19 +2396,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
-dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2600,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2623,13 +2505,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "native-tls",
- "tokio 1.39.3",
+ "rustls",
+ "rustls-pki-types",
+ "tokio 1.40.0",
 ]
 
 [[package]]
@@ -2642,7 +2525,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio 1.39.3",
+ "tokio 1.40.0",
 ]
 
 [[package]]
@@ -2700,7 +2583,7 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio 1.39.3",
+ "tokio 1.40.0",
  "tower-layer",
  "tower-service",
 ]
@@ -2786,6 +2669,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3493,16 +3382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,3 +3478,9 @@ dependencies = [
  "quote",
  "syn 2.0.75",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/namui/namui/Cargo.toml
+++ b/namui/namui/Cargo.toml
@@ -33,13 +33,25 @@ tokio = { path = "../third-party-forks/tokio/tokio", features = [
     "rt-multi-thread",
     "fs",
 ] }
-reqwest = { path = "../third-party-forks/reqwest", features = ["stream"] }
 rusqlite = { path = "../third-party-forks/rusqlite", features = ["bundled"] }
 rayon = "1.10.0"
+http = "1.1.0"
+http-body = "1.0.1"
+bytes = "1.7.1"
+hyper = "1.4.1"
+http-body-util = "0.1.2"
 
 [target.'cfg(not(target_os="wasi"))'.dependencies]
+hyper-rustls = { version = "0.27.2", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 winit = "0.29.4"
 opener = "0.7.1"
+hyper-util = { version = "0.1.7", features = ["client", "http1", "http2"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 wasapi = "0.14.0"

--- a/namui/namui/src/lib.rs
+++ b/namui/namui/src/lib.rs
@@ -21,7 +21,6 @@ pub use namui_skia::*;
 pub use namui_type as types;
 pub use namui_type::*;
 pub use render::*;
-pub use reqwest;
 pub use serde;
 pub use shader_macro::shader;
 #[cfg(target_os = "windows")]
@@ -29,6 +28,7 @@ pub use system::media::*;
 pub use system::*;
 pub use tokio;
 pub use tokio::task::{spawn, spawn_local};
+pub use system::network::http::{RequestExt, ResponseExt};
 
 pub fn start(component: impl 'static + Fn(&RenderCtx) + Send) {
     namui_type::set_log(|x| log::log(x));

--- a/namui/namui/src/system/mod.rs
+++ b/namui/namui/src/system/mod.rs
@@ -29,6 +29,9 @@ type InitResult = Result<()>;
 static SYSTEM_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub(super) async fn init_system() -> InitResult {
+    #[cfg(target_os = "wasi")]
+    wasi::init().await?;
+
     futures::try_join!(
         cache::init(),
         file::init(),

--- a/namui/namui/src/system/network/http/non_wasi.rs
+++ b/namui/namui/src/system/network/http/non_wasi.rs
@@ -1,0 +1,66 @@
+use super::{HttpError, ResponseBody};
+use futures::StreamExt;
+use http::{Request, Response};
+use hyper_rustls::HttpsConnector;
+use hyper_util::{
+    client::legacy::{connect::HttpConnector, Client},
+    rt::TokioExecutor,
+};
+use std::sync::OnceLock;
+
+pub(crate) async fn send<ReqBody, ReqBodyErr>(
+    request: Request<ReqBody>,
+) -> std::result::Result<Response<impl ResponseBody>, HttpError>
+where
+    ReqBody: http_body::Body<Data = bytes::Bytes, Error = ReqBodyErr>
+        + Send
+        + std::marker::Unpin
+        + 'static,
+    ReqBodyErr: std::error::Error + Send + Sync + 'static,
+{
+    let http_connector = {
+        static HTTP_CONNECTOR: OnceLock<HttpsConnector<HttpConnector>> = OnceLock::new();
+        HTTP_CONNECTOR
+            .get_or_init(|| {
+                hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_native_roots()
+                    .expect("failed to load native roots")
+                    .https_or_http()
+                    .enable_all_versions()
+                    .build()
+            })
+            .clone()
+    };
+
+    let client = Client::builder(TokioExecutor::new()).build(http_connector);
+
+    let response: Response<hyper::body::Incoming> = client
+        .request(request)
+        .await
+        .map_err(|error| HttpError::Unknown(error.to_string()))?;
+
+    Ok(response.map(http_body_util::BodyStream::new))
+}
+
+impl ResponseBody for http_body_util::BodyStream<hyper::body::Incoming> {
+    async fn bytes(
+        mut self,
+        content_length: Option<usize>,
+    ) -> std::result::Result<Vec<u8>, HttpError> {
+        if let Some(content_length) = content_length {
+            let mut bytes = Vec::with_capacity(content_length);
+            while let Some(frame) = self.next().await {
+                let frame = frame?;
+                bytes.extend_from_slice(frame.into_data().unwrap().as_ref());
+            }
+            Ok(bytes)
+        } else {
+            let mut bytes = Vec::new();
+            while let Some(frame) = self.next().await {
+                let frame = frame?;
+                bytes.extend_from_slice(frame.into_data().unwrap().as_ref());
+            }
+            Ok(bytes)
+        }
+    }
+}

--- a/namui/namui/src/system/network/http/wasi.rs
+++ b/namui/namui/src/system/network/http/wasi.rs
@@ -1,0 +1,242 @@
+use super::{HttpError, ResponseBody};
+use anyhow::Result;
+use bytes::Bytes;
+use dashmap::DashMap;
+use futures::StreamExt;
+use http::{HeaderName, HeaderValue, Request, Response, StatusCode};
+use std::{str::FromStr, sync::OnceLock};
+use tokio::sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender},
+    oneshot,
+};
+
+pub(crate) async fn send<ReqBody, ReqBodyErr>(
+    request: Request<ReqBody>,
+) -> std::result::Result<Response<impl ResponseBody>, HttpError>
+where
+    ReqBody: http_body::Body<Data = bytes::Bytes, Error = ReqBodyErr>
+        + Send
+        + std::marker::Unpin
+        + 'static,
+    ReqBodyErr: std::error::Error + Send + Sync + 'static,
+{
+    let (parts, body) = request.into_parts();
+
+    let fetch_id = unsafe {
+        let uri = parts.uri.to_string();
+        let uri = uri.as_bytes();
+        let method = parts.method.as_str().as_bytes();
+        _http_fetch_init(uri.as_ptr(), uri.len(), method.as_ptr(), method.len())
+    };
+
+    for key in parts.headers.keys() {
+        let values = parts.headers.get_all(key);
+        let value_string = values
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<&str>>()
+            .join(", ");
+
+        unsafe {
+            let key_bytes = key.as_str().as_bytes();
+            let value_bytes = value_string.as_bytes();
+            _http_fetch_set_header(
+                fetch_id,
+                key_bytes.as_ptr(),
+                key_bytes.len(),
+                value_bytes.as_ptr(),
+                value_bytes.len(),
+            );
+        }
+    }
+
+    unsafe { _http_fetch_start(fetch_id) }
+
+    let (error_from_js_tx, mut error_from_js_rx) = oneshot::channel::<String>();
+
+    error_from_js_txs().insert(fetch_id, error_from_js_tx);
+
+    // TODO: send body in same time with receiving response
+    let mut body_stream = http_body_util::BodyStream::new(body);
+
+    loop {
+        tokio::select! {
+            error_from_js = &mut error_from_js_rx => {
+                error_from_js_txs().remove(&fetch_id);
+                return Err(HttpError::Unknown(error_from_js.unwrap()));
+            },
+            frame = body_stream.next() => {
+                let frame = match frame {
+                    None => break,
+                    Some(Ok(frame)) => frame,
+                    Some(Err(error)) => {
+                        return Err(HttpError::ReqBodyErr(Box::new(error)));
+                    },
+                };
+                let data = frame.into_data().unwrap();
+                unsafe {
+                    _http_fetch_push_request_body_chunk(fetch_id, data.as_ptr(), data.len());
+                }
+            }
+        }
+    }
+
+    unsafe {
+        _http_fetch_finish_request_body_stream(fetch_id);
+    }
+
+    let (response_sender, response_receiver) = oneshot::channel();
+    RESPONSE_WAITERS
+        .get_or_init(Default::default)
+        .insert(fetch_id, response_sender);
+
+    tokio::select! {
+        error_from_js = error_from_js_rx => {
+            response_waiters().remove(&fetch_id);
+            error_from_js_txs().remove(&fetch_id);
+            Err(HttpError::Unknown(error_from_js.unwrap()))
+        },
+        response = response_receiver => {
+            response_waiters().remove(&fetch_id);
+            error_from_js_txs().remove(&fetch_id);
+            response.unwrap()
+        },
+    }
+}
+
+extern "C" {
+    fn _http_fetch_init(
+        url_ptr: *const u8,
+        url_len: usize,
+        method_ptr: *const u8,
+        method_len: usize,
+    ) -> u32;
+    fn _http_fetch_set_header(
+        fetch_id: u32,
+        key_ptr: *const u8,
+        key_len: usize,
+        value_ptr: *const u8,
+        value_len: usize,
+    );
+    fn _http_fetch_start(fetch_id: u32);
+    fn _http_fetch_push_request_body_chunk(fetch_id: u32, data_ptr: *const u8, data_len: usize);
+    fn _http_fetch_finish_request_body_stream(fetch_id: u32);
+    fn _http_fetch_error_on_rust_side(fetch_id: u32);
+}
+
+type ResBodyChunk = Result<Bytes, HttpError>;
+static RES_BODY_TXS: OnceLock<DashMap<u32, UnboundedSender<ResBodyChunk>>> = OnceLock::new();
+fn res_body_txs() -> &'static DashMap<u32, UnboundedSender<ResBodyChunk>> {
+    RES_BODY_TXS.get_or_init(Default::default)
+}
+
+type ResponseMakingResult = Result<Response<ResBody>, HttpError>;
+static RESPONSE_WAITERS: OnceLock<DashMap<u32, oneshot::Sender<ResponseMakingResult>>> =
+    OnceLock::new();
+fn response_waiters() -> &'static DashMap<u32, oneshot::Sender<ResponseMakingResult>> {
+    RESPONSE_WAITERS.get_or_init(Default::default)
+}
+
+static ERROR_FROM_JS_TXS: OnceLock<DashMap<u32, oneshot::Sender<String>>> = OnceLock::new();
+fn error_from_js_txs() -> &'static DashMap<u32, oneshot::Sender<String>> {
+    ERROR_FROM_JS_TXS.get_or_init(Default::default)
+}
+
+struct ResBody {
+    fetch_id: u32,
+    rx: UnboundedReceiver<ResBodyChunk>,
+}
+
+impl Drop for ResBody {
+    fn drop(&mut self) {
+        res_body_txs().remove(&self.fetch_id);
+    }
+}
+
+impl ResponseBody for ResBody {
+    async fn bytes(
+        mut self,
+        content_length: Option<usize>,
+    ) -> std::result::Result<Vec<u8>, HttpError> {
+        if let Some(content_length) = content_length {
+            let mut bytes = Vec::with_capacity(content_length);
+            while bytes.len() < content_length {
+                let chunk = self.rx.recv().await.ok_or(HttpError::Disconnected)??;
+                bytes.extend_from_slice(&chunk);
+            }
+            if bytes.len() > content_length {
+                unsafe {
+                    _http_fetch_error_on_rust_side(self.fetch_id);
+                }
+                res_body_txs().remove(&self.fetch_id);
+                return Err(HttpError::TooManyBytes);
+            }
+            Ok(bytes)
+        } else {
+            let mut bytes = Vec::new();
+            while let Some(chunk) = self.rx.recv().await {
+                bytes.extend_from_slice(&chunk?);
+            }
+            Ok(bytes)
+        }
+    }
+}
+
+pub(crate) fn http_fetch_on_response(fetch_id: u32, status: u16, headers: Vec<(String, String)>) {
+    let (_, response_sender) = response_waiters().remove(&fetch_id).unwrap();
+
+    let response = 'outer: {
+        let status_code = match StatusCode::from_u16(status) {
+            Ok(status_code) => status_code,
+            Err(error) => break 'outer Err(HttpError::HttpError(error.into())),
+        };
+        let mut builder = Response::builder().status(status_code);
+
+        let headers_mut = builder.headers_mut().unwrap();
+        for (key, value) in headers {
+            let header_name = match HeaderName::from_str(&key) {
+                Ok(header_name) => header_name,
+                Err(error) => break 'outer Err(HttpError::HttpError(error.into())),
+            };
+            let header_value = match HeaderValue::from_str(&value) {
+                Ok(header_value) => header_value,
+                Err(error) => break 'outer Err(HttpError::HttpError(error.into())),
+            };
+            headers_mut.insert(header_name, header_value);
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        res_body_txs().insert(fetch_id, tx);
+
+        let response = match builder.body(ResBody { fetch_id, rx }) {
+            Ok(response) => response,
+            Err(error) => break 'outer Err(HttpError::HttpError(error)),
+        };
+
+        Ok(response)
+    };
+
+    let _ = response_sender.send(response);
+}
+
+pub(crate) fn http_fetch_on_response_body_chunk(fetch_id: u32, data: Bytes) {
+    let Some(tx) = res_body_txs().get(&fetch_id) else {
+        return;
+    };
+    let _ = tx.send(Ok(data));
+}
+
+pub(crate) fn http_fetch_on_response_body_done(fetch_id: u32) {
+    let _ = res_body_txs().remove(&fetch_id);
+}
+
+pub(crate) fn http_fetch_on_error(fetch_id: u32, message: String) {
+    eprintln!("http_fetch_on_error: {}", message);
+    if let Some((_, tx)) = error_from_js_txs().remove(&fetch_id) {
+        let _ = tx.send(message.clone());
+    };
+
+    if let Some((_, res_body_tx)) = res_body_txs().remove(&fetch_id) {
+        let _ = res_body_tx.send(Err(HttpError::Unknown(message)));
+    }
+}

--- a/namui/namui/src/system/skia/mod.rs
+++ b/namui/namui/src/system/skia/mod.rs
@@ -9,7 +9,7 @@ use wasi as inner;
 use winit as inner;
 
 use super::InitResult;
-use crate::ResourceLocation;
+use crate::*;
 use anyhow::{anyhow, Result};
 use namui_skia::*;
 use namui_type::*;
@@ -57,7 +57,14 @@ pub async fn load_image_from_resource_location(
             load_image_from_bytes(bytes.as_ref()).await
         }
         ResourceLocation::Network(url) => {
-            let bytes = crate::system::network::http::get_bytes(url.as_ref()).await?;
+            use crate::system::network::http;
+            let bytes = http::Request::get(url.to_string())
+                .body(())?
+                .send()
+                .await?
+                .ensure_status_code()?
+                .bytes()
+                .await?;
             load_image_from_bytes(bytes.as_ref()).await
         }
     }

--- a/namui/namui/src/system/wasi/buffer_pool.rs
+++ b/namui/namui/src/system/wasi/buffer_pool.rs
@@ -1,0 +1,30 @@
+use bytes::Bytes;
+use dashmap::DashMap;
+use std::sync::OnceLock;
+
+static SENT_TO_JS: OnceLock<DashMap<usize, Bytes>> = OnceLock::new();
+
+const K32: usize = 32 * 1024;
+
+pub(crate) fn send_new_buffer_to_js() {
+    let bytes = Bytes::from(vec![0; K32]);
+
+    let ptr = bytes.as_ptr() as usize;
+    SENT_TO_JS
+        .get_or_init(Default::default)
+        .insert(ptr, bytes.clone());
+
+    unsafe {
+        _buffer_pool_new_buffer(ptr as *const u8, bytes.len());
+    }
+}
+
+pub(crate) fn take_buffer_from_js(ptr: *const u8) -> Bytes {
+    SENT_TO_JS.get().unwrap().remove(&(ptr as usize)).unwrap().1
+}
+
+// # data callback protocol
+// [data byte length: u16][message data: ...]
+extern "C" {
+    fn _buffer_pool_new_buffer(buffer_ptr: *const u8, buffer_len: usize);
+}

--- a/namui/namui/src/system/wasi/insert_js.rs
+++ b/namui/namui/src/system/wasi/insert_js.rs
@@ -1,0 +1,87 @@
+use namui_type::RingBuffer;
+use std::sync::{atomic::AtomicBool, Arc};
+
+/// Insert JavaScript code into the WASI runtime.
+///
+/// You should keep returned JsHandle to keep running the JavaScript code.
+///
+/// ### Special function on js
+/// - `namui_sendData(data: ArrayBuffer)`
+///     - Send data to the WASI runtime.
+///     - CAUTION: data must not be TypedArray. It must be ArrayBuffer.
+///     - example) `const buffer = new Uint8Array(...); namui_sendData(buffer.buffer);`
+/// - `namui_onDrop()`
+///    - Called when the handle is dropped. You might implement cleanup logic here.
+///    - example) `const namui_onDrop = () => { ...remove event listener... }`
+pub async fn insert_js<OnData: FnMut(&[u8]) + 'static + Send>(
+    js: impl ToString,
+    on_data: Option<OnData>,
+) -> JsHandle {
+    let js = js.to_string();
+    let dropped = Arc::new(AtomicBool::new(false));
+
+    let Some(mut on_data) = on_data else {
+        return JsHandle::WithoutOnData {
+            id: tokio::task::spawn_blocking(move || unsafe { _insert_js(js.as_ptr(), js.len()) })
+                .await
+                .unwrap(),
+        };
+    };
+
+    std::thread::spawn({
+        let dropped = dropped.clone();
+        move || {
+            let mut buffer = RingBuffer::new(1024 * 1024);
+
+            let id = unsafe {
+                _insert_js_with_data_callback(js.as_ptr(), js.len(), buffer.ptr(), buffer.size())
+            };
+
+            while !dropped.load(std::sync::atomic::Ordering::Relaxed) {
+                if unsafe { _insert_js_data_poll(33) } == 0 {
+                    continue;
+                }
+                let data_byte_length = buffer.read_u16() as usize;
+                let data = buffer.read_bytes(data_byte_length);
+                on_data(&data);
+                unsafe { _insert_js_data_commit(buffer.take_read_count()) }
+            }
+
+            unsafe { _insert_js_drop(id) }
+        }
+    });
+    JsHandle::WithOnData { dropped }
+}
+
+pub enum JsHandle {
+    WithoutOnData { id: u32 },
+    WithOnData { dropped: Arc<AtomicBool> },
+}
+
+impl Drop for JsHandle {
+    fn drop(&mut self) {
+        match self {
+            JsHandle::WithoutOnData { id } => {
+                unsafe { _insert_js_drop(*id) };
+            }
+            JsHandle::WithOnData { dropped } => {
+                dropped.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+// # data callback protocol
+// [data byte length: u16][message data: ...]
+extern "C" {
+    fn _insert_js(js_ptr: *const u8, js_len: usize) -> u32;
+    fn _insert_js_with_data_callback(
+        js_ptr: *const u8,
+        js_len: usize,
+        ring_buffer_ptr: *const u8,
+        ring_buffer_len: usize,
+    ) -> u32;
+    fn _insert_js_drop(js_id: u32);
+    fn _insert_js_data_poll(timeout_ms: u32) -> u32;
+    fn _insert_js_data_commit(byte_length: usize);
+}

--- a/namui/namui/src/system/wasi/mod.rs
+++ b/namui/namui/src/system/wasi/mod.rs
@@ -1,92 +1,20 @@
-use namui_type::RingBuffer;
-use std::sync::{atomic::AtomicBool, Arc};
+mod buffer_pool;
+mod insert_js;
+pub(crate) mod new_event_system;
 
-/// Insert JavaScript code into the WASI runtime.
-///
-/// You should keep returned JsHandle to keep running the JavaScript code.
-///
-/// ### Special function on js
-/// - `namui_sendData(data: ArrayBuffer)`
-///     - Send data to the WASI runtime.
-///     - CAUTION: data must not be TypedArray. It must be ArrayBuffer.
-///     - example) `const buffer = new Uint8Array(...); namui_sendData(buffer.buffer);`
-/// - `namui_onDrop()`
-///    - Called when the handle is dropped. You might implement cleanup logic here.
-///    - example) `const namui_onDrop = () => { ...remove event listener... }`
-pub async fn insert_js<OnData: FnMut(&[u8]) + 'static + Send>(
-    js: impl ToString,
-    on_data: Option<OnData>,
-) -> JsHandle {
-    let js = js.to_string();
-    let dropped = Arc::new(AtomicBool::new(false));
+use super::InitResult;
+pub use insert_js::*;
 
-    let Some(mut on_data) = on_data else {
-        return JsHandle::WithoutOnData {
-            id: tokio::task::spawn_blocking(move || unsafe { _insert_js(js.as_ptr(), js.len()) })
-                .await
-                .unwrap(),
-        };
-    };
+pub(crate) async fn init() -> InitResult {
+    new_event_system::init().await?;
 
-    std::thread::spawn({
-        let dropped = dropped.clone();
-        move || {
-            let mut buffer = RingBuffer::new(1024 * 1024);
-
-            let id = unsafe {
-                _insert_js_with_data_callback(js.as_ptr(), js.len(), buffer.ptr(), buffer.size())
-            };
-
-            while !dropped.load(std::sync::atomic::Ordering::Relaxed) {
-                if unsafe { _insert_js_data_poll(33) } == 0 {
-                    continue;
-                }
-                let data_byte_length = buffer.read_u16() as usize;
-                let data = buffer.read_bytes(data_byte_length);
-                on_data(&data);
-                unsafe { _insert_js_data_commit(buffer.take_read_count()) }
-            }
-
-            unsafe { _insert_js_drop(id) }
-        }
-    });
-    JsHandle::WithOnData { dropped }
-}
-
-pub enum JsHandle {
-    WithoutOnData { id: u32 },
-    WithOnData { dropped: Arc<AtomicBool> },
-}
-
-impl Drop for JsHandle {
-    fn drop(&mut self) {
-        match self {
-            JsHandle::WithoutOnData { id } => {
-                unsafe { _insert_js_drop(*id) };
-            }
-            JsHandle::WithOnData { dropped } => {
-                dropped.store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-        }
-    }
+    Ok(())
 }
 
 pub(crate) fn hardware_concurrency() -> u32 {
     unsafe { _hardware_concurrency() }
 }
 
-// # data callback protocol
-// [data byte length: u16][message data: ...]
 extern "C" {
-    fn _insert_js(js_ptr: *const u8, js_len: usize) -> u32;
-    fn _insert_js_with_data_callback(
-        js_ptr: *const u8,
-        js_len: usize,
-        ring_buffer_ptr: *const u8,
-        ring_buffer_len: usize,
-    ) -> u32;
-    fn _insert_js_drop(js_id: u32);
-    fn _insert_js_data_poll(timeout_ms: u32) -> u32;
-    fn _insert_js_data_commit(byte_length: usize);
     fn _hardware_concurrency() -> u32;
 }

--- a/namui/namui/src/system/wasi/new_event_system/event.rs
+++ b/namui/namui/src/system/wasi/new_event_system/event.rs
@@ -1,0 +1,105 @@
+pub(crate) enum Event {
+    HttpFetchOnResponse {
+        fetch_id: u32,
+        status: u16,
+        headers: Vec<(String, String)>,
+    },
+    HttpFetchOnResponseBodyChunk {
+        fetch_id: u32,
+        pooled_buffer_ptr: u32,
+        written: u32,
+    },
+    HttpFetchOnResponseBodyDone {
+        fetch_id: u32,
+    },
+    HttpFetchOnError {
+        fetch_id: u32,
+        message: String,
+    },
+    BufferPoolRequestBuffer,
+}
+
+// export type NewSystemEvent =
+//     | {
+//           type: "http-fetch/on-response";
+//           fetchId: U32;
+//           status: U16;
+//           headerCount: U16;
+//           headers: {
+//               keyByteLength: U16;
+//               key: Bytes;
+//               valueByteLength: U16;
+//               value: Bytes;
+//           }[];
+//       }
+//     | {
+//           type: "http-fetch/on-response-body-chunk";
+//           fetchId: U32;
+//           pooledBufferPtr: U32;
+//           written: U32;
+//       }
+//     | {
+//           type: "http-fetch/on-response-body-done";
+//           fetchId: U32;
+//       }
+//     | {
+//           type: "http-fetch/on-error";
+//           fetchId: U32;
+//           messageByteLength: U32;
+//           message: Bytes;
+//       }
+//     | {
+//           type: "buffer-pool/request-buffer";
+//       };
+
+pub(crate) fn read(event_buffer: &mut namui_type::RingBuffer) -> Event {
+    let message_type = event_buffer.read_u8();
+    match message_type {
+        1 => {
+            let fetch_id = event_buffer.read_u32();
+            let status = event_buffer.read_u16();
+            let header_count = event_buffer.read_u16();
+
+            let mut headers = Vec::with_capacity(header_count as usize);
+            for _ in 0..header_count {
+                let key_length = event_buffer.read_u16() as usize;
+                let key_bytes = event_buffer.read_bytes(key_length);
+                let key = std::str::from_utf8(&key_bytes).unwrap().to_string();
+
+                let value_length = event_buffer.read_u16() as usize;
+                let value_bytes = event_buffer.read_bytes(value_length);
+                let value = std::str::from_utf8(&value_bytes).unwrap().to_string();
+
+                headers.push((key, value));
+            }
+            Event::HttpFetchOnResponse {
+                fetch_id,
+                status,
+                headers,
+            }
+        }
+        2 => {
+            let fetch_id = event_buffer.read_u32();
+            let pooled_buffer_ptr = event_buffer.read_u32();
+            let written = event_buffer.read_u32();
+            Event::HttpFetchOnResponseBodyChunk {
+                fetch_id,
+                pooled_buffer_ptr,
+                written,
+            }
+        }
+        3 => {
+            let fetch_id = event_buffer.read_u32();
+            Event::HttpFetchOnResponseBodyDone { fetch_id }
+        }
+        4 => {
+            let fetch_id = event_buffer.read_u32();
+            let message_length = event_buffer.read_u32() as usize;
+            let message_bytes = event_buffer.read_bytes(message_length);
+            let message = std::str::from_utf8(&message_bytes).unwrap().to_string();
+            Event::HttpFetchOnError { fetch_id, message }
+        }
+        5 => Event::BufferPoolRequestBuffer,
+        _ => unreachable!(),
+    }
+}

--- a/namui/namui/src/system/wasi/new_event_system/mod.rs
+++ b/namui/namui/src/system/wasi/new_event_system/mod.rs
@@ -1,0 +1,72 @@
+mod event;
+
+use crate::system::InitResult;
+use namui_type::RingBuffer;
+
+// TODO: Move other event related code to this system.
+
+pub(crate) async fn init() -> InitResult {
+    spawn_thread();
+    Ok(())
+}
+
+// # data callback protocol
+// [data byte length: u16][message data: ...]
+extern "C" {
+    fn _new_event_system_init_thread(event_buffer_ptr: *const u8, event_buffer_len: usize);
+    fn _new_event_system_event_poll() -> usize;
+    fn _new_event_system_event_commit(byte_length: usize);
+}
+
+fn spawn_thread() {
+    std::thread::spawn({
+        move || {
+            let mut event_buffer = RingBuffer::new(4 * 1024 * 1024);
+
+            unsafe {
+                _new_event_system_init_thread(event_buffer.ptr(), event_buffer.size());
+            }
+
+            loop {
+                assert_ne!(unsafe { _new_event_system_event_poll() }, 0);
+
+                let event = event::read(&mut event_buffer);
+                unsafe { _new_event_system_event_commit(event_buffer.take_read_count()) };
+
+                match event {
+                    event::Event::HttpFetchOnResponse {
+                        fetch_id,
+                        status,
+                        headers,
+                    } => crate::system::network::http::wasi::http_fetch_on_response(
+                        fetch_id, status, headers,
+                    ),
+                    event::Event::HttpFetchOnResponseBodyChunk {
+                        fetch_id,
+                        pooled_buffer_ptr,
+                        written,
+                    } => {
+                        let bytes = crate::system::wasi::buffer_pool::take_buffer_from_js(
+                            pooled_buffer_ptr as *const u8,
+                        )
+                        .slice(..written as usize);
+                        crate::system::network::http::wasi::http_fetch_on_response_body_chunk(
+                            fetch_id, bytes,
+                        );
+                    }
+                    event::Event::HttpFetchOnResponseBodyDone { fetch_id } => {
+                        crate::system::network::http::wasi::http_fetch_on_response_body_done(
+                            fetch_id,
+                        );
+                    }
+                    event::Event::HttpFetchOnError { fetch_id, message } => {
+                        crate::system::network::http::wasi::http_fetch_on_error(fetch_id, message);
+                    }
+                    event::Event::BufferPoolRequestBuffer => {
+                        crate::system::wasi::buffer_pool::send_new_buffer_to_js();
+                    }
+                }
+            }
+        }
+    });
+}

--- a/namui/sample/http/.gitignore
+++ b/namui/sample/http/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+bin/
+pkg/
+wasm-pack.log
+.vscode/

--- a/namui/sample/http/Cargo.lock
+++ b/namui/sample/http/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.28"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb"
+checksum = "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -20,9 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -35,9 +35,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -59,27 +59,27 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-activity"
-version = "0.5.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
+checksum = "052ad56e336bcc615a214bffbeca6c181ee9550acec193f0327e0b103b033a4d"
 dependencies = [
  "android-properties",
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "cc",
  "cesu8",
  "jni",
@@ -101,24 +101,24 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -128,9 +128,9 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "atomic-polyfill"
-version = "1.0.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
@@ -149,15 +149,15 @@ checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -200,7 +200,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -213,7 +213,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.31",
  "which",
 ]
 
@@ -225,9 +225,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "block-sys"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
+checksum = "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92"
 dependencies = [
  "objc-sys",
 ]
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
@@ -301,15 +301,15 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -319,11 +319,11 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+checksum = "7b50b5a44d59a98c55a9eeb518f39bf7499ba19fd98ee7d22618687f3f10adbf"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "log",
  "polling",
  "rustix",
@@ -345,13 +345,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
- "shlex",
+ "once_cell",
 ]
 
 [[package]]
@@ -383,13 +383,13 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -400,9 +400,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
@@ -410,18 +410,18 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -429,15 +429,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
-version = "0.23.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -510,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -544,7 +544,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -579,20 +579,20 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.8.1",
 ]
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elsa"
@@ -605,12 +605,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,9 +612,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -662,21 +656,21 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox 0.1.3",
- "windows-sys 0.59.0",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -706,7 +700,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -717,9 +711,9 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -732,9 +726,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -763,9 +757,9 @@ checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -786,7 +780,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -821,19 +815,19 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.4.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
 dependencies = [
  "libc",
- "windows-targets 0.48.5",
+ "winapi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -844,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -868,7 +862,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.39.3",
+ "tokio 1.37.0",
  "tokio-util",
  "tracing",
 ]
@@ -888,16 +882,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
+ "ahash 0.7.6",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.6",
  "allocator-api2",
 ]
 
@@ -907,14 +901,14 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -932,15 +926,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "home"
@@ -986,10 +977,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-sample"
+version = "0.1.0"
+dependencies = [
+ "namui",
+ "namui-prebuilt",
+]
+
+[[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "hyper"
@@ -1007,7 +1006,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "smallvec",
- "tokio 1.39.3",
+ "tokio 1.37.0",
  "want",
 ]
 
@@ -1024,7 +1023,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "tokio 1.39.3",
+ "tokio 1.37.0",
  "tokio-rustls",
  "tower-service",
 ]
@@ -1043,7 +1042,7 @@ dependencies = [
  "hyper",
  "pin-project-lite",
  "socket2",
- "tokio 1.39.3",
+ "tokio 1.37.0",
  "tower",
  "tower-service",
  "tracing",
@@ -1062,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1072,12 +1071,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1091,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jni"
@@ -1119,27 +1118,27 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
@@ -1149,9 +1148,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.157"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374af5f94e54fa97cf75e945cce8a6b201e88a1a07e688b47dfd2a59c66dbd86"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libdbus-sys"
@@ -1165,12 +1164,22 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1179,20 +1188,9 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "libc",
  "redox_syscall 0.4.1",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "redox_syscall 0.5.3",
 ]
 
 [[package]]
@@ -1206,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -1222,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
@@ -1232,22 +1230,31 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1258,23 +1265,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1402,7 +1408,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -1427,6 +1433,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,18 +1456,18 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.3.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "num"
-version = "0.4.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -1461,37 +1479,39 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
+ "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1500,10 +1520,11 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
+ "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1511,49 +1532,49 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.19"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "objc-sys"
-version = "0.3.5"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
 
 [[package]]
 name = "objc2"
@@ -1573,9 +1594,9 @@ checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -1588,14 +1609,14 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opener"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0812e5e4df08da354c851a3376fead46db31c2214f849d3de356d774d057681"
+checksum = "f8df34be653210fbe9ffaff41d3b92721c56ce82dfee58ee684f9afb5e3a90c0"
 dependencies = [
  "bstr",
  "dbus",
  "normpath",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1610,14 +1631,14 @@ version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "libredox 0.0.2",
+ "libredox",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "4.2.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
  "rand",
@@ -1627,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.24.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
+checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
  "ttf-parser",
 ]
@@ -1642,7 +1663,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.1",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1655,9 +1676,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
@@ -1676,7 +1697,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1693,70 +1714,66 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "3.7.3"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "postcard"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+checksum = "d534c6e61df1c7166e636ca612d9820d486fe96ddad37f7abc671517b297488e"
 dependencies = [
  "cobs",
- "embedded-io",
  "heapless",
  "serde",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1783,18 +1800,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.34.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1839,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.6.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "rayon"
@@ -1865,6 +1882,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -1883,52 +1909,46 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "libredox 0.1.3",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rend"
@@ -1941,24 +1961,23 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
 dependencies = [
  "cc",
- "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -1974,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1987,7 +2006,7 @@ dependencies = [
 name = "rusqlite"
 version = "0.31.0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2006,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -2027,11 +2046,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2077,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -2094,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -2124,15 +2143,15 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b31447ca297092c5a9916fc3b955203157b37c19ca8edde4f52e9843e602c7"
+checksum = "1729a30a469de249c6effc17ec8d039b0aa29b3af79b819b7f51cb6ab8046a90"
 dependencies = [
  "ab_glyph",
  "log",
@@ -2149,11 +2168,11 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2162,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2172,47 +2191,46 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
- "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -2223,9 +2241,9 @@ version = "0.1.0"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "simdutf8"
@@ -2235,9 +2253,9 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "skia-bindings"
@@ -2258,7 +2276,7 @@ dependencies = [
 name = "skia-safe"
 version = "0.74.0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "lazy_static",
  "skia-bindings",
  "windows 0.56.0",
@@ -2281,17 +2299,17 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -2312,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
 dependencies = [
  "serde",
 ]
@@ -2369,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2386,9 +2404,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -2397,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -2408,29 +2426,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "tiny-skia"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+checksum = "b6a067b809476893fce6a254cf285850ff69c847e6cfbade6a20b655b6c7e80d"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -2442,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+checksum = "5de35e8a90052baaaf61f171680ac2f8e925a1e43ea9d2e3a00514772250e541"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2453,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2465,6 +2483,21 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "tokio"
@@ -2478,27 +2511,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.39.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2509,65 +2527,55 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
- "tokio 1.39.3",
+ "tokio 1.37.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio 1.39.3",
+ "tokio 1.37.0",
+ "tracing",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow",
 ]
 
 [[package]]
@@ -2580,92 +2588,97 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio 1.39.3",
+ "tokio 1.37.0",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "try-lock"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ttf-parser"
-version = "0.24.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown 0.12.3",
+ "regex",
+]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -2675,9 +2688,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2687,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
@@ -2699,13 +2712,13 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.10.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1cd046f83ea2c4e920d6ee9f7c3537ef928d75dce5d84a87c2c5d6b3999a3a"
+checksum = "c1b300a878652a387d2a0de915bdae8f1a548f0c6d45e072fe2688794b656cc9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2716,15 +2729,15 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -2732,10 +2745,11 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
+ "log",
  "try-lock",
 ]
 
@@ -2759,35 +2773,34 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
- "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2797,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2807,32 +2820,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
+checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "nix",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -2840,12 +2853,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.5"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
+checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
 dependencies = [
- "bitflags 2.6.0",
- "rustix",
+ "bitflags 2.4.1",
+ "nix",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -2856,29 +2869,29 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef9489a8df197ebf3a8ce8a7a7f0a2320035c3743f3c1bd0bdbccf07ce64f95"
+checksum = "a44aa20ae986659d6c77d64d808a046996a932aa763913864dc40c359ef7ad5b"
 dependencies = [
- "rustix",
+ "nix",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2890,7 +2903,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2903,7 +2916,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2912,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
+checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2923,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
+checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
 dependencies = [
  "dlib",
  "log",
@@ -2935,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2945,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2967,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -2989,11 +3002,20 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
- "windows-sys 0.59.0",
+ "winapi",
+]
+
+[[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3053,7 +3075,7 @@ checksum = "fb2b158efec5af20d8846836622f50a87e6556b9153a42772fa047f773c0e555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3064,7 +3086,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3075,7 +3097,7 @@ checksum = "0546e63e1ce64c04403d2311fa0e3ab5ae3a367bd524b4a38d8d8d18c70cfa76"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3086,14 +3108,14 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3121,15 +3143,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3314,14 +3327,14 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.29.15"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
+checksum = "d25d662bb83b511acd839534bb2d88521b0bbc81440969cb077d23c4db9e62c7"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.6",
  "android-activity",
  "atomic-waker",
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "bytemuck",
  "calloop",
  "cfg_aliases",
@@ -3362,18 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
@@ -3400,30 +3404,35 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.13.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
 dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading",
+ "libloading 0.7.4",
+ "nix",
  "once_cell",
- "rustix",
+ "winapi",
+ "winapi-wsapoll",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
+dependencies = [
+ "nix",
+]
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
 dependencies = [
  "libc",
  "linux-raw-sys",
@@ -3432,17 +3441,17 @@ dependencies = [
 
 [[package]]
 name = "xcursor"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
+checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
 
 [[package]]
 name = "xkbcommon-dl"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.4.1",
  "dlib",
  "log",
  "once_cell",
@@ -3451,29 +3460,28 @@ dependencies = [
 
 [[package]]
 name = "xkeysym"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/namui/sample/http/Cargo.toml
+++ b/namui/sample/http/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "http-sample"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.namui]
+targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
+
+[dependencies]
+namui = { path = "../../namui" }
+namui-prebuilt = { path = "../../namui-prebuilt" }

--- a/namui/sample/http/src/lib.rs
+++ b/namui/sample/http/src/lib.rs
@@ -1,0 +1,70 @@
+use namui::*;
+use namui_prebuilt::{table, typography};
+
+pub fn main() {
+    namui::start(render)
+}
+
+fn render(ctx: &RenderCtx) {
+    let (geojs_content, set_geojs_content) = ctx.state(|| None);
+    let (google_content, set_google_content) = ctx.state(|| None);
+
+    ctx.effect("geojs - no cors", || {
+        ctx.spawn(async move {
+            let content = match request("https://get.geojs.io/v1/ip/country.json?ip=8.8.8.8").await
+            {
+                Ok(content) => content,
+                Err(err) => err.to_string(),
+            };
+            set_geojs_content.set(Some(content));
+        });
+    });
+
+    ctx.effect("google - yes cors", || {
+        ctx.spawn(async move {
+            let content = match request("https://google.com").await {
+                Ok(content) => content,
+                Err(err) => err.to_string(),
+            };
+            set_google_content.set(Some(content));
+        });
+    });
+
+    ctx.compose(|ctx| {
+        table::vertical([
+            table::ratio(1, |_, ctx| {
+                ctx.add(typography::body::left_top(
+                    match geojs_content.as_ref() {
+                        Some(content) => "geojs: ".to_string() + &content.to_string(),
+                        None => "geojs loading...".to_string(),
+                    },
+                    Color::BLACK,
+                ));
+            }),
+            table::ratio(1, |_, ctx| {
+                ctx.add(typography::body::left_top(
+                    match google_content.as_ref() {
+                        Some(content) => "google: ".to_string() + &content.to_string(),
+                        None => "google loading...".to_string(),
+                    },
+                    Color::BLACK,
+                ));
+            }),
+        ])(namui::screen::size().map(|x| x.into_px()), ctx);
+    });
+}
+
+async fn request(url: &str) -> namui::Result<String> {
+    let bytes = namui::system::network::http::Request::builder()
+        // no cors
+        .uri(url)
+        .body(())?
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    let content = String::from_utf8(bytes).unwrap();
+
+    Ok(content)
+}

--- a/namui/sample/media/Cargo.lock
+++ b/namui/sample/media/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "calloop"
@@ -326,7 +326,7 @@ dependencies = [
  "bitflags 2.4.1",
  "log",
  "polling",
- "rustix 0.38.28",
+ "rustix",
  "slab",
  "thiserror",
 ]
@@ -338,7 +338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
 dependencies = [
  "calloop",
- "rustix 0.38.28",
+ "rustix",
  "wayland-backend",
  "wayland-client",
 ]
@@ -442,7 +442,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -473,13 +473,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.17"
+name = "crossbeam-deque"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "cursor-icon"
@@ -589,30 +605,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "errno"
@@ -622,16 +618,6 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -645,15 +631,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "ffmpeg-next"
@@ -707,21 +684,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -734,12 +702,6 @@ dependencies = [
  "quote",
  "syn 2.0.31",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -993,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -1003,12 +965,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1022,9 +984,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1041,26 +1003,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
+name = "hyper-rustls"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
- "bytes",
- "http-body-util",
+ "futures-util",
+ "http",
  "hyper",
  "hyper-util",
- "native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio 1.25.0",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1106,31 +1070,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
 ]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
-dependencies = [
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "itoa"
@@ -1248,12 +1187,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
@@ -1316,12 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,13 +1280,16 @@ name = "namui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bumpalo",
+ "bytes",
  "dashmap",
- "derivative",
- "elsa",
  "ffmpeg-next",
  "futures",
- "indexmap",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "lazy_static",
  "namui-cfg",
  "namui-drawer",
@@ -1370,17 +1300,11 @@ dependencies = [
  "opener",
  "percent-encoding",
  "rand",
- "reqwest",
+ "rayon",
  "rusqlite",
- "rustc-hash",
  "serde",
  "serde_json",
  "shader-macro",
- "slab",
- "smallvec",
- "smol_str",
- "stable_deref_trait",
- "static-tree",
  "tokio 1.38.0",
  "url",
  "wasapi",
@@ -1468,24 +1392,6 @@ dependencies = [
  "directories",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1706,49 +1612,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orbclient"
@@ -1852,7 +1719,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1986,6 +1853,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,43 +1943,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.4"
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
 dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio 1.25.0",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2168,29 +2029,42 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.2.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
- "errno 0.3.8",
+ "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2208,6 +2082,17 @@ name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "ryu"
@@ -2334,18 +2219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "shader-macro"
 version = "0.1.0"
 
@@ -2369,7 +2242,7 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "skia-bindings"
-version = "0.75.0"
+version = "0.74.0"
 dependencies = [
  "bindgen 0.69.1",
  "cc",
@@ -2384,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.75.0"
+version = "0.74.0"
 dependencies = [
  "bitflags 2.4.1",
  "lazy_static",
@@ -2426,7 +2299,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix 0.38.28",
+ "rustix",
  "thiserror",
  "wayland-backend",
  "wayland-client",
@@ -2483,19 +2356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static-tree"
-version = "0.1.0"
-dependencies = [
- "elsa",
- "rustc-hash",
- "slab",
-]
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2520,33 +2390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,19 +2404,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall 0.2.16",
- "rustix 0.36.8",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2684,12 +2514,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio 1.25.0",
 ]
 
@@ -2842,6 +2673,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3132,7 +2969,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.28",
+ "rustix",
 ]
 
 [[package]]
@@ -3526,7 +3363,7 @@ dependencies = [
  "percent-encoding",
  "raw-window-handle",
  "redox_syscall 0.3.5",
- "rustix 0.38.28",
+ "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -3552,16 +3389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3617,8 +3444,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.12",
- "rustix 0.38.28",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]
@@ -3665,3 +3492,9 @@ dependencies = [
  "quote",
  "syn 2.0.31",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"


### PR DESCRIPTION
This PR exposes [http](https://docs.rs/http/latest/http/) crate as interface for http request and response.
I put some Extension traits of http::Request and http::Response, so user can send and receive using that trait.

# Implementation Status

Windows: need tokio update (https://github.com/tokio-rs/tokio/pull/6822), because hyper-util's dns system use original tokio.
Wasi: Works well.
![image](https://github.com/user-attachments/assets/82acf31b-b143-4cfd-80e6-8a53cc69da5a)

google's fail is natural because google server blocks our request by cors policy.


# Additional changes

1. `new-event-system` added. I will put every js-rs event things in here, including pre-made other event systems, like websocket, screen, etc.