### PR TITLE
Add force start button to skip tower placement

### DIFF
--- a/tower-defense/Cargo.lock
+++ b/tower-defense/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 dependencies = [
  "backtrace",
 ]

--- a/tower-defense/Cargo.lock
+++ b/tower-defense/Cargo.lock
@@ -3374,6 +3374,7 @@ dependencies = [
 name = "tower-defense"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "image",
  "namui",
  "namui-prebuilt",

--- a/tower-defense/Cargo.toml
+++ b/tower-defense/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 namui = true
 
 [dependencies]
+anyhow = "1.0.98"
 namui = { path = "../namui/namui" }
 namui-prebuilt = { path = "../namui/namui-prebuilt" }
 rand = { version = "0.8.5", features = ["alloc"] }

--- a/tower-defense/src/asset_loader/mod.rs
+++ b/tower-defense/src/asset_loader/mod.rs
@@ -4,6 +4,7 @@ use crate::game_state::background::BackgroundKind;
 use crate::game_state::tower::{AnimationKind, TowerKind};
 use crate::icon::IconKind;
 use crate::theme::{palette, typography};
+use anyhow;
 use namui::skia::load_image_from_resource_location;
 use namui::tokio::task::JoinSet;
 use namui::*;
@@ -45,7 +46,7 @@ enum State {
     },
     Error {
         resource_location: ResourceLocation,
-        error: namui::anyhow::Error,
+        error: anyhow::Error,
     },
 }
 
@@ -167,7 +168,7 @@ impl Component for LoadingScreen<'_> {
     }
 }
 
-fn start_load_assets() -> JoinSet<Result<(), (ResourceLocation, namui::anyhow::Error)>> {
+fn start_load_assets() -> JoinSet<Result<(), (ResourceLocation, anyhow::Error)>> {
     let mut set = JoinSet::new();
     load(
         &mut set,
@@ -361,7 +362,7 @@ impl ToResourceLocation for (TowerKind, AnimationKind) {
 }
 
 fn load<Key: ToResourceLocation + Copy + Send + Sync + 'static>(
-    set: &mut JoinSet<Result<(), (ResourceLocation, namui::anyhow::Error)>>,
+    set: &mut JoinSet<Result<(), (ResourceLocation, anyhow::Error)>>,
     keys: impl IntoIterator<Item = Key>,
     loader: &'static OnceLock<AssetLoader<Key>>,
 ) {

--- a/tower-defense/src/asset_loader/mod.rs
+++ b/tower-defense/src/asset_loader/mod.rs
@@ -4,7 +4,6 @@ use crate::game_state::background::BackgroundKind;
 use crate::game_state::tower::{AnimationKind, TowerKind};
 use crate::icon::IconKind;
 use crate::theme::{palette, typography};
-use anyhow;
 use namui::skia::load_image_from_resource_location;
 use namui::tokio::task::JoinSet;
 use namui::*;

--- a/tower-defense/src/asset_loader/mod.rs
+++ b/tower-defense/src/asset_loader/mod.rs
@@ -45,7 +45,7 @@ enum State {
     },
     Error {
         resource_location: ResourceLocation,
-        error: anyhow::Error,
+        error: namui::anyhow::Error,
     },
 }
 
@@ -167,7 +167,7 @@ impl Component for LoadingScreen<'_> {
     }
 }
 
-fn start_load_assets() -> JoinSet<Result<(), (ResourceLocation, anyhow::Error)>> {
+fn start_load_assets() -> JoinSet<Result<(), (ResourceLocation, namui::anyhow::Error)>> {
     let mut set = JoinSet::new();
     load(
         &mut set,
@@ -361,7 +361,7 @@ impl ToResourceLocation for (TowerKind, AnimationKind) {
 }
 
 fn load<Key: ToResourceLocation + Copy + Send + Sync + 'static>(
-    set: &mut JoinSet<Result<(), (ResourceLocation, anyhow::Error)>>,
+    set: &mut JoinSet<Result<(), (ResourceLocation, namui::anyhow::Error)>>,
     keys: impl IntoIterator<Item = Key>,
     loader: &'static OnceLock<AssetLoader<Key>>,
 ) {

--- a/tower-defense/src/game_speed_indicator.rs
+++ b/tower-defense/src/game_speed_indicator.rs
@@ -6,9 +6,7 @@ use crate::{
 use namui::*;
 use namui_prebuilt::table;
 
-pub struct GameSpeedIndicator {
-    pub screen_wh: Wh<Px>,
-}
+pub struct GameSpeedIndicator;
 
 impl Component for GameSpeedIndicator {
     fn render(self, ctx: &RenderCtx) {
@@ -53,7 +51,7 @@ impl Component for GameSpeedIndicator {
                 // Current speed display
                 table::fixed(32.px(), |wh, ctx| {
                     ctx.add(
-                        paragraph(format!("Speed: {}", current_speed_text))
+                        paragraph(format!("Speed: {current_speed_text}"))
                             .align(TextAlign::Center { wh })
                             .build(),
                     );

--- a/tower-defense/src/lib.rs
+++ b/tower-defense/src/lib.rs
@@ -109,7 +109,7 @@ impl Component for Game {
 
         // Game speed indicator in bottom-right corner
         ctx.translate((screen_wh.width - 116.px(), screen_wh.height - 88.px()))
-            .add(GameSpeedIndicator { screen_wh });
+            .add(GameSpeedIndicator);
 
         ctx.compose(|ctx| {
             let GameFlow::SelectingUpgrade { upgrades } = &game_state.flow else {

--- a/tower-defense/src/tower_placing_hand/mod.rs
+++ b/tower-defense/src/tower_placing_hand/mod.rs
@@ -62,37 +62,40 @@ impl Component for TowerPlacingHand {
                                 on_click: &select_tower,
                             });
                         }),
+                        table::fixed_no_clip(120.px(), |wh, ctx| {
+                            ctx.compose(|ctx| {
+                                table::vertical([
+                                    table::ratio(1, |_, _| {}),
+                                    table::fixed(48.px(), |wh, ctx| {
+                                        let padding = px(8.0);
+                                        table::padding(padding, |wh, ctx| {
+                                            ctx.add(
+                                                Button::new(
+                                                    wh,
+                                                    &|| {
+                                                        force_start();
+                                                    },
+                                                    &|wh, text_color, ctx| {
+                                                        ctx.add(
+                                                            headline("START")
+                                                                .color(text_color)
+                                                                .align(TextAlign::Center { wh })
+                                                                .build(),
+                                                        );
+                                                    },
+                                                )
+                                                .variant(ButtonVariant::Contained)
+                                                .color(ButtonColor::Primary),
+                                            );
+                                        })(wh, ctx);
+                                    }),
+                                    table::ratio(1, |_, _| {}),
+                                ])(wh, ctx);
+                            });
+                        }),
                         table::ratio_no_clip(1, |_, _| {}),
                     ]),
                 ),
-                table::fixed(60.px(), |wh, ctx| {
-                    table::horizontal([
-                        table::ratio(1, |_, _| {}),
-                        table::fixed(120.px(), |wh, ctx| {
-                            let padding = px(8.0);
-                            table::padding(padding, |wh, ctx| {
-                                ctx.add(
-                                    Button::new(
-                                        wh,
-                                        &|| {
-                                            force_start();
-                                        },
-                                        &|wh, text_color, ctx| {
-                                            ctx.add(
-                                                headline("START")
-                                                    .color(text_color)
-                                                    .align(TextAlign::Center { wh })
-                                                    .build(),
-                                            );
-                                        },
-                                    )
-                                    .variant(ButtonVariant::Contained)
-                                    .color(ButtonColor::Primary),
-                                );
-                            })(wh, ctx);
-                        }),
-                    ])(wh, ctx);
-                }),
             ])(screen_wh, ctx);
         });
     }

--- a/tower-defense/src/tower_placing_hand/mod.rs
+++ b/tower-defense/src/tower_placing_hand/mod.rs
@@ -1,7 +1,11 @@
-use crate::game_state::{
-    cursor_preview::PreviewKind,
-    hand::{HAND_WH, HandComponent, HandSlotId},
-    mutate_game_state, use_game_state,
+use crate::{
+    game_state::{
+        cursor_preview::PreviewKind,
+        hand::{HAND_WH, HandComponent, HandSlotId},
+        mutate_game_state, use_game_state,
+    },
+    icon::{Icon, IconKind, IconSize},
+    theme::button::Button,
 };
 use namui::*;
 use namui_prebuilt::table;
@@ -39,6 +43,13 @@ impl Component for TowerPlacingHand {
             });
         };
 
+        let force_start = || {
+            mutate_game_state(|game_state| {
+                game_state.hand.clear();
+                game_state.goto_defense();
+            });
+        };
+
         ctx.compose(|ctx| {
             table::vertical([
                 table::ratio_no_clip(1, |_, _| {}),
@@ -50,6 +61,22 @@ impl Component for TowerPlacingHand {
                             ctx.add(HandComponent {
                                 hand: &game_state.hand,
                                 on_click: &select_tower,
+                            });
+                        }),
+                        table::fixed_no_clip(HAND_WH.height, |wh, ctx| {
+                            let padding = px(4.0);
+                            ctx.compose(|ctx| {
+                                table::padding(padding, |wh, ctx| {
+                                    ctx.add(Button::new(
+                                        wh,
+                                        &|| {
+                                            force_start();
+                                        },
+                                        &|wh, _text_color, ctx| {
+                                            ctx.add(Icon::new(IconKind::Up).size(IconSize::Large).wh(wh));
+                                        },
+                                    ));
+                                })(wh, ctx);
                             });
                         }),
                         table::ratio_no_clip(1, |_, _| {}),

--- a/tower-defense/src/tower_placing_hand/mod.rs
+++ b/tower-defense/src/tower_placing_hand/mod.rs
@@ -65,37 +65,33 @@ impl Component for TowerPlacingHand {
                         table::ratio_no_clip(1, |_, _| {}),
                     ]),
                 ),
-                table::fixed_no_clip(60.px(), |wh, ctx| {
-                    ctx.compose(|ctx| {
-                        table::horizontal([
-                            table::ratio(1, |_, _| {}),
-                            table::fixed(120.px(), |wh, ctx| {
-                                let padding = px(8.0);
-                                ctx.compose(|ctx| {
-                                    table::padding(padding, |wh, ctx| {
-                                        ctx.add(
-                                            Button::new(
-                                                wh,
-                                                &|| {
-                                                    force_start();
-                                                },
-                                                &|wh, text_color, ctx| {
-                                                    ctx.add(
-                                                        headline("START")
-                                                            .color(text_color)
-                                                            .align(TextAlign::Center { wh })
-                                                            .build(),
-                                                    );
-                                                },
-                                            )
-                                            .variant(ButtonVariant::Contained)
-                                            .color(ButtonColor::Primary),
-                                        );
-                                    })(wh, ctx);
-                                });
-                            }),
-                        ])(wh, ctx);
-                    });
+                table::fixed(60.px(), |wh, ctx| {
+                    table::horizontal([
+                        table::ratio(1, |_, _| {}),
+                        table::fixed(120.px(), |wh, ctx| {
+                            let padding = px(8.0);
+                            table::padding(padding, |wh, ctx| {
+                                ctx.add(
+                                    Button::new(
+                                        wh,
+                                        &|| {
+                                            force_start();
+                                        },
+                                        &|wh, text_color, ctx| {
+                                            ctx.add(
+                                                headline("START")
+                                                    .color(text_color)
+                                                    .align(TextAlign::Center { wh })
+                                                    .build(),
+                                            );
+                                        },
+                                    )
+                                    .variant(ButtonVariant::Contained)
+                                    .color(ButtonColor::Primary),
+                                );
+                            })(wh, ctx);
+                        }),
+                    ])(wh, ctx);
                 }),
             ])(screen_wh, ctx);
         });

--- a/tower-defense/src/tower_placing_hand/mod.rs
+++ b/tower-defense/src/tower_placing_hand/mod.rs
@@ -4,8 +4,7 @@ use crate::{
         hand::{HAND_WH, HandComponent, HandSlotId},
         mutate_game_state, use_game_state,
     },
-    icon::{Icon, IconKind, IconSize},
-    theme::button::Button,
+    theme::{button::{Button, ButtonVariant, ButtonColor}, typography::{TextAlign, headline}},
 };
 use namui::*;
 use namui_prebuilt::table;
@@ -63,25 +62,42 @@ impl Component for TowerPlacingHand {
                                 on_click: &select_tower,
                             });
                         }),
-                        table::fixed_no_clip(HAND_WH.height, |wh, ctx| {
-                            let padding = px(4.0);
-                            ctx.compose(|ctx| {
-                                table::padding(padding, |wh, ctx| {
-                                    ctx.add(Button::new(
-                                        wh,
-                                        &|| {
-                                            force_start();
-                                        },
-                                        &|wh, _text_color, ctx| {
-                                            ctx.add(Icon::new(IconKind::Up).size(IconSize::Large).wh(wh));
-                                        },
-                                    ));
-                                })(wh, ctx);
-                            });
-                        }),
                         table::ratio_no_clip(1, |_, _| {}),
                     ]),
                 ),
+                table::fixed_no_clip(60.px(), |wh, ctx| {
+                    ctx.compose(|ctx| {
+                        table::horizontal([
+                            table::ratio(1, |_, _| {}),
+                            table::fixed(120.px(), |wh, ctx| {
+                                let padding = px(8.0);
+                                ctx.compose(|ctx| {
+                                    table::padding(padding, |wh, ctx| {
+                                        ctx.add(
+                                            Button::new(
+                                                wh,
+                                                &|| {
+                                                    force_start();
+                                                },
+                                                &|wh, text_color, ctx| {
+                                                    ctx.add(
+                                                        headline("START")
+                                                            .color(text_color)
+                                                            .align(TextAlign::Center { wh })
+                                                            .build(),
+                                                    );
+                                                },
+                                            )
+                                            .variant(ButtonVariant::Contained)
+                                            .color(ButtonColor::Primary),
+                                        );
+                                    })(wh, ctx);
+                                });
+                            }),
+                            table::ratio(1, |_, _| {}),
+                        ])(wh, ctx);
+                    });
+                }),
             ])(screen_wh, ctx);
         });
     }

--- a/tower-defense/src/tower_placing_hand/mod.rs
+++ b/tower-defense/src/tower_placing_hand/mod.rs
@@ -94,7 +94,6 @@ impl Component for TowerPlacingHand {
                                     })(wh, ctx);
                                 });
                             }),
-                            table::ratio(1, |_, _| {}),
                         ])(wh, ctx);
                     });
                 }),

--- a/tower-defense/src/tower_selecting_hand/mod.rs
+++ b/tower-defense/src/tower_selecting_hand/mod.rs
@@ -81,6 +81,13 @@ impl Component for TowerSelectingHand {
                 state.goto_placing_tower(tower_template);
             });
         };
+
+        let force_start = || {
+            mutate_game_state(|game_state| {
+                game_state.hand.clear();
+                game_state.goto_defense();
+            });
+        };
         ctx.compose(|ctx| {
             table::vertical([
                 table::ratio_no_clip(1, |_, _| {}),
@@ -111,6 +118,7 @@ impl Component for TowerSelectingHand {
                                     some_selected: *some_selected,
                                     reroll_selected: &reroll_selected,
                                     use_tower: &use_tower,
+                                    force_start: &force_start,
                                 });
                             }),
                         ),
@@ -127,6 +135,7 @@ struct InteractionArea<'a> {
     some_selected: bool,
     reroll_selected: &'a dyn Fn(),
     use_tower: &'a dyn Fn(),
+    force_start: &'a dyn Fn(),
 }
 impl Component for InteractionArea<'_> {
     fn render(self, ctx: &RenderCtx) {
@@ -135,6 +144,7 @@ impl Component for InteractionArea<'_> {
             some_selected,
             reroll_selected,
             use_tower,
+            force_start,
         } = self;
         let game_state = crate::game_state::use_game_state(ctx);
         ctx.compose(|ctx| {
@@ -168,6 +178,18 @@ impl Component for InteractionArea<'_> {
                             )
                             .disabled(!some_selected || game_state.left_reroll_chance == 0),
                         );
+                    }),
+                    table::ratio(1, |_, _| {}),
+                    table::fixed(48.px(), |wh, ctx| {
+                        ctx.add(Button::new(
+                            wh,
+                            &|| {
+                                force_start();
+                            },
+                            &|wh, _text_color, ctx| {
+                                ctx.add(Icon::new(IconKind::Up).size(IconSize::Large).wh(wh));
+                            },
+                        ));
                     }),
                     table::ratio(1, |_, _| {}),
                     table::fixed(48.px(), |wh, ctx| {

--- a/tower-defense/src/tower_selecting_hand/mod.rs
+++ b/tower-defense/src/tower_selecting_hand/mod.rs
@@ -82,12 +82,6 @@ impl Component for TowerSelectingHand {
             });
         };
 
-        let force_start = || {
-            mutate_game_state(|game_state| {
-                game_state.hand.clear();
-                game_state.goto_defense();
-            });
-        };
         ctx.compose(|ctx| {
             table::vertical([
                 table::ratio_no_clip(1, |_, _| {}),
@@ -118,7 +112,6 @@ impl Component for TowerSelectingHand {
                                     some_selected: *some_selected,
                                     reroll_selected: &reroll_selected,
                                     use_tower: &use_tower,
-                                    force_start: &force_start,
                                 });
                             }),
                         ),
@@ -135,7 +128,6 @@ struct InteractionArea<'a> {
     some_selected: bool,
     reroll_selected: &'a dyn Fn(),
     use_tower: &'a dyn Fn(),
-    force_start: &'a dyn Fn(),
 }
 impl Component for InteractionArea<'_> {
     fn render(self, ctx: &RenderCtx) {
@@ -144,7 +136,6 @@ impl Component for InteractionArea<'_> {
             some_selected,
             reroll_selected,
             use_tower,
-            force_start,
         } = self;
         let game_state = crate::game_state::use_game_state(ctx);
         ctx.compose(|ctx| {
@@ -178,18 +169,6 @@ impl Component for InteractionArea<'_> {
                             )
                             .disabled(!some_selected || game_state.left_reroll_chance == 0),
                         );
-                    }),
-                    table::ratio(1, |_, _| {}),
-                    table::fixed(48.px(), |wh, ctx| {
-                        ctx.add(Button::new(
-                            wh,
-                            &|| {
-                                force_start();
-                            },
-                            &|wh, _text_color, ctx| {
-                                ctx.add(Icon::new(IconKind::Up).size(IconSize::Large).wh(wh));
-                            },
-                        ));
                     }),
                     table::ratio(1, |_, _| {}),
                     table::fixed(48.px(), |wh, ctx| {


### PR DESCRIPTION

<img width="819" height="193" alt="image" src="https://github.com/user-attachments/assets/77f5233a-774e-45be-aa56-d3aeacaf31b9" />


## Summary
- Add force start button in tower placement phase to allow starting defense without placing all towers
- Button displays as "START" text in compact design positioned to the right of tower cards
- Maintains original card centering while providing easy access to skip tower placement

## Changes
- Add START button to `TowerPlacingHand` component with Primary Contained style
- Position button in the same row as tower cards without affecting vertical layout
- Implement force start logic that clears remaining tower slots and transitions to defense phase
- Fix various code quality issues (remove unused screen_wh field, clippy warnings)

## Test plan
- [x] Verify START button appears in tower placement phase
- [x] Confirm button functionality skips to defense phase
- [x] Check that card layout remains centered and unaffected
- [x] Validate button positioning and styling

closes #1104

🤖 Generated with [Claude Code](https://claude.ai/code)