### PR TITLE
Expose rand

### DIFF
--- a/namui/namui/src/lib.rs
+++ b/namui/namui/src/lib.rs
@@ -20,6 +20,7 @@ pub use namui_cfg::*;
 pub use namui_skia::*;
 pub use namui_type as types;
 pub use namui_type::*;
+pub use rand;
 pub use rayon;
 pub use render::*;
 pub use serde;


### PR DESCRIPTION
I hope namui exposes crates that use by rust community generally, as de facto.

For example, rand is most used crate (I guess!?!?) for random generation.