### PR TITLE
feat(namui-cli): support macOS → Windows cross-compilation

### DIFF
--- a/namui/namui-cli/README.md
+++ b/namui/namui-cli/README.md
@@ -19,6 +19,23 @@ rustup target add x86_64-pc-windows-msvc
 cargo install cargo-xwin
 ```
 
+### macOS → Windows cross-compilation
+
+To cross-compile for `x86_64-pc-windows-msvc` from macOS, install the following:
+
+```bash
+# LLVM (provides clang-cl, llvm-lib, lld-link)
+brew install llvm
+
+# Make clang-cl / llvm-lib / lld-link discoverable on PATH.
+# Add to your shell rc (zshrc/bashrc):
+export PATH="$(brew --prefix llvm)/bin:$PATH"
+
+# Rust target and cargo-xwin
+rustup target add x86_64-pc-windows-msvc
+cargo install cargo-xwin
+```
+
 ## Troubleshooting
 
 -   **If you encounter errors related to `std` or `core` not being found when targeting `wasm32-wasi-web` for `start` or `build` commands:**

--- a/namui/namui-cli/src/procedures/build.rs
+++ b/namui/namui-cli/src/procedures/build.rs
@@ -30,6 +30,9 @@ pub async fn build(target: Target, manifest_path: PathBuf, release: bool) -> Res
                 Target::Aarch64AppleDarwin => {
                     macos::aarch64_apple_darwin::build(&manifest_path, release).await?
                 }
+                Target::X86_64PcWindowsMsvc => {
+                    macos::x86_64_pc_windows_msvc::build(&manifest_path, release).await?
+                }
                 _ => unimplemented!(),
             }
         }

--- a/namui/namui-cli/src/procedures/check.rs
+++ b/namui/namui-cli/src/procedures/check.rs
@@ -33,7 +33,7 @@ pub async fn check(target: Target, manifest_path: PathBuf) -> Result<()> {
         }
         Target::X86_64PcWindowsMsvc => {
             let mut args = vec![];
-            if cfg!(target_os = "linux") {
+            if cfg!(any(target_os = "linux", target_os = "macos")) {
                 args.push("xwin");
             }
 
@@ -46,7 +46,7 @@ pub async fn check(target: Target, manifest_path: PathBuf) -> Result<()> {
                 "--tests",
             ]);
 
-            if cfg!(target_os = "linux") {
+            if cfg!(any(target_os = "linux", target_os = "macos")) {
                 args.extend([
                     "--xwin-arch",
                     "x86_64",

--- a/namui/namui-cli/src/procedures/clippy.rs
+++ b/namui/namui-cli/src/procedures/clippy.rs
@@ -33,7 +33,7 @@ pub async fn clippy(target: Target, manifest_path: PathBuf) -> Result<()> {
         }
         Target::X86_64PcWindowsMsvc => {
             let mut args = vec![];
-            if cfg!(target_os = "linux") {
+            if cfg!(any(target_os = "linux", target_os = "macos")) {
                 args.push("xwin");
             }
 
@@ -46,7 +46,7 @@ pub async fn clippy(target: Target, manifest_path: PathBuf) -> Result<()> {
                 "--tests",
             ]);
 
-            if cfg!(target_os = "linux") {
+            if cfg!(any(target_os = "linux", target_os = "macos")) {
                 args.extend([
                     "--xwin-arch",
                     "x86_64",

--- a/namui/namui-cli/src/procedures/macos/mod.rs
+++ b/namui/namui-cli/src/procedures/macos/mod.rs
@@ -1,2 +1,3 @@
 pub mod aarch64_apple_darwin;
 pub mod wasm32_wasi_web;
+pub mod x86_64_pc_windows_msvc;

--- a/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/build.rs
+++ b/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/build.rs
@@ -1,0 +1,64 @@
+use crate::{
+    services::{
+        build_status_service::{BuildStatusCategory, BuildStatusService},
+        resource_collect_service,
+        runtime_project::{
+            RuntimeProjectMode, x86_64_pc_windows_msvc::generate_runtime_project,
+        },
+        rust_build_service::{self, BuildOption},
+    },
+    *,
+};
+
+pub async fn build(manifest_path: impl AsRef<std::path::Path>, release: bool) -> Result<()> {
+    let manifest_path = manifest_path.as_ref();
+    let target = cli::Target::X86_64PcWindowsMsvc;
+    let project_root_path = manifest_path.parent().unwrap().to_path_buf();
+    let release_path = project_root_path
+        .join("target")
+        .join("namui")
+        .join("x86_64-pc-windows-msvc");
+    let runtime_target_dir = project_root_path.join("target/namui");
+
+    generate_runtime_project(services::runtime_project::GenerateRuntimeProjectArgs {
+        target_dir: runtime_target_dir.clone(),
+        project_path: project_root_path.clone(),
+        strip_debug_info: true,
+        mode: RuntimeProjectMode::Binary,
+    })?;
+
+    let build_status_service = BuildStatusService::new();
+
+    build_status_service
+        .build_started(services::build_status_service::BuildStatusCategory::Namui)
+        .await;
+
+    let cargo_build_output = rust_build_service::build(BuildOption {
+        target: cli::Target::X86_64PcWindowsMsvc,
+        project_root_path: runtime_target_dir,
+        watch: false,
+        release,
+    })
+    .await??;
+    build_status_service
+        .build_finished(
+            BuildStatusCategory::Namui,
+            cargo_build_output.error_messages,
+            vec![],
+        )
+        .await;
+
+    let bundle_manifest =
+        crate::services::bundle::NamuiBundleManifest::parse(project_root_path.clone())?;
+
+    resource_collect_service::collect_all(
+        &project_root_path,
+        &release_path,
+        target,
+        bundle_manifest,
+        None,
+        release,
+    )?;
+
+    Ok(())
+}

--- a/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/mod.rs
+++ b/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/mod.rs
@@ -1,0 +1,7 @@
+mod build;
+mod start;
+mod test;
+
+pub use build::build;
+pub use start::start;
+pub use test::test;

--- a/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/start.rs
+++ b/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/start.rs
@@ -1,0 +1,83 @@
+use crate::cli::Target;
+use crate::*;
+use services::build_status_service::{BuildStatusCategory, BuildStatusService};
+use services::runtime_project::{
+    GenerateRuntimeProjectArgs, RuntimeProjectMode,
+    x86_64_pc_windows_msvc::generate_runtime_project,
+};
+use services::rust_build_service::{self, BuildOption};
+use services::rust_project_watch_service::RustProjectWatchService;
+
+pub async fn start(
+    manifest_path: impl AsRef<std::path::Path>,
+    start_option: StartOption,
+) -> Result<()> {
+    let manifest_path = manifest_path.as_ref();
+    let target = Target::X86_64PcWindowsMsvc;
+    let project_root_path = manifest_path.parent().unwrap().to_path_buf();
+    let build_status_service = BuildStatusService::new();
+    let runtime_target_dir = project_root_path.join("target/namui");
+    let bundle_path = {
+        let opt_level = match start_option.release {
+            true => "release",
+            false => "debug",
+        };
+        project_root_path
+            .join("target")
+            .join("namui")
+            .join("target")
+            .join("x86_64-pc-windows-msvc")
+            .join(opt_level)
+            .join("bundle.sqlite")
+    };
+
+    generate_runtime_project(GenerateRuntimeProjectArgs {
+        target_dir: runtime_target_dir.clone(),
+        project_path: project_root_path.clone(),
+        strip_debug_info: start_option.strip_debug_info,
+        mode: RuntimeProjectMode::Binary,
+    })?;
+
+    build_status_service
+        .build_started(BuildStatusCategory::Namui)
+        .await;
+    let result = rust_build_service::build(BuildOption {
+        target,
+        project_root_path: runtime_target_dir.clone(),
+        release: start_option.release,
+        watch: false,
+    })
+    .await??;
+    let bundle_manifest =
+        crate::services::bundle::NamuiBundleManifest::parse(project_root_path.clone())?;
+    bundle_manifest.bundle_to_sqlite(&bundle_path)?;
+    build_status_service
+        .build_finished(BuildStatusCategory::Namui, result.error_messages, vec![])
+        .await;
+    println!(
+        "In this environment, namui does not run built binary. It works like `build --watch`. Run the binary yourself"
+    );
+
+    let mut rust_project_watch = RustProjectWatchService::new(manifest_path)?;
+
+    while let Some(()) = rust_project_watch.next().await? {
+        build_status_service
+            .build_started(BuildStatusCategory::Namui)
+            .await;
+        let result = rust_build_service::build(BuildOption {
+            target,
+            project_root_path: runtime_target_dir.clone(),
+            release: start_option.release,
+            watch: false,
+        })
+        .await??;
+        let bundle_manifest =
+            crate::services::bundle::NamuiBundleManifest::parse(project_root_path.clone())?;
+        bundle_manifest.bundle_to_sqlite(&bundle_path)?;
+        build_status_service
+            .build_finished(BuildStatusCategory::Namui, result.error_messages, vec![])
+            .await;
+    }
+
+    Ok(())
+}

--- a/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/test.rs
+++ b/namui/namui-cli/src/procedures/macos/x86_64_pc_windows_msvc/test.rs
@@ -1,0 +1,21 @@
+use crate::*;
+use std::process::Command;
+
+pub fn test(manifest_path: impl AsRef<std::path::Path>) -> Result<()> {
+    Command::new("cargo")
+        .args([
+            "xwin",
+            "test",
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "--xwin-arch",
+            "x86_64",
+            "--xwin-version",
+            "17",
+            "--cross-compiler",
+            "clang",
+        ])
+        .status()?;
+
+    Ok(())
+}

--- a/namui/namui-cli/src/procedures/start.rs
+++ b/namui/namui-cli/src/procedures/start.rs
@@ -34,6 +34,9 @@ pub async fn start(
                 Target::Aarch64AppleDarwin => {
                     macos::aarch64_apple_darwin::start(&manifest_path, start_option).await?
                 }
+                Target::X86_64PcWindowsMsvc => {
+                    macos::x86_64_pc_windows_msvc::start(&manifest_path, start_option).await?
+                }
                 _ => unimplemented!(),
             }
         }

--- a/namui/namui-cli/src/procedures/test.rs
+++ b/namui/namui-cli/src/procedures/test.rs
@@ -28,6 +28,9 @@ pub fn test(target: Target, manifest_path: PathBuf) -> Result<()> {
             match target {
                 Target::Wasm32WasiWeb => macos::wasm32_wasi_web::test(&manifest_path)?,
                 Target::Aarch64AppleDarwin => macos::aarch64_apple_darwin::test(&manifest_path)?,
+                Target::X86_64PcWindowsMsvc => {
+                    macos::x86_64_pc_windows_msvc::test(&manifest_path)?
+                }
                 _ => unimplemented!(),
             }
         }

--- a/namui/namui-cli/src/services/rust_build_service.rs
+++ b/namui/namui-cli/src/services/rust_build_service.rs
@@ -59,7 +59,7 @@ async fn run_build_process(build_option: &BuildOption) -> Result<Output> {
         }
         Target::X86_64PcWindowsMsvc => {
             let mut args = vec![];
-            if cfg!(target_os = "linux") {
+            if cfg!(any(target_os = "linux", target_os = "macos")) {
                 args.push("xwin");
             }
 
@@ -75,7 +75,7 @@ async fn run_build_process(build_option: &BuildOption) -> Result<Output> {
                 args.push("--release");
             }
 
-            if cfg!(target_os = "linux") {
+            if cfg!(any(target_os = "linux", target_os = "macos")) {
                 args.extend([
                     "--xwin-arch",
                     "x86_64",


### PR DESCRIPTION
## Summary
- Mirror `src/procedures/linux/x86_64_pc_windows_msvc` under `src/procedures/macos` so that `namui build/start/test x86_64-pc-windows-msvc` works on a Mac host.
- Extend the `cfg!(target_os = \"linux\")` guards in `services/rust_build_service.rs`, `procedures/check.rs`, and `procedures/clippy.rs` to `cfg!(any(target_os = \"linux\", target_os = \"macos\"))` so that the `cargo xwin` subcommand and `--xwin-*` flags are emitted on macOS too.
- Document the macOS prerequisites (`brew install llvm`, PATH, `rustup target add`, `cargo install cargo-xwin`) in `README.md`.

## Test plan
- [x] `cargo check` of namui-cli passes on macOS.
- [x] `cargo build --release` of namui-cli passes on macOS.
- [x] Clean `namui build x86_64-pc-windows-msvc` of `tower-defense` on macOS produces a valid `PE32+ executable (console) x86-64, for MS Windows` (15 MB exe + 105 MB pdb + 54 MB bundle.sqlite).
- [ ] Run the produced .exe on an actual Windows machine (not verified — no Windows host available locally).