### PR TITLE
Fix left reroll chance counting for prevent error from extra reroll

### DIFF
--- a/tower-defense/src/game_state/flow.rs
+++ b/tower-defense/src/game_state/flow.rs
@@ -44,6 +44,7 @@ impl GameState {
         self.left_reroll_chance = self.max_reroll_chance();
         self.shield = 0.0;
         self.item_used = false;
+        self.rerolled_count = 0;
 
         match self.in_even_stage() {
             true => {

--- a/tower-defense/src/game_state/mod.rs
+++ b/tower-defense/src/game_state/mod.rs
@@ -83,6 +83,7 @@ pub struct GameState {
     pub level: NonZeroUsize,
     game_now: Instant,
     pub fast_forward_multiplier: FastForwardMultiplier,
+    pub rerolled_count: usize,
 }
 impl GameState {
     pub fn in_even_stage(&self) -> bool {
@@ -111,10 +112,7 @@ impl GameState {
         self.upgrade_state.reroll_chance_plus + 1
     }
     pub fn rerolled(&self) -> bool {
-        self.rerolled_count() > 0
-    }
-    pub fn rerolled_count(&self) -> usize {
-        self.max_reroll_chance() - self.left_reroll_chance
+        self.rerolled_count > 0
     }
 
     pub fn earn_gold(&mut self, gold: usize) {
@@ -202,6 +200,7 @@ pub fn init_game_state<'a>(ctx: &'a RenderCtx) -> Sig<'a, GameState> {
             level: NonZeroUsize::new(1).unwrap(),
             game_now: Instant::now(),
             fast_forward_multiplier: Default::default(),
+            rerolled_count: 0,
         };
 
         game_state.goto_selecting_tower();

--- a/tower-defense/src/tower_selecting_hand/mod.rs
+++ b/tower-defense/src/tower_selecting_hand/mod.rs
@@ -68,6 +68,7 @@ impl Component for TowerSelectingHand<'_> {
                     cards[index] = Card::new_random();
                 }
                 game_state.left_reroll_chance -= 1;
+                game_state.rerolled_count += 1;
 
                 on_quest_trigger_event(game_state, QuestTriggerEvent::Reroll);
             });

--- a/tower-defense/src/tower_selecting_hand/tower_preview.rs
+++ b/tower-defense/src/tower_selecting_hand/tower_preview.rs
@@ -222,7 +222,7 @@ fn calculate_upgrade_state(
         apply_tower_select_upgrade_target(TowerSelectUpgradeTarget::LowCard);
     }
 
-    let rerolled_count = game_state.rerolled_count();
+    let rerolled_count = game_state.rerolled_count;
     if rerolled_count == 0 {
         apply_tower_select_upgrade_target(TowerSelectUpgradeTarget::NoReroll);
     } else if let Some(upgrade_state) = game_state


### PR DESCRIPTION
It was the best record, but the game crashed because of this