### PR TITLE
Add tower-defense to CI/CD workflows

### DIFF
--- a/tower-defense/Cargo.toml
+++ b/tower-defense/Cargo.toml
@@ -3,8 +3,8 @@ name = "tower-defense"
 version = "0.1.0"
 edition = "2024"
 
-[package.metadata]
-namui = true
+[package.metadata.namui]
+targets = ["wasm32-wasi-web", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
 
 [dependencies]
 namui = { path = "../namui/namui" }


### PR DESCRIPTION
## Summary
- Tower-defense 프로젝트를 GitHub Actions CI/CD 워크플로우에 추가
- Cargo.toml에 targets 메타데이터를 추가하여 자동 빌드 포함

## Changes
- `tower-defense/Cargo.toml`에 `[package.metadata.namui]` 섹션 추가
- 4개 플랫폼 타겟 지원: wasm32-wasi-web, x86_64-unknown-linux-gnu, x86_64-pc-windows-msvc, aarch64-apple-darwin

## Test plan
- [x] matrix-output 도구로 tower-defense가 올바르게 감지되는지 확인
- [ ] CI/CD 워크플로우에서 tower-defense 빌드가 성공하는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)