### PR TITLE
Fix inventory check logic for shop item purchases

### DIFF
--- a/tower-defense/src/game_state/event_handlers.rs
+++ b/tower-defense/src/game_state/event_handlers.rs
@@ -84,7 +84,7 @@ impl GameState {
                 if self.gold < *cost {
                     return;
                 }
-                if self.items.len() <= MAX_INVENTORY_SLOT {
+                if self.items.len() >= MAX_INVENTORY_SLOT {
                     return;
                 }
 


### PR DESCRIPTION
Changed condition from <= to >= to properly check if inventory is full. Previously, items could only be purchased when inventory was full, now they can be purchased when there's space available.

🤖 Generated with [Claude Code](https://claude.ai/code)

closes #1169