### PR TITLE
Fix Windows build pipeline and add Steam build script

### DIFF
--- a/build-windows-steam.sh
+++ b/build-windows-steam.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v zip &> /dev/null; then
+    echo "ERROR: 'zip' is not installed. Install it with:"
+    echo "  sudo apt-get install -y zip"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR/tower-defense"
+BUILD_OUTPUT_DIR="$PROJECT_DIR/target/namui/x86_64-pc-windows-msvc"
+ZIP_NAME="tower-defense-windows-steam.zip"
+ZIP_PATH="$SCRIPT_DIR/$ZIP_NAME"
+
+echo "=== Building tower-defense for x86_64-pc-windows-msvc ==="
+namui build x86_64-pc-windows-msvc --manifest-path "$PROJECT_DIR/Cargo.toml" --release
+
+echo "=== Build complete ==="
+
+if [ ! -d "$BUILD_OUTPUT_DIR" ]; then
+    echo "ERROR: Build output directory not found: $BUILD_OUTPUT_DIR"
+    exit 1
+fi
+
+echo "=== Creating zip: $ZIP_NAME ==="
+rm -f "$ZIP_PATH"
+cd "$BUILD_OUTPUT_DIR"
+zip -r "$ZIP_PATH" .
+
+WINDOWS_DESKTOP="/mnt/c/Users/namse/Desktop"
+if [ -d "$WINDOWS_DESKTOP" ]; then
+    cp "$ZIP_PATH" "$WINDOWS_DESKTOP/$ZIP_NAME"
+    echo "=== Copied to Windows Desktop ==="
+fi
+
+echo "=== Done ==="
+echo "Output: $ZIP_PATH"
+echo "Size: $(du -h "$ZIP_PATH" | cut -f1)"

--- a/namui/asset-macro/src/lib.rs
+++ b/namui/asset-macro/src/lib.rs
@@ -253,7 +253,7 @@ pub fn register_assets(_input: TokenStream) -> TokenStream {
                 .unwrap()
                 .to_string();
             image_init_calls.push(quote! {
-                register_image(#id, #relative_path);
+                register_image(#id, #relative_path, &read_asset);
             });
         }
 
@@ -266,34 +266,23 @@ pub fn register_assets(_input: TokenStream) -> TokenStream {
                 .unwrap()
                 .to_string();
             audio_init_calls.push(quote! {
-                register_audio(#id, #relative_path);
+                register_audio(#id, #relative_path, &read_asset);
             });
         }
 
         quote! {
-            pub fn init_native_assets() {
+            pub fn init_native_assets(read_asset: impl Fn(&str) -> Vec<u8>) {
                 unsafe extern "C" {
                     fn _register_image(image_id: usize, buffer_ptr: *const u8, buffer_len: usize);
                     fn _register_audio(audio_id: usize, buffer_ptr: *const u8, buffer_len: usize);
                 }
-                fn asset_base_dir() -> std::path::PathBuf {
-                    std::env::current_exe()
-                        .expect("Failed to get current exe path")
-                        .parent()
-                        .unwrap()
-                        .join("asset")
-                }
-                fn register_image(id: usize, relative_path: &str) {
-                    let path = asset_base_dir().join(relative_path);
-                    let data = std::fs::read(&path)
-                        .unwrap_or_else(|e| panic!("Failed to read asset {}: {e}", path.display()));
+                fn register_image(id: usize, relative_path: &str, read_asset: &impl Fn(&str) -> Vec<u8>) {
+                    let data = read_asset(relative_path);
                     let leaked = Box::leak(data.into_boxed_slice());
                     unsafe { _register_image(id, leaked.as_ptr(), leaked.len()); }
                 }
-                fn register_audio(id: usize, relative_path: &str) {
-                    let path = asset_base_dir().join(relative_path);
-                    let data = std::fs::read(&path)
-                        .unwrap_or_else(|e| panic!("Failed to read audio asset {}: {e}", path.display()));
+                fn register_audio(id: usize, relative_path: &str, read_asset: &impl Fn(&str) -> Vec<u8>) {
+                    let data = read_asset(relative_path);
                     let leaked = Box::leak(data.into_boxed_slice());
                     unsafe { _register_audio(id, leaked.as_ptr(), leaked.len()); }
                 }

--- a/namui/namui-cli/src/main.rs
+++ b/namui/namui-cli/src/main.rs
@@ -3,16 +3,19 @@
 // temporary allow dead code for cross platform development. it will be removed when the project is stable.
 
 mod cli;
+mod procedures;
+mod services;
 mod start;
 mod types;
 mod util;
 
-use anyhow::Result;
+use anyhow::{anyhow, bail, Result};
 use clap::Parser;
-use cli::{Cli, Commands, Target};
+use cli::{Cli, Commands, StartOption, Target};
 use std::env::current_dir;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let cli = Cli::parse();
     let project_path = current_dir().expect("No current dir found");
 
@@ -28,8 +31,18 @@ fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Build {
+            target,
+            manifest_path,
+            release,
+        } => {
+            let target = target.unwrap_or(Target::X86_64PcWindowsMsvc);
+            let manifest_path =
+                manifest_path.unwrap_or_else(|| project_path.join("Cargo.toml"));
+            procedures::build(target, manifest_path, release).await?;
+        }
         _ => {
-            eprintln!("Only 'start' command is currently supported");
+            eprintln!("Command not yet supported");
             std::process::exit(1);
         }
     }

--- a/namui/namui-cli/src/procedures/mod.rs
+++ b/namui/namui-cli/src/procedures/mod.rs
@@ -11,7 +11,11 @@ mod test;
 pub mod windows;
 
 pub use build::*;
+#[allow(unused_imports)]
 pub use check::*;
+#[allow(unused_imports)]
 pub use clippy::*;
+#[allow(unused_imports)]
 pub use start::*;
+#[allow(unused_imports)]
 pub use test::*;

--- a/namui/namui-cli/src/services/bundle/bundle_to_sqlite.rs
+++ b/namui/namui-cli/src/services/bundle/bundle_to_sqlite.rs
@@ -19,7 +19,12 @@ pub fn bundle_to_sqlite(
 ) -> Result<()> {
     let sqlite_path = sqlite_path.as_ref().to_path_buf();
     create_dir_all(sqlite_path.parent().unwrap())?;
-    let create_conn = || Connection::open(&sqlite_path).unwrap();
+    let create_conn = || {
+        let conn = Connection::open(&sqlite_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+        conn.busy_timeout(std::time::Duration::from_secs(30)).unwrap();
+        conn
+    };
     let conn = create_conn();
     let has_changes = Arc::new(AtomicBool::new(false));
 

--- a/namui/namui-cli/src/services/mod.rs
+++ b/namui/namui-cli/src/services/mod.rs
@@ -7,4 +7,4 @@ pub mod runtime_project;
 pub mod rust_build_service;
 pub mod rust_project_watch_service;
 pub mod vite_config;
-pub mod wasi_cargo_envs;
+pub use crate::start::wasi_cargo_envs;

--- a/namui/namui-cli/src/services/resource_collect_service.rs
+++ b/namui/namui-cli/src/services/resource_collect_service.rs
@@ -89,7 +89,7 @@ fn collect_dir_recursive(
         if path.is_dir() {
             collect_dir_recursive(ops, &path, &dest_prefix.join(&file_name))?;
         } else {
-            ops.push(CollectOperation::new(&path, dest_prefix.clone()));
+            ops.push(CollectOperation::new(&path, dest_prefix));
         }
     }
     Ok(())

--- a/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
+++ b/namui/namui-cli/src/services/runtime_project/x86_64_pc_windows_msvc.rs
@@ -30,18 +30,24 @@ pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> 
         })
     });
 
-    // Derive native-runner path from namui path (sibling directory)
-    let native_runner_path_in_relative = namui_abs_path.as_ref().and_then(|namui_canonical| {
-        let parent = namui_canonical.parent()?;
-        let runner_path = parent.join("native-runner");
-        pathdiff::diff_paths(&runner_path, &args.target_dir).map(|p| {
-            p.to_str()
-                .unwrap()
-                .split('\\')
-                .collect::<Vec<&str>>()
-                .join("/")
+    // Helper to derive sibling paths from namui parent directory
+    let sibling_path = |dir_name: &str| -> Option<String> {
+        namui_abs_path.as_ref().and_then(|namui_canonical| {
+            let parent = namui_canonical.parent()?;
+            let sibling = parent.join(dir_name);
+            pathdiff::diff_paths(&sibling, &args.target_dir).map(|p| {
+                p.to_str()
+                    .unwrap()
+                    .split('\\')
+                    .collect::<Vec<&str>>()
+                    .join("/")
+            })
         })
-    });
+    };
+
+    let native_runner_path_in_relative = sibling_path("native-runner");
+    let audio_native_path_in_relative = sibling_path("audio-native");
+    let kv_store_native_path_in_relative = sibling_path("kv-store-native");
 
     match args.mode {
         RuntimeProjectMode::Binary => {
@@ -51,6 +57,8 @@ pub fn generate_runtime_project(args: GenerateRuntimeProjectArgs) -> Result<()> 
                 &project_path_str,
                 namui_path_in_relative.as_deref(),
                 native_runner_path_in_relative.as_deref(),
+                audio_native_path_in_relative.as_deref(),
+                kv_store_native_path_in_relative.as_deref(),
             )?;
         }
         RuntimeProjectMode::Cdylib => {
@@ -72,6 +80,8 @@ fn generate_binary_project(
     project_path: &str,
     namui_path: Option<&str>,
     native_runner_path: Option<&str>,
+    audio_native_path: Option<&str>,
+    kv_store_native_path: Option<&str>,
 ) -> Result<()> {
     let namui_dep = if let Some(path) = namui_path {
         format!(r#"namui = {{ path = "{path}" }}"#)
@@ -81,6 +91,18 @@ fn generate_binary_project(
 
     let native_runner_dep = if let Some(path) = native_runner_path {
         format!(r#"native-runner = {{ path = "{path}" }}"#)
+    } else {
+        String::new()
+    };
+
+    let audio_native_dep = if let Some(path) = audio_native_path {
+        format!(r#"namui-audio-native = {{ path = "{path}" }}"#)
+    } else {
+        String::new()
+    };
+
+    let kv_store_native_dep = if let Some(path) = kv_store_native_path {
+        format!(r#"namui-kv-store-native = {{ path = "{path}" }}"#)
     } else {
         String::new()
     };
@@ -97,7 +119,10 @@ edition = "2024"
 {project_name} = {{ path = "{project_path}" }}
 {namui_dep}
 {native_runner_dep}
+{audio_native_dep}
+{kv_store_native_dep}
 mimalloc = "0.1.39"
+rusqlite = {{ version = "0.31.0", features = ["blob", "bundled"] }}
 
 [profile.release]
 opt-level = 3
@@ -122,9 +147,78 @@ opt-level = 2
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {{
+    let exe_dir = std::env::current_exe()
+        .expect("Failed to get current exe path")
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let bundle_path = exe_dir.join("bundle.sqlite");
+    {project_name_underscored}::asset::init_native_assets(|relative_path| {{
+        use std::io::Read;
+        let asset_path = format!("asset/{{}}", relative_path);
+        let conn = rusqlite::Connection::open_with_flags(
+            &bundle_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        ).unwrap_or_else(|e| panic!("Failed to open bundle.sqlite: {{e}}"));
+        let rowid: i64 = conn.query_row(
+            "SELECT rowid FROM bundle WHERE path = ?",
+            [&asset_path],
+            |row| row.get(0),
+        ).unwrap_or_else(|e| panic!("Asset not found in bundle '{{}}': {{e}}", asset_path));
+        let mut blob = conn.blob_open(
+            rusqlite::DatabaseName::Main,
+            "bundle",
+            "data",
+            rowid,
+            true,
+        ).unwrap_or_else(|e| panic!("Failed to open blob for '{{}}': {{e}}", asset_path));
+        let mut data = vec![0u8; blob.len()];
+        blob.read_exact(&mut data)
+            .unwrap_or_else(|e| panic!("Failed to read blob for '{{}}': {{e}}", asset_path));
+        data
+    }});
     {project_name_underscored}::main();
     native_runner::run();
 }}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn namui_main() {{
+    // Already called from main(), this is a no-op for binary mode.
+}}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _dylib_image_buffer_list(out: *mut usize, max_count: usize) -> usize {{
+    let list = namui::image_buffer_list();
+    let count = list.len().min(max_count);
+    let out = unsafe {{ std::slice::from_raw_parts_mut(out, count * 3) }};
+    for (i, [id, ptr, len]) in list.iter().enumerate().take(count) {{
+        out[i * 3] = *id;
+        out[i * 3 + 1] = *ptr;
+        out[i * 3 + 2] = *len;
+    }}
+    count
+}}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _dylib_register_font(
+    name_ptr: *const u8,
+    name_len: usize,
+    buffer_ptr: *const u8,
+    buffer_len: usize,
+) {{
+    let name = unsafe {{ std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, name_len)) }};
+    let bytes = unsafe {{ std::slice::from_raw_parts(buffer_ptr, buffer_len) }};
+    namui::NativeTypeface::load(name, bytes)
+        .unwrap_or_else(|e| panic!("Failed to load font {{name}}: {{e}}"));
+}}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _dylib_set_image_infos(ptr: *const u8, count: usize) {{
+    unsafe {{ namui::_set_image_infos(ptr, count) }};
+}}
+
+extern crate namui_audio_native;
+extern crate namui_kv_store_native;
 "#
             ),
         )?;

--- a/namui/namui-cli/src/start/dylib_wrapper.rs
+++ b/namui/namui-cli/src/start/dylib_wrapper.rs
@@ -51,7 +51,16 @@ debug = "line-tables-only"
         format!(
             r#"#[unsafe(no_mangle)]
 pub extern "C" fn namui_main() {{
-    {project_name_underscored}::asset::init_native_assets();
+    let asset_dir = std::env::current_exe()
+        .expect("Failed to get current exe path")
+        .parent()
+        .unwrap()
+        .join("asset");
+    {project_name_underscored}::asset::init_native_assets(|relative_path| {{
+        let path = asset_dir.join(relative_path);
+        std::fs::read(&path)
+            .unwrap_or_else(|e| panic!("Failed to read asset {{}}: {{e}}", path.display()))
+    }});
     {project_name_underscored}::main();
 }}
 

--- a/namui/namui-cli/src/start/mod.rs
+++ b/namui/namui-cli/src/start/mod.rs
@@ -1,7 +1,7 @@
 mod app_wrapper;
 mod dylib_wrapper;
 pub mod mac;
-mod wasi_cargo_envs;
+pub mod wasi_cargo_envs;
 mod watcher;
 
 use crate::{util::get_cli_root_path, *};

--- a/namui/namui-cli/src/util/mod.rs
+++ b/namui/namui-cli/src/util/mod.rs
@@ -1,9 +1,11 @@
 #[macro_use]
 mod debug_println;
 mod get_cli_root_path;
+mod print_build_result;
 mod recreate_dir_all;
 
 #[allow(unused_imports)]
 pub use debug_println::*;
 pub use get_cli_root_path::*;
+pub use print_build_result::*;
 pub use recreate_dir_all::*;


### PR DESCRIPTION
## Summary
- Fix `namui build` command that was disconnected from `main.rs` after recent CLI refactor
- Fix Windows binary build template: add missing `namui-audio-native`, `namui-kv-store-native` dependencies and required FFI symbol definitions (`namui_main`, `_dylib_image_buffer_list`, `_dylib_set_image_infos`, `_dylib_register_font`)
- Change `init_native_assets()` to accept a reader closure, so binary builds read assets from `bundle.sqlite` instead of individual files (which aren't shipped)
- Fix SQLite concurrent write locking in `bundle_to_sqlite` with WAL mode and busy_timeout (fixes WSL build failures)
- Fix `wasi_cargo_envs` and `print_build_result` module path issues
- Add `build-windows-steam.sh` script for one-command Windows build + zip packaging for Steam web upload

## Test plan
- [x] `namui build x86_64-pc-windows-msvc --release` completes successfully on Linux (WSL)
- [x] Run the built `.exe` on Windows and verify the game launches
- [ ] Run `build-windows-steam.sh` end-to-end and verify the zip output

🤖 Generated with [Claude Code](https://claude.com/claude-code)