### PR TITLE
Fix wrong length setting for http stream buffer

### DIFF
--- a/namui/namui-cli/webCode/src/httpFetch/yesStream.ts
+++ b/namui/namui-cli/webCode/src/httpFetch/yesStream.ts
@@ -112,7 +112,7 @@ export class YesStreamHttpFetchHandle implements HttpFetchHandle {
                         await this.getResponseBodyBuffer();
 
                     // NOTE: Currently byob doesn't support to write to shared buffer directly
-                    const tempBuffer = new Uint8Array(buffer.buffer.byteLength);
+                    const tempBuffer = new Uint8Array(buffer.length);
 
                     const { value, done } = await reader.read(tempBuffer);
 


### PR DESCRIPTION
`buffer.buffer.byteLength` returns full length of memory, not the view's length.