### PR TITLE
Use global xy for mouse xy in test

### DIFF
--- a/namui/namui-hooks/benches/translate_benchmark.rs
+++ b/namui/namui-hooks/benches/translate_benchmark.rs
@@ -15,7 +15,7 @@ fn my_benchmark(c: &mut Criterion) {
 }
 
 fn bench_translate() {
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     #[derive(Debug)]
     struct A {}
@@ -38,7 +38,7 @@ fn bench_translate() {
     World::run(&mut world, A {});
 }
 fn bench_translate_run_twice() {
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     #[derive(Debug)]
     struct A {}

--- a/namui/namui-hooks/src/compose/ctx/public/event.rs
+++ b/namui/namui-hooks/src/compose/ctx/public/event.rs
@@ -24,8 +24,7 @@ impl ComposeCtx<'_, '_> {
 
         let is_global_xy_clip_in = |mut global_xy: Xy<Px>| -> bool {
             if self
-                .full_stack
-                .iter()
+                .parent_stack()
                 .all(|command| !matches!(command, ComposeCommand::Clip { .. }))
             {
                 return true;
@@ -65,29 +64,20 @@ impl ComposeCtx<'_, '_> {
             true
         };
 
-        let to_local_xy = |mut global_xy: Xy<Px>| -> Xy<Px> {
-            let original_xy = global_xy;
-            for command in self.full_stack.iter() {
-                match command {
-                    ComposeCommand::Translate { xy } => global_xy -= xy,
-                    ComposeCommand::Absolute { xy } => global_xy = original_xy - xy,
-                    ComposeCommand::Rotate { angle } => {
-                        global_xy = TransformMatrix::from_rotate(-angle).transform_xy(global_xy);
-                    }
-                    ComposeCommand::Scale { scale_xy } => {
-                        global_xy = TransformMatrix::from_scale(1.0 / scale_xy.x, 1.0 / scale_xy.y)
-                            .transform_xy(global_xy);
-                    }
-                    ComposeCommand::Clip { .. }
-                    | ComposeCommand::OnTop
-                    | ComposeCommand::MouseCursor { .. } => {}
-                }
-            }
+        /*
+        Q. Which local do you mean?
+        1 2 3 4 5 6 7 8 9
+        ^------------------                    <= global
+            ^-------------- ctx.compose        <= parent local
+                  ^-------- ctx.translate
+                      ^---- ctx.add
+                        ^-- ctx.attach_event   <= local
+        */
 
-            global_xy
-        };
+        let to_local_xy = |xy| apply_commands_to_xy(xy, self.full_stack.iter());
+        let to_parent_local_xy = |xy| apply_commands_to_xy(xy, self.parent_stack());
 
-        let bounding_box_xy_in = |xy: Xy<Px>| -> bool {
+        let xy_in = |global_xy: Xy<Px>| -> bool {
             let Some(bounding_box) = self
                 .rt_container
                 .iter()
@@ -95,16 +85,21 @@ impl ComposeCtx<'_, '_> {
             else {
                 return false;
             };
-            bounding_box.is_xy_inside(xy)
+            let parent_local_xy = to_parent_local_xy(global_xy);
+            if !bounding_box.is_xy_inside(parent_local_xy) {
+                return false;
+            }
+
+            self.rt_container
+                .iter()
+                .any(|rt| rt.xy_in(self.world.sk_calculate.as_ref(), parent_local_xy))
         };
 
         match raw_event {
             RawEvent::MouseDown { event } => {
                 let event = MouseEvent {
                     local_xy: &move || to_local_xy(event.xy),
-                    is_local_xy_in: &move || {
-                        is_global_xy_clip_in(event.xy) && bounding_box_xy_in(event.xy)
-                    },
+                    is_local_xy_in: &move || is_global_xy_clip_in(event.xy) && xy_in(event.xy),
                     global_xy: event.xy,
                     pressing_buttons: &event.pressing_buttons,
                     button: event.button,
@@ -117,9 +112,7 @@ impl ComposeCtx<'_, '_> {
             RawEvent::MouseMove { event } => {
                 let event = MouseEvent {
                     local_xy: &move || to_local_xy(event.xy),
-                    is_local_xy_in: &move || {
-                        is_global_xy_clip_in(event.xy) && bounding_box_xy_in(event.xy)
-                    },
+                    is_local_xy_in: &move || is_global_xy_clip_in(event.xy) && xy_in(event.xy),
                     global_xy: event.xy,
                     pressing_buttons: &event.pressing_buttons,
                     button: event.button,
@@ -132,9 +125,7 @@ impl ComposeCtx<'_, '_> {
             RawEvent::MouseUp { event } => {
                 let event = MouseEvent {
                     local_xy: &move || to_local_xy(event.xy),
-                    is_local_xy_in: &move || {
-                        is_global_xy_clip_in(event.xy) && bounding_box_xy_in(event.xy)
-                    },
+                    is_local_xy_in: &move || is_global_xy_clip_in(event.xy) && xy_in(event.xy),
                     global_xy: event.xy,
                     pressing_buttons: &event.pressing_buttons,
                     button: event.button,
@@ -150,8 +141,7 @@ impl ComposeCtx<'_, '_> {
                         delta_xy: event.delta_xy,
                         local_xy: &move || to_local_xy(event.mouse_xy),
                         is_local_xy_in: &move || {
-                            is_global_xy_clip_in(event.mouse_xy)
-                                && bounding_box_xy_in(event.mouse_xy)
+                            is_global_xy_clip_in(event.mouse_xy) && xy_in(event.mouse_xy)
                         },
                         is_stop_event_propagation: &self.world.is_stop_event_propagation,
                     },
@@ -188,4 +178,29 @@ impl ComposeCtx<'_, '_> {
 
         self
     }
+}
+
+fn apply_commands_to_xy<'a>(
+    mut target_xy: Xy<Px>,
+    commands: impl Iterator<Item = &'a ComposeCommand> + 'a,
+) -> Xy<Px> {
+    let original_xy = target_xy;
+    for command in commands {
+        match command {
+            ComposeCommand::Translate { xy } => target_xy -= xy,
+            ComposeCommand::Absolute { xy } => target_xy = original_xy - xy,
+            ComposeCommand::Rotate { angle } => {
+                target_xy = TransformMatrix::from_rotate(-angle).transform_xy(target_xy);
+            }
+            ComposeCommand::Scale { scale_xy } => {
+                target_xy = TransformMatrix::from_scale(1.0 / scale_xy.x, 1.0 / scale_xy.y)
+                    .transform_xy(target_xy);
+            }
+            ComposeCommand::Clip { .. }
+            | ComposeCommand::OnTop
+            | ComposeCommand::MouseCursor { .. } => {}
+        }
+    }
+
+    target_xy
 }

--- a/namui/namui-hooks/src/compose/ctx/public/event.rs
+++ b/namui/namui-hooks/src/compose/ctx/public/event.rs
@@ -37,7 +37,7 @@ impl ComposeCtx<'_, '_> {
                     ComposeCommand::Translate { xy } => global_xy -= xy,
                     ComposeCommand::Absolute { xy } => global_xy = original_xy - xy,
                     ComposeCommand::Clip { path, clip_op } => {
-                        let path_xy_in = path.xy_in(self.world.sk_calculate, global_xy);
+                        let path_xy_in = path.xy_in(self.world.sk_calculate.as_ref(), global_xy);
                         match clip_op {
                             ClipOp::Intersect => {
                                 if !path_xy_in {
@@ -91,11 +91,10 @@ impl ComposeCtx<'_, '_> {
             let Some(bounding_box) = self
                 .rt_container
                 .iter()
-                .bounding_box(self.world.sk_calculate)
+                .bounding_box(self.world.sk_calculate.as_ref())
             else {
                 return false;
             };
-            let xy = to_local_xy(xy);
             bounding_box.is_xy_inside(xy)
         };
 

--- a/namui/namui-hooks/src/compose/ctx/public/stack.rs
+++ b/namui/namui-hooks/src/compose/ctx/public/stack.rs
@@ -7,12 +7,8 @@ impl ComposeCtx<'_, '_> {
             composer: self.composer,
             world: self.world,
             // NOTE: Optimize point: `stack` can be replace with the index of full_stack.
-            stack: {
-                let mut stack = self.stack.clone();
-                stack.push(command.clone());
-                stack
-            },
             rt_container: self.rt_container,
+            stack_parent_len: self.stack_parent_len,
             full_stack: {
                 let mut full_stack = self.full_stack.clone().into_owned();
                 full_stack.push(command);

--- a/namui/namui-hooks/src/render_ctx/dependencies.rs
+++ b/namui/namui-hooks/src/render_ctx/dependencies.rs
@@ -202,7 +202,7 @@ mod tests {
             }
         }
 
-        let world = World::init(Instant::now, &MockSkCalculate);
+        let world = World::init(Instant::now, Arc::new(MockSkCalculate));
         let sig = Sig::new(&1, SigId::Atom { index: 0 }, &world);
         let _cloned: i32 = sig.to_owned();
     }

--- a/namui/namui-hooks/src/test/mod.rs
+++ b/namui/namui-hooks/src/test/mod.rs
@@ -1,3 +1,4 @@
+mod mouse_event;
 mod pass_sig;
 
 use crate::*;
@@ -38,7 +39,7 @@ impl SkCalculate for MockSkCalculate {
 fn memo_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 
@@ -118,7 +119,7 @@ fn memo_should_work() {
 fn effect_by_set_state_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 
@@ -198,7 +199,7 @@ fn effect_by_set_state_should_work() {
 fn effect_by_memo_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let call_count = Arc::new(AtomicUsize::new(0));
 
@@ -279,7 +280,7 @@ fn effect_by_memo_should_work() {
 fn effect_clean_up_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 
@@ -394,7 +395,7 @@ fn interval_should_work() {
                 *now
             }
         },
-        &MockSkCalculate,
+        Arc::new(MockSkCalculate),
     );
 
     let call_count = Arc::new(AtomicUsize::new(0));
@@ -494,7 +495,7 @@ fn interval_should_work() {
 fn controlled_memo_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 
@@ -589,7 +590,7 @@ fn controlled_memo_should_work() {
 fn atom_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 
@@ -674,7 +675,7 @@ fn atom_should_work() {
 
 #[test]
 fn set_state_should_be_copied_into_async_move() {
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     #[derive(Debug)]
     struct A {}
@@ -705,7 +706,7 @@ fn set_state_should_be_copied_into_async_move() {
 
 #[test]
 fn set_state_should_be_copied_into_async_effect() {
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     #[derive(Debug)]
     struct A {}
@@ -770,7 +771,7 @@ fn set_state_should_be_copied_into_async_effect() {
 fn tuple_set_state_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 

--- a/namui/namui-hooks/src/test/mouse_event.rs
+++ b/namui/namui-hooks/src/test/mouse_event.rs
@@ -1,0 +1,88 @@
+use super::*;
+use std::sync::{Arc, atomic::AtomicUsize};
+
+#[test]
+fn event_local_xy_in() {
+    let sk_calculate = namui_skia::init_calculate().unwrap();
+    let mut world = World::init(Instant::now, sk_calculate);
+
+    #[derive(Debug)]
+    struct A {
+        record: Arc<AtomicUsize>,
+    }
+
+    const ROWS: usize = 3;
+    const COLS: usize = 3;
+
+    const RECT_WH: Wh<Px> = Wh::new(px(100.0), px(100.0));
+
+    impl Component for A {
+        fn render(self, ctx: &RenderCtx) {
+            let rect_rt = RenderingTree::Node(DrawCommand::Path {
+                command: Box::new(PathDrawCommand {
+                    path: Path::new().add_rect(Rect::from_xy_wh(Xy::zero(), RECT_WH)),
+                    paint: Paint::new(Color::WHITE).set_style(PaintStyle::Fill),
+                }),
+            });
+
+            for x in 0..COLS {
+                for y in 0..ROWS {
+                    ctx.compose(|ctx| {
+                        ctx.translate((RECT_WH.width * x, RECT_WH.height * y))
+                            .add(rect_rt.clone())
+                            .attach_event(|event| {
+                                let Event::MouseMove { event } = event else {
+                                    return;
+                                };
+                                if event.is_local_xy_in() {
+                                    let index = x * ROWS + y;
+                                    self.record
+                                        .store(index, std::sync::atomic::Ordering::Relaxed);
+                                    assert_eq!(
+                                        event.global_xy,
+                                        Xy::new(
+                                            RECT_WH.width * (x as f32 + 0.5),
+                                            RECT_WH.height * (y as f32 + 0.5),
+                                        ),
+                                        "x: {x}, y: {y}",
+                                    );
+                                    assert_eq!(
+                                        event.local_xy(),
+                                        RECT_WH.as_xy() * 0.5,
+                                        "x: {x}, y: {y}",
+                                    );
+                                }
+                            });
+                    });
+                }
+            }
+        }
+    }
+
+    let record = Arc::new(AtomicUsize::new(usize::MAX));
+
+    let mut result = [usize::MAX; ROWS * COLS];
+    for x in 0..COLS {
+        for y in 0..ROWS {
+            let mouse_xy = Xy::new(
+                RECT_WH.width * (x as f32 + 0.5),
+                RECT_WH.height * (y as f32 + 0.5),
+            );
+            World::run_with_event(
+                &mut world,
+                A {
+                    record: record.clone(),
+                },
+                RawEvent::MouseMove {
+                    event: RawMouseEvent {
+                        xy: mouse_xy,
+                        pressing_buttons: Default::default(),
+                        button: Default::default(),
+                    },
+                },
+            );
+            result[x * ROWS + y] = record.load(std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    assert_eq!(result, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
+}

--- a/namui/namui-hooks/src/test/mouse_event.rs
+++ b/namui/namui-hooks/src/test/mouse_event.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::sync::{Arc, atomic::AtomicUsize};
 
 #[test]
-fn event_local_xy_in() {
+fn event_local_xy_in_on_compose_translate() {
     let sk_calculate = namui_skia::init_calculate().unwrap();
     let mut world = World::init(Instant::now, sk_calculate);
 
@@ -49,9 +49,97 @@ fn event_local_xy_in() {
                                     assert_eq!(
                                         event.local_xy(),
                                         RECT_WH.as_xy() * 0.5,
-                                        "x: {x}, y: {y}",
+                                        "x: {x}, y: {y}, global_xy: {:?}",
+                                        event.global_xy
                                     );
                                 }
+                            });
+                    });
+                }
+            }
+        }
+    }
+
+    let record = Arc::new(AtomicUsize::new(usize::MAX));
+
+    let mut result = [usize::MAX; ROWS * COLS];
+    for x in 0..COLS {
+        for y in 0..ROWS {
+            let mouse_xy = Xy::new(
+                RECT_WH.width * (x as f32 + 0.5),
+                RECT_WH.height * (y as f32 + 0.5),
+            );
+            World::run_with_event(
+                &mut world,
+                A {
+                    record: record.clone(),
+                },
+                RawEvent::MouseMove {
+                    event: RawMouseEvent {
+                        xy: mouse_xy,
+                        pressing_buttons: Default::default(),
+                        button: Default::default(),
+                    },
+                },
+            );
+            result[x * ROWS + y] = record.load(std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    assert_eq!(result, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
+}
+
+#[test]
+fn event_local_xy_in_after_translate_at_out() {
+    let sk_calculate = namui_skia::init_calculate().unwrap();
+    let mut world = World::init(Instant::now, sk_calculate);
+
+    #[derive(Debug)]
+    struct A {
+        record: Arc<AtomicUsize>,
+    }
+
+    const ROWS: usize = 3;
+    const COLS: usize = 3;
+
+    const RECT_WH: Wh<Px> = Wh::new(px(100.0), px(100.0));
+
+    impl Component for A {
+        fn render(self, ctx: &RenderCtx) {
+            let rect_rt = RenderingTree::Node(DrawCommand::Path {
+                command: Box::new(PathDrawCommand {
+                    path: Path::new().add_rect(Rect::from_xy_wh(Xy::zero(), RECT_WH)),
+                    paint: Paint::new(Color::WHITE).set_style(PaintStyle::Fill),
+                }),
+            });
+
+            for x in 0..COLS {
+                for y in 0..ROWS {
+                    ctx.compose(|ctx| {
+                        ctx.translate((RECT_WH.width * x, RECT_WH.height * y))
+                            .compose(|ctx| {
+                                ctx.add(rect_rt.clone()).attach_event(|event| {
+                                    let Event::MouseMove { event } = event else {
+                                        return;
+                                    };
+                                    if event.is_local_xy_in() {
+                                        let index = x * ROWS + y;
+                                        self.record
+                                            .store(index, std::sync::atomic::Ordering::Relaxed);
+                                        assert_eq!(
+                                            event.global_xy,
+                                            Xy::new(
+                                                RECT_WH.width * (x as f32 + 0.5),
+                                                RECT_WH.height * (y as f32 + 0.5),
+                                            ),
+                                            "x: {x}, y: {y}",
+                                        );
+                                        assert_eq!(
+                                            event.local_xy(),
+                                            RECT_WH.as_xy() * 0.5,
+                                            "x: {x}, y: {y}",
+                                        );
+                                    }
+                                });
                             });
                     });
                 }

--- a/namui/namui-hooks/src/test/pass_sig.rs
+++ b/namui/namui-hooks/src/test/pass_sig.rs
@@ -4,7 +4,7 @@ use super::*;
 fn pass_sig_to_child_should_work() {
     use std::sync::{Arc, atomic::AtomicUsize};
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     let record = Arc::new(AtomicUsize::new(0));
 

--- a/namui/namui-hooks/src/world/mod.rs
+++ b/namui/namui-hooks/src/world/mod.rs
@@ -4,6 +4,7 @@ use crate::*;
 use elsa::*;
 use rustc_hash::FxHashSet;
 use std::sync::{
+    Arc,
     atomic::{AtomicBool, AtomicUsize},
     mpsc,
 };
@@ -20,7 +21,7 @@ pub struct World {
     pub(crate) atom_index: AtomicUsize,
     pub(crate) raw_event: Option<RawEvent>,
     pub(crate) is_stop_event_propagation: AtomicBool,
-    pub(crate) sk_calculate: &'static dyn SkCalculate,
+    pub(crate) sk_calculate: Arc<dyn SkCalculate>,
 }
 
 impl World {

--- a/namui/namui-hooks/src/world/public.rs
+++ b/namui/namui-hooks/src/world/public.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 impl World {
     pub fn init(
         get_now: impl Fn() -> Instant + 'static,
-        sk_calculate: &'static dyn SkCalculate,
+        sk_calculate: Arc<dyn SkCalculate>,
     ) -> Self {
         let (set_state_tx, set_state_rx) = std::sync::mpsc::channel();
         Self {

--- a/namui/namui-prebuilt/src/table/tests.rs
+++ b/namui/namui-prebuilt/src/table/tests.rs
@@ -41,7 +41,7 @@ async fn closure_should_give_right_wh() {
     let body_render_called = Arc::new(AtomicBool::new(false));
     let body_inner_render_called = Arc::new(AtomicBool::new(false));
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     struct Test {
         button_render_called: Arc<AtomicBool>,
@@ -133,7 +133,7 @@ async fn fit_should_work() {
     namui::system::init_for_test().await.unwrap();
     let a_width = Arc::new(Mutex::new(0.px()));
 
-    let mut world = World::init(Instant::now, &MockSkCalculate);
+    let mut world = World::init(Instant::now, Arc::new(MockSkCalculate));
 
     struct Test {
         a_width: Arc<Mutex<Px>>,

--- a/namui/namui-type/src/types/units/rect.rs
+++ b/namui/namui-type/src/types/units/rect.rs
@@ -679,3 +679,28 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_xy_inside() {
+        let rect = Rect::Ltrb {
+            left: 0.0.px(),
+            top: 0.0.px(),
+            right: 48.0.px(),
+            bottom: 24.0.px(),
+        };
+        let xy = Xy {
+            x: 12.0.px(),
+            y: 11.0.px(),
+        };
+        assert!(rect.is_xy_inside(xy));
+        let xy = Xy {
+            x: 12.0.px(),
+            y: 25.0.px(),
+        };
+        assert!(!rect.is_xy_inside(xy));
+    }
+}

--- a/namui/namui/src/hooks/looper.rs
+++ b/namui/namui/src/hooks/looper.rs
@@ -13,7 +13,7 @@ pub(crate) struct Looper {
 }
 impl Looper {
     pub(crate) fn new(root_component: impl 'static + Fn(&RenderCtx)) -> Looper {
-        let mut world = World::init(crate::time::now, crate::system::skia::sk_calculate());
+        let mut world = World::init(crate::time::now, crate::system::skia::sk_calculate_arc());
         let rendering_tree = world.run(&root_component);
         crate::system::skia::request_draw_rendering_tree(rendering_tree);
 

--- a/namui/namui/src/system/skia/mod.rs
+++ b/namui/namui/src/system/skia/mod.rs
@@ -89,6 +89,9 @@ pub async fn load_image_from_raw(image_info: ImageInfo, bytes: &[u8]) -> Result<
 pub(crate) fn sk_calculate() -> &'static dyn SkCalculate {
     SK_CALCULATE.get().unwrap().as_ref()
 }
+pub(crate) fn sk_calculate_arc() -> Arc<dyn SkCalculate> {
+    SK_CALCULATE.get().unwrap().clone()
+}
 
 pub(crate) fn group_glyph(font: &Font, paint: &Paint) -> Arc<dyn GroupGlyph> {
     sk_calculate().group_glyph(font, paint)


### PR DESCRIPTION
I found that mouse xy in test doesn't work well with ``ctx.translate`.
As quick fix, I removed converting mouse xy to local xy during bounding box check.

It mean, if we rotate Rect and test mouse in, it will return false answer on the left-top, right top, and bottoms also because it only handle with bounding box, not path itself.

I will change that later.