### PR TITLE
Set duplex on fetch start

### DIFF
--- a/namui/namui-cli/webCode/src/httpFetch/yesStream.ts
+++ b/namui/namui-cli/webCode/src/httpFetch/yesStream.ts
@@ -43,8 +43,6 @@ export class YesStreamHttpFetchHandle implements HttpFetchHandle {
     }): void {
         const request = new Request(url, {
             method,
-            // @ts-ignore
-            duplex: "half",
         });
 
         const id = this.nextId++;
@@ -94,6 +92,8 @@ export class YesStreamHttpFetchHandle implements HttpFetchHandle {
                         ? undefined
                         : readable,
                     signal: abortController.signal,
+                    // @ts-ignore
+                    duplex: "half",
                 });
                 this.onResponse(fetchId, response);
 


### PR DESCRIPTION
Previously, the duplex mode setting was not applied, resulting in the following error:
```text
[WASI stderr(tid: 2)] http_fetch_on_error: TypeError: Failed to execute 'fetch' on 'Window': The `duplex` member must be specified for a request with a streaming body
```