### PR TITLE
Fix E0277 on render_stuffs()

### DIFF
--- a/tower-defense/src/game_state/render.rs
+++ b/tower-defense/src/game_state/render.rs
@@ -94,10 +94,9 @@ impl GameState {
     fn render_stuffs<'a, C, MapCoord, MapAxis>(
         &self,
         ctx: &ComposeCtx,
-        stuffs: impl Iterator<Item = (MapCoord, &'a C)>,
+        stuffs: impl Iterator<Item = (MapCoord, C)>,
     ) where
-        C: 'a,
-        &'a C: Component,
+        C: 'a + Component,
         MapCoord: AsRef<Xy<MapAxis>>,
         MapAxis: Ratio + std::fmt::Debug + Clone + Copy,
     {


### PR DESCRIPTION
Fixes
```text
error[E0275]: overflow evaluating the requirement `&_: namui::Component`
   --> src/game_state/render.rs:42:14
    |
42  |         self.render_stuffs(
    |              ^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`tower_defense`)
    = note: required for `&std::option::Option<_>` to implement `namui::Component`
    = note: 124 redundant requirements hidden
    = note: required for `&Option<Option<Option<Option<Option<Option<Option<Option<...>>>>>>>>` to implement `namui::Component`
note: required by a bound in `game_state::render::<impl game_state::GameState>::render_stuffs`
   --> src/game_state/render.rs:100:16
    |
94  |     fn render_stuffs<'a, C, MapCoord, MapAxis>(
    |        ------------- required by a bound in this associated function
...
100 |         &'a C: Component,
    |                ^^^^^^^^^ required by this bound in `game_state::render::<impl GameState>::render_stuffs`
    = note: the full name for the type has been written to '/home/bigfood/programming/namseent/tower-defense/target/wasm32-wasip1-threads/debug/deps/tower_defense-1492a8679a526e1c.long-type-5827029224252416959.txt'
    = note: consider using `--verbose` to print the full type name to the console

```