### PR TITLE
Fix draw_atlas sampling options causing image artifacts

### DIFF
--- a/namui/skia/src/canvas.rs
+++ b/namui/skia/src/canvas.rs
@@ -136,7 +136,10 @@ impl SkCanvas for skia_safe::Canvas {
             &skia_tex_rects,
             skia_colors.as_deref(),
             sprite_colors_blend_mode.into(),
-            skia_safe::SamplingOptions::default(),
+            skia_safe::SamplingOptions::new(
+                skia_safe::FilterMode::Linear,
+                skia_safe::MipmapMode::Linear,
+            ),
             None,
             skia_paint.as_ref(),
         );


### PR DESCRIPTION
closes #1254

## Summary
- `draw_atlas` was using `SamplingOptions::default()`, which resolves to `FilterMode::Nearest` + `MipmapMode::None`
- This caused aliasing artifacts when images are scaled
- Changed to `FilterMode::Linear` + `MipmapMode::Linear` to match the sampling quality used by `draw_image`

## Test plan
- [ ] Verify image artifacts in particle rendering are gone
- [x] Verify no moiré patterns or shimmer on downscaled sprites


Before

<img width="835" height="553" alt="image" src="https://github.com/user-attachments/assets/5869c01c-1ddf-4f31-a178-037cc0ed180d" />


After

<img width="1110" height="710" alt="image" src="https://github.com/user-attachments/assets/a059c05f-73ef-4dd5-9216-d6825efbb5f4" />
