### PR TITLE
Put EpisodeEditingUserDoc on creating episode

### DIFF
--- a/luda-editor/new-server/server/src/api/episode/create_new_episode/mod.rs
+++ b/luda-editor/new-server/server/src/api/episode/create_new_episode/mod.rs
@@ -34,6 +34,11 @@ pub async fn create_new_episode(
             project_id,
             ttl: None,
         },
+        EpisodeEditingUserDocPut {
+            episode_id: &episode_id,
+            editing_user: &None,
+            ttl: None,
+        },
     ))
     .await?;
 


### PR DESCRIPTION
'EpisodeNotExist' occurs because `EpisodeEditingUserDoc` is not created

https://github.com/NamseEnt/namseent/blob/0ab5b050d36b6d27ea1da2e6c6b5c4c9bddf4551/luda-editor/new-server/server/src/api/episode_editor/join_episode_editor/mod.rs#L80-L117