### PR TITLE
fix(namui-drawer): reset frame arena on each rendering tree decode (#1294)

### DIFF
--- a/namui/namui-drawer/src/lib.rs
+++ b/namui/namui-drawer/src/lib.rs
@@ -12,6 +12,12 @@ thread_local! {
 }
 
 /// Draw a rendering tree directly (for native targets).
+///
+/// The caller (typically a `World::run_impl` frame) owns the arena lifecycle:
+/// the same thread's next `World::run_impl` will reset the arena and any
+/// references the slot still holds become dangling. Callers must guarantee a
+/// fresh `draw_rendering_tree` call follows before the next `redraw`, or
+/// stash the tree somewhere else.
 pub fn draw_rendering_tree(
     skia: &mut NativeSkia,
     rendering_tree: RenderingTree,

--- a/namui/namui-drawer/src/main.rs
+++ b/namui/namui-drawer/src/main.rs
@@ -70,10 +70,10 @@ mod wasi_ffi {
         let slice = unsafe {
             std::slice::from_raw_parts(rendering_tree_bytes_ptr, rendering_tree_bytes_len)
         };
-        let (rendering_tree, _): (RenderingTree, usize) =
-            bincode::decode_from_slice(slice, bincode::config::standard()).unwrap();
-        RENDERING_TREE.with(|rendering_tree_cell| {
-            *rendering_tree_cell.borrow_mut() = Some(rendering_tree);
+        swap_arena_slot(&RENDERING_TREE, || {
+            let (rendering_tree, _): (RenderingTree, usize) =
+                bincode::decode_from_slice(slice, bincode::config::standard()).unwrap();
+            rendering_tree
         });
         unsafe { _redraw(mouse_x, mouse_y) };
     }

--- a/namui/namui-hooks/src/world/mod.rs
+++ b/namui/namui-hooks/src/world/mod.rs
@@ -395,6 +395,7 @@ impl World {
         self.rendered_composer_count.set(0);
         self.compose_command_arena.get_mut().clear();
         reset_render_arena();
+        let _arena_scope = enter_arena_scope();
         self.reset_updated_sig_ids();
         self.handle_set_states();
 

--- a/namui/rendering-tree/src/arena.rs
+++ b/namui/rendering-tree/src/arena.rs
@@ -142,10 +142,7 @@ pub fn reset_render_arena() {
 /// valid until the next `swap_arena_slot` call on the same slot. This is the
 /// pattern for receivers (e.g. the wasm drawer) that need to keep the most
 /// recent decoded tree alive across cheap "redraw with last tree" calls.
-pub fn swap_arena_slot<T>(
-    slot: &'static LocalKey<RefCell<Option<T>>>,
-    build: impl FnOnce() -> T,
-) {
+pub fn swap_arena_slot<T>(slot: &'static LocalKey<RefCell<Option<T>>>, build: impl FnOnce() -> T) {
     slot.with(|cell| {
         *cell.borrow_mut() = None;
     });

--- a/namui/rendering-tree/src/arena.rs
+++ b/namui/rendering-tree/src/arena.rs
@@ -1,5 +1,6 @@
 use bumpalo::Bump;
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::{Cell, RefCell, UnsafeCell};
+use std::thread::LocalKey;
 
 type DropEntry = (*mut u8, unsafe fn(*mut u8));
 
@@ -13,6 +14,7 @@ thread_local! {
         bump: UnsafeCell::new(Bump::new()),
         drops: RefCell::new(Vec::new()),
     };
+    static SCOPE_ACTIVE: Cell<bool> = const { Cell::new(false) };
 }
 
 unsafe fn drop_in_place_as<T>(ptr: *mut u8) {
@@ -29,6 +31,49 @@ fn with_arena<R>(f: impl FnOnce(&'static RenderArena) -> R) -> R {
     })
 }
 
+fn debug_assert_scope_active() {
+    debug_assert!(
+        SCOPE_ACTIVE.with(|s| s.get()),
+        "arena_alloc/arena_alloc_slice called outside an arena scope. \
+         Wrap the entry point with `swap_arena_slot`, or hold an `ArenaScopeGuard` \
+         around the build (see `enter_arena_scope`)."
+    );
+}
+
+/// RAII guard that marks the current thread as inside an arena scope.
+///
+/// While the guard is alive, `arena_alloc`/`arena_alloc_slice` are permitted.
+/// On drop, the scope flag is cleared but the arena is **not** reset — any
+/// `&'static` references handed out by allocs during the scope remain valid
+/// until the next [`reset_render_arena`] call (typically performed by the next
+/// scope's setup or by `swap_arena_slot`).
+#[must_use = "ArenaScopeGuard clears the scope flag on drop"]
+pub struct ArenaScopeGuard {
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl Drop for ArenaScopeGuard {
+    fn drop(&mut self) {
+        SCOPE_ACTIVE.with(|s| s.set(false));
+    }
+}
+
+/// Opens an arena scope on the current thread. Nested scopes panic.
+///
+/// Pair this with a prior `reset_render_arena()` if the caller wants a fresh
+/// arena for the scope; otherwise the new allocs share the existing arena
+/// memory. The returned guard must be kept alive for the duration of the
+/// allocations.
+pub fn enter_arena_scope() -> ArenaScopeGuard {
+    SCOPE_ACTIVE.with(|s| {
+        assert!(!s.get(), "nested arena scope is not allowed");
+        s.set(true);
+    });
+    ArenaScopeGuard {
+        _not_send: std::marker::PhantomData,
+    }
+}
+
 /// Allocates a value in the per-thread frame render arena.
 ///
 /// # Safety contract
@@ -36,6 +81,7 @@ fn with_arena<R>(f: impl FnOnce(&'static RenderArena) -> R) -> R {
 /// call on the same thread. Callers must not read it across a frame boundary
 /// or move it to another thread.
 pub fn arena_alloc<T>(value: T) -> &'static T {
+    debug_assert_scope_active();
     with_arena(|arena| {
         let bump = unsafe { &*arena.bump.get() };
         let allocated: &'static mut T = bump.alloc(value);
@@ -57,6 +103,7 @@ where
     I::IntoIter: ExactSizeIterator,
 {
     debug_assert!(!std::mem::needs_drop::<T>());
+    debug_assert_scope_active();
     with_arena(|arena| {
         let bump = unsafe { &*arena.bump.get() };
         bump.alloc_slice_fill_iter(values)
@@ -79,4 +126,33 @@ pub fn reset_render_arena() {
             (*arena.bump.get()).reset();
         }
     })
+}
+
+/// Swaps the value held by a thread-local slot, replacing any arena-borrowing
+/// payload safely:
+///
+/// 1. drop the slot's current value (releasing every `&'static` it held into
+///    the arena),
+/// 2. reset the arena (now no references remain pointing into it),
+/// 3. open an arena scope and run `build` to produce a new value (which may
+///    `arena_alloc` freely),
+/// 4. store the new value back into the slot.
+///
+/// The arena is **not** reset on exit — the new value's arena references stay
+/// valid until the next `swap_arena_slot` call on the same slot. This is the
+/// pattern for receivers (e.g. the wasm drawer) that need to keep the most
+/// recent decoded tree alive across cheap "redraw with last tree" calls.
+pub fn swap_arena_slot<T>(
+    slot: &'static LocalKey<RefCell<Option<T>>>,
+    build: impl FnOnce() -> T,
+) {
+    slot.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+    reset_render_arena();
+    let _scope = enter_arena_scope();
+    let new = build();
+    slot.with(|cell| {
+        *cell.borrow_mut() = Some(new);
+    });
 }

--- a/namui/rendering-tree/src/decode.rs
+++ b/namui/rendering-tree/src/decode.rs
@@ -151,6 +151,7 @@ mod tests {
 
     #[test]
     fn rendering_tree_encode_decode_round_trip() {
+        let _scope = enter_arena_scope();
         let tree = RenderingTree::Children(arena_alloc_slice(vec![
             RenderingTree::Empty,
             RenderingTree::Special(SpecialRenderingNode::Translate(TranslateNode {

--- a/namui/rendering-tree/src/xy_in/rendering_tree.rs
+++ b/namui/rendering-tree/src/xy_in/rendering_tree.rs
@@ -216,6 +216,7 @@ mod tests {
 
     #[test]
     fn rln_visiting_order_should_be_rln() {
+        let _scope = enter_arena_scope();
         /*
             tree:
                  0
@@ -257,6 +258,7 @@ mod tests {
 
     #[test]
     fn to_local_xy_should_work() {
+        let _scope = enter_arena_scope();
         /*
             tree:
                    0
@@ -364,6 +366,7 @@ mod tests {
     }
     #[test]
     fn to_local_xy_should_work_with_matrix_transform() {
+        let _scope = enter_arena_scope();
         /*
             tree:
                    0
@@ -449,6 +452,7 @@ mod tests {
 
     #[test]
     fn to_local_xy_translate_scale_translate_test() {
+        let _scope = enter_arena_scope();
         let node_2 = crate::translate(px(2.0), px(2.0), dummy_leaf());
         let node_1 = crate::scale(2.0, 2.0, RenderingTree::wrap([node_2]));
         let node_0 = crate::translate(px(2.0), px(2.0), RenderingTree::wrap([node_1]));
@@ -515,6 +519,7 @@ mod tests {
 
     #[test]
     fn to_local_xy_translate_after_scale_test() {
+        let _scope = enter_arena_scope();
         let node_1 = crate::translate(px(2.0), px(2.0), dummy_leaf());
         let node_0 = crate::scale(2.0, 2.0, RenderingTree::wrap([node_1]));
 
@@ -579,6 +584,7 @@ mod tests {
 
     #[test]
     fn with_ancestors_should_give_right_ancestors() {
+        let _scope = enter_arena_scope();
         /*
             tree:
                  0


### PR DESCRIPTION
## Problem

`namui-drawer`'s `_draw_rendering_tree` decoded each frame's RenderingTree into the per-thread frame arena (`namui_rendering_tree::arena`) but **never called `reset_render_arena()`**. The arena grew unbounded across frames until Skia's `sk_malloc_flags` failed and aborted (~2 minutes in tower-defense). Stack trace in #1294 matches exactly:

```
abort
└ sk_malloc_flags
  └ SkArenaAlloc::ensureSpace
    └ ...
      └ NativeSurface::flush
        └ _draw_rendering_tree
```

`World::run_impl` already resets the arena every frame on the game side, so the leak was drawer-only.

## Fix

Two lifecycle helpers in `namui-rendering-tree::arena`:

- **`enter_arena_scope() -> ArenaScopeGuard`** — RAII guard that sets a thread-local active flag. `arena_alloc` / `arena_alloc_slice` `debug_assert` the flag is set, so any future missed scope surfaces as a panic on the first alloc, not as a delayed OOM.
- **`swap_arena_slot(slot, build)`** — encapsulates the receiver pattern: drop the slot's old value (releasing its `&'static` arena refs), reset the arena, open a scope, run `build`, store the new value in the slot. The arena is *not* reset on exit, so subsequent "redraw with last tree" calls keep reading the same data.

Applied:

- `World::run_impl`: one-line `let _arena_scope = enter_arena_scope();` right after the existing reset. Lifecycle unchanged.
- `_draw_rendering_tree`: decode/stash wrapped in `swap_arena_slot(&RENDERING_TREE, || decode(slice))`.
- `draw_rendering_tree` (native): kept as-is. The caller's frame owns the arena lifecycle; calling `swap_arena_slot` here would dangle the tree the caller just passed in. Doc comment added.
- Tests that build RenderingTree fragments by hand open a local arena scope at the top.

## Verification

`namui start tower-defense` → 4m 20s of idle observation via `performance.measureUserAgentSpecificMemory()` (Vite COOP/COEP enabled, so wasm linear memory is counted):

| t | total | jsHeap |
|---|-------|--------|
| 0 s | 194.40 MB | 18.23 MB |
| 20 s | 198.45 MB | 19.98 MB |
| 260 s | 198.34 MB | 12.80 MB |

After a one-shot ~4 MB warmup, total memory stays within ±0.3 MB for the entire window. Previously the same test would have crashed at ~2 minutes. Canvas backing (84 MB in the last sample, the bulk of wasm linear memory) is flat. No panic / abort in the console.

`cargo test -p namui-rendering-tree`: 17/17 pass. `cargo test -p namui-hooks`: 45/46 pass — the one failure (`interval_should_work`) is unrelated and reproduces on `arena/on-master` HEAD without this PR.

## Trade-offs considered

- **Add lifetime parameters to RenderingTree** (stop pretending arena refs are `'static`): would let rustc statically catch use-after-reset, but breaks the "Copy and lifetime-free" design `b46bf175` deliberately introduced and would propagate `'a` through `Component`, `Ctx`, hooks, and user code. Rejected.
- **Drop the arena scope check** (only add the helpers, no panic guard): simpler but loses the "missed scope = immediate panic" property that makes future regressions visible right away. Rejected.
- The `debug_assert` is release no-op so the production wasm path is unchanged.

Fixes #1294
