### PR TITLE
Fix inverted camera zoom direction in windows build (#1291)

### DIFF
--- a/namui/native-runner/src/lib.rs
+++ b/namui/native-runner/src/lib.rs
@@ -251,8 +251,8 @@ impl ApplicationHandler for NamuiApp {
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 let (dx, dy) = match delta {
-                    winit::event::MouseScrollDelta::LineDelta(x, y) => (x * 100.0, y * 100.0),
-                    winit::event::MouseScrollDelta::PixelDelta(d) => (d.x as f32, d.y as f32),
+                    winit::event::MouseScrollDelta::LineDelta(x, y) => (-x * 100.0, -y * 100.0),
+                    winit::event::MouseScrollDelta::PixelDelta(d) => (-d.x as f32, -d.y as f32),
                 };
                 let (mx, my) = MOUSE_STATE.with(|s| {
                     let s = s.borrow();


### PR DESCRIPTION
## Summary
- Negate winit mouse wheel delta in `native-runner` so windows build zoom matches browser DOM convention.

Fixes #1291

## Test plan
- [ ] Verify camera zoom direction in windows build matches browser behavior