### PR TITLE
feat(namui): replace println logging with tracing-based plugin

### DIFF
--- a/namui/audio-native/Cargo.toml
+++ b/namui/audio-native/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 kira = "0.12"
 mint = "0.5"
+tracing = "0.1"

--- a/namui/audio-native/src/lib.rs
+++ b/namui/audio-native/src/lib.rs
@@ -77,7 +77,7 @@ pub extern "C" fn _register_audio(audio_id: usize, buffer_ptr: *const u8, buffer
 pub extern "C" fn _audio_play(audio_id: usize, playback_id: usize, repeat: bool) {
     let data_map = SOUND_DATA.lock().unwrap();
     let Some(data) = data_map.get(&audio_id) else {
-        eprintln!("audio_play: unknown audio_id {audio_id}");
+        tracing::warn!(target: "namui::audio", "audio_play: unknown audio_id {audio_id}");
         return;
     };
     let mut sound_data = data.clone().volume(Decibels::SILENCE);
@@ -97,7 +97,7 @@ pub extern "C" fn _audio_play(audio_id: usize, playback_id: usize, repeat: bool)
             );
         }
         Err(e) => {
-            eprintln!("audio_play: failed to play audio {audio_id}: {e}");
+            tracing::error!(target: "namui::audio", "audio_play: failed to play audio {audio_id}: {e}");
         }
     }
 }
@@ -106,7 +106,7 @@ pub extern "C" fn _audio_play(audio_id: usize, playback_id: usize, repeat: bool)
 pub extern "C" fn _audio_play_spatial(audio_id: usize, playback_id: usize, repeat: bool) {
     let data_map = SOUND_DATA.lock().unwrap();
     let Some(data) = data_map.get(&audio_id) else {
-        eprintln!("audio_play_spatial: unknown audio_id {audio_id}");
+        tracing::warn!(target: "namui::audio", "audio_play_spatial: unknown audio_id {audio_id}");
         return;
     };
     let mut sound_data = data.clone().volume(Decibels::SILENCE);
@@ -131,7 +131,7 @@ pub extern "C" fn _audio_play_spatial(audio_id: usize, playback_id: usize, repea
                 *listener_guard = Some(handle);
             }
             Err(e) => {
-                eprintln!("audio_play_spatial: failed to create listener: {e}");
+                tracing::error!(target: "namui::audio", "audio_play_spatial: failed to create listener: {e}");
                 return;
             }
         }
@@ -161,11 +161,11 @@ pub extern "C" fn _audio_play_spatial(audio_id: usize, playback_id: usize, repea
                 );
             }
             Err(e) => {
-                eprintln!("audio_play_spatial: failed to play audio {audio_id}: {e}");
+                tracing::error!(target: "namui::audio", "audio_play_spatial: failed to play audio {audio_id}: {e}");
             }
         },
         Err(e) => {
-            eprintln!("audio_play_spatial: failed to create spatial track: {e}");
+            tracing::error!(target: "namui::audio", "audio_play_spatial: failed to create spatial track: {e}");
         }
     }
 }

--- a/namui/docs/specs/logging.md
+++ b/namui/docs/specs/logging.md
@@ -1,0 +1,304 @@
+# namui 로깅 시스템 스펙
+
+상태: Implemented (Phase 1+2+3)
+작성일: 2026-05-26
+대상 브랜치: crash-reporter
+
+## 1. 배경
+
+현재 namui 프레임워크는 `println!` / `eprintln!` / `dbg!` 를 로그 시스템으로 직접 사용하고 있다. 워크스페이스 전체에 약 92곳에서 사용 중이며, public API에는 로깅 매크로가 노출되어 있지 않다 (`namui::log!` 매크로가 lib.rs에 존재하나 본문이 깨진 dead code 이며 어디서도 호출되지 않음).
+
+`println!` 직접 사용은 다음 문제를 가진다.
+
+- 로그 레벨이 없어 빌드/환경별 필터링 불가
+- 타임스탬프 / 모듈 경로 / 스레드 ID 메타데이터 부재
+- stdout 단일 sink만 사용 가능 (파일, 원격 텔레메트리, 인게임 콘솔 등 불가)
+- 멀티스레드 환경에서 인터리빙으로 가독성 저하
+- 릴리스 빌드에서 verbose 로그를 컴파일 타임에 제거 불가
+- 구조화 로깅 불가 (JSON 파싱, 옵저버빌리티 도구 연동 불가)
+
+Rust 생태계의 de facto 표준은 `log` 파사드 또는 `tracing` 이며, Rust 게임 엔진 중 가장 대표적인 Bevy 는 `bevy_log` 가 내부적으로 `tracing` 을 기반으로 동작한다. namui 도 동일한 노선을 따른다.
+
+## 2. 목표 / 비목표
+
+### 목표
+
+1. namui 사용자는 `use namui::*; info!(...)` 형태로 즉시 로깅 가능 (제로 학습 비용).
+2. 빌드 타깃(wasm32-wasi-web / native / android 등)에 맞춰 자동으로 적절한 sink 로 라우팅.
+3. 기본 설정(zero-config)으로도 합리적인 동작, 환경변수 `RUST_LOG` 호환, 필요시 builder 로 커스터마이즈.
+4. 게임 루프의 매-프레임 스팸을 막는 `info_once!` / 스로틀 매크로 제공.
+5. 인게임 콘솔에 최근 로그를 표시할 수 있는 링 버퍼 layer 제공.
+6. crash-reporter 와 통합하여 panic / signal 발생 시 최근 N개 로그를 크래시 리포트에 첨부.
+7. native-runner 의 dylib 동적 로드 환경에서 단일 dispatcher 로 통일.
+
+### 비목표
+
+- 사용자 코드의 `println!` 을 강제로 금지하지 않는다 (계속 동작, 다만 가이드에서 권장하지 않음).
+- 외부 로그 수집 인프라(Datadog, Sentry 등) 연동은 본 스펙 범위 외 — Layer 추가만으로 가능하도록 확장점만 보장.
+- 사용자 게임 로직의 마이그레이션은 본 스펙 범위 외 — namui 프레임워크 내부 코드만 마이그레이션 대상.
+
+## 3. 채택 기술
+
+| 항목 | 선택 |
+|------|------|
+| 로깅 파사드 | `tracing` |
+| Subscriber | `tracing-subscriber` (env-filter, fmt) |
+| log 크레이트 호환 | `tracing-log` (외부 의존 라이브러리가 log 사용 시 자동 흡수) |
+| Wasm 브라우저 출력 | `tracing-wasm` 또는 `web_sys::console` 직접 호출 layer |
+
+`log` 크레이트를 직접 채택하지 않는 이유: namui 는 async tokio runtime 기반 게임 루프 + 멀티스레드 환경이며, span 기반 컨텍스트 추적이 평면 로그보다 가치가 크다. `tracing-log` 어댑터로 `log` 매크로 호출도 자동 흡수되므로 호환성 손실 없음.
+
+## 4. Public API
+
+### 4-1. 매크로 re-export
+
+`namui/src/lib.rs` 에서 다음을 re-export.
+
+```rust
+pub use tracing::{trace, debug, info, warn, error, instrument, span, Level};
+```
+
+사용자는 `use namui::*;` 이후 다음과 같이 호출.
+
+```rust
+info!("game started");
+info!(player_id = id, "player spawned");
+warn!("low fps: {:.1}", fps);
+error!(?err, "asset load failed");
+
+#[instrument(skip(world))]
+fn update(world: &mut World) { ... }
+```
+
+기존 `namui::log!` 매크로는 dead code 이므로 삭제.
+
+### 4-2. 게임 특화 매크로
+
+namui 자체적으로 다음 매크로를 추가 제공 (`namui/src/system/log/macros.rs`).
+
+```rust
+namui::info_once!(...)             // 프로세스 생애 동안 호출 위치별 1회만 출력
+namui::warn_once!(...)
+namui::error_once!(...)
+namui::info_every_n!(n, ...)       // n번 호출당 1회 출력
+namui::warn_every_n!(n, ...)
+namui::info_throttled!(duration, ...)  // duration 간격 스로틀
+namui::warn_throttled!(duration, ...)
+```
+
+구현은 호출 위치별 `AtomicU64` (마지막 출력 카운터 또는 timestamp) 를 lazy static 으로 두는 패턴.
+
+### 4-3. 초기화 API
+
+`namui::start` 가 내부에서 LogPlugin 을 자동 초기화. 명시적으로 설정하려면 `namui::start_with` 사용.
+
+```rust
+namui::start(root_component);  // 자동 LogPlugin
+
+namui::start_with(
+    namui::StartConfig::default()
+        .log(|l| l
+            .level(namui::Level::INFO)
+            .filter("wgpu=warn,my_game::ai=trace")
+            .file_output("./logs")
+            .in_game_console(true)
+        ),
+    root_component,
+);
+```
+
+`StartConfig::log` 의 closure 는 `LogConfigBuilder` 를 받아 다음을 설정 가능.
+
+- `level(Level)` — 기본 레벨
+- `filter(&str)` — `RUST_LOG` 문법의 필터 문자열 (지정 시 `level` 보다 우선)
+- `file_output(path)` — 로그 파일 출력 디렉터리 (native 전용, 일일 회전)
+- `in_game_console(bool)` — 링 버퍼 layer 활성화
+- `ring_buffer_capacity(usize)` — 링 버퍼 용량 (기본 1024)
+- `additional_layer(Box<dyn Layer>)` — 사용자 정의 layer 추가
+
+`RUST_LOG` 환경변수가 설정되어 있으면 코드의 `filter` 보다 우선 적용.
+
+## 5. 플랫폼별 라우팅
+
+`namui::system::log::init_log_plugin(config)` 가 빌드 타깃에 따라 sink 조합을 결정.
+
+| 타깃 | 기본 sink | 포맷 |
+|------|-----------|------|
+| `target_os = "wasi"` (wasm32-wasi-web 브라우저) | `web_sys::console::log/warn/error` | 레벨 색상 활용 |
+| native dev (`debug_assertions`) | stderr | ANSI 컬러, 타임스탬프, target, 레벨 |
+| native release | stderr + 회전 파일 | stderr: 평문, 파일: JSON |
+| android (장기) | logcat (`tracing-android`) | 기본 |
+| 인게임 콘솔 활성화 시 | 위 sink + 링 버퍼 layer | — |
+
+### 5-1. wasm32-wasi-web 의 특수성
+
+namui 는 wasm32-wasi-web 을 주 타깃으로 한다. `cfg(target_os = "wasi")` 일 때:
+
+- 기본적으로 stderr 도 호스트 (브라우저 wasi-shim) 에 캡처되므로 fallback 가능.
+- 그러나 브라우저 DevTools 에서 레벨별 색상을 활용하려면 `web_sys::console::*` 호출이 필요.
+- namui 가 wasm-bindgen 을 사용 중인지에 따라 결정 — `web_sys` 호출이 가능하면 그것을 우선, 아니면 stderr.
+
+구현 시 `namui-cfg` 의 cfg 매크로로 분기.
+
+### 5-2. native 파일 출력 경로
+
+`file_output` 미지정 시 기본 경로:
+
+- macOS: `$HOME/Library/Logs/<app-name>/`
+- Linux: `$XDG_STATE_HOME/<app-name>/logs/` (없으면 `$HOME/.local/state/<app-name>/logs/`)
+- Windows: `%LOCALAPPDATA%/<app-name>/logs/`
+
+`<app-name>` 은 `Cargo.toml` 의 패키지명 또는 `StartConfig::app_name` 으로 지정.
+
+릴리스 빌드에서만 파일 출력 활성화 (debug 빌드는 stderr 만).
+
+## 6. 인게임 콘솔 Layer
+
+`namui::system::log::ring_buffer::RingBufferLayer` 를 제공.
+
+- 고정 크기 락-프리 링 버퍼 (capacity 는 config 로 조정).
+- 각 엔트리: `{ timestamp, level, target, message }`.
+- `namui::system::log::recent_logs(n: usize) -> Vec<LogEntry>` 로 최근 로그 조회.
+- 별도 namui-prebuilt 위젯(`DebugConsole`) 에서 구독하여 화면에 렌더 (별도 PR 에서 추가).
+
+스레드 안전: `crossbeam::queue::ArrayQueue` 또는 `parking_lot::Mutex<VecDeque>` 사용.
+
+## 7. crash-reporter 통합
+
+현재 `native-runner/src/main.rs` 가 시그널 핸들러 + panic hook 으로 fatal 이벤트를 잡아 stderr 에 출력한다. tracing 도입 후:
+
+1. namui 측 (dylib) 의 panic hook 을 `error!("panic at {}: {}", location, payload)` 로 흘려서 모든 sink 에 동시 기록.
+2. RingBufferLayer 의 내용을 crash report payload 에 첨부 (스냅샷 함수 `dump_ring_buffer() -> Vec<LogEntry>` 제공).
+3. native-runner 측은 본 스펙의 범위 밖. signal 핸들러는 async-signal-safe 제약으로 tracing 사용 불가하므로 현행 stderr write 유지.
+
+crash-reporter 브랜치의 별도 작업과 본 작업의 인터페이스는 `dump_ring_buffer()` 한 함수로 정의.
+
+## 8. dylib / 다중 dispatcher 문제
+
+native-runner 는 게임 dylib 을 `libloading` 으로 동적 로드한다. tracing 의 global default dispatcher 는 정적 변수이므로, 같은 프로세스 내에서도 정적 링크 단위(host vs dylib) 별로 별개의 인스턴스가 생길 수 있다.
+
+### 8-1. 현황 분석
+
+- `native-runner` crate 의 dependencies: `namui-skia`, `namui-drawer`, `namui-rendering-tree`, `namui-type`, `winit`, `libloading`, `notify`, `bincode`, `mimalloc`, `anyhow` — 즉 `namui` 본체 의존 없음.
+- 게임 dylib 은 `namui` 본체를 의존하여 컴파일됨.
+- 따라서 native-runner 가 `tracing` 을 직접 의존하지 않는 한 dispatcher 충돌은 발생하지 않음. dylib 측의 `tracing` 정적 인스턴스 하나만 존재.
+
+### 8-2. 결정
+
+- native-runner 는 tracing 을 의존하지 않는다. 기존 `eprintln!("[runner] ...")` 유지.
+- 사용자 게임 코드와 namui 프레임워크 코드는 모두 dylib 내에서 동일한 `tracing` dispatcher 를 공유한다.
+- 추후 native-runner 도 tracing 도입이 필요해지면, dylib 진입점에 `namui::system::log::install_external_dispatcher(dispatch: tracing::Dispatch)` 를 추가하여 host 의 dispatcher 를 dylib 으로 전달한다 (본 스펙 범위 외).
+
+## 9. 디렉터리 구조
+
+namui crate 내 신규 모듈.
+
+```
+namui/src/system/log/
+  mod.rs              # public API, init_log_plugin, LogConfigBuilder
+  config.rs           # LogConfigBuilder, LogConfig
+  init.rs             # platform 분기 init
+  ring_buffer.rs      # RingBufferLayer
+  macros.rs           # info_once!, info_every_n!, throttled! 등
+  paths.rs            # 플랫폼별 로그 디렉터리
+```
+
+기존 `namui/src/lib.rs` 의 깨진 `log!` 매크로(라인 131-136)는 삭제.
+
+## 10. 의존성 추가
+
+`namui/Cargo.toml` 에 추가.
+
+```toml
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
+tracing-log = "0.2"
+
+[target.'cfg(target_os = "wasi")'.dependencies]
+# wasm32-wasi-web 의 web_sys 가용성에 따라 결정. 우선은 stderr fallback.
+# tracing-wasm = "0.2"  # 추후 활성화
+
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+tracing-appender = "0.2"  # 파일 회전
+```
+
+`tracing-wasm` 활성화 여부는 namui 의 wasm-bindgen 사용 현황 확인 후 결정.
+
+## 11. 마이그레이션 단계
+
+### Phase 1 — 인프라 도입 (본 PR 범위)
+
+1. 의존성 추가 (`namui/Cargo.toml`).
+2. `namui/src/system/log/` 모듈 생성.
+3. `namui::start` 에서 `init_log_plugin(LogConfig::default())` 호출.
+4. `namui/src/lib.rs` 에서 `tracing` 매크로 re-export, 깨진 `log!` 매크로 삭제.
+5. 게임 특화 매크로(`info_once!`, `info_every_n!`, `info_throttled!` 등) 구현.
+6. `RingBufferLayer` 구현, `dump_ring_buffer()` 공개 함수 추가.
+
+### Phase 2 — 런타임 핵심 경로 마이그레이션 (본 PR 범위)
+
+`namui` 본체 및 `namui` crate 의존하는 런타임 핵심 crate 의 production code 만 본 PR 에서 마이그레이션. 빌드 도구 / 네이티브 백엔드 등 별도 의존성 트리에 있는 crate 는 Phase 3 로 이관.
+
+본 PR 마이그레이션 대상 (production code):
+- `namui` — `ffi.rs`, `hooks/looper.rs` 의 `println!` / `eprintln!` 교체 완료.
+- `namui-prebuilt` — `rich_text/mod.rs` 의 `eprintln!` 교체 완료 (namui 의존 통해).
+- `namui-rendering-tree` — `mouse_cursor.rs` 의 `println!` 교체 완료 (`tracing` 직접 의존).
+
+레벨 기준:
+- 빌드 진행/단계 표시 → `info!`
+- 셰이더 컴파일 실패, 에셋 로드 실패, FFI panic → `error!`
+- 디버그 보조 출력 → `debug!` 또는 `trace!`
+- 사용자 입력 검증 실패, 설정 오류 → `warn!`
+
+제외 대상 (본 PR 에서 제외, Phase 3 로 이관):
+- `native-runner` (앞 8-2 결정 — 시그널 핸들러는 async-signal-safe 제약, eprintln 유지).
+- `namui-cli` (빌드 도구, 별도 의존성 트리).
+- `namui-drawer` (네이티브 백엔드, 별도 의존성 트리).
+- `namui-skia` 래퍼 (low-level).
+- `namui-audio-native` (네이티브 백엔드).
+- `namui-hooks` (production code 내 `println!` 없음).
+- `sample/` 내 예제 코드.
+- `asset-macro/examples/test-project` (테스트 픽스처).
+- `third-party-forks/` (외부 코드).
+- 모든 `*/tests/` `*/benches/` `*/examples/`.
+
+### Phase 3 — 잔여 마이그레이션 및 통합 (본 PR 범위, 완료)
+
+본 PR 마이그레이션 대상 (production code):
+- `namui-skia` — `canvas.rs` 의 `println!` 교체 완료 (`tracing` 자체 의존).
+- `namui-audio-native` — `lib.rs` 의 `eprintln!` 6개소 교체 완료 (`tracing` 자체 의존).
+
+본 PR 인프라:
+- `std::panic::set_hook` 통합 — 모든 panic 이 `error!(target: "namui::panic")` 으로 흐른 뒤 기존 hook 으로 전파. ring buffer 와 자동 통합.
+- `tracing-appender` 도입 — `LogConfigBuilder::file_output(path)` 또는 `app_name` 지정 시 일일 회전 파일 출력 활성화 (non-wasi 전용, 비동기 non-blocking).
+- ring buffer 구독 API — `dump_ring_buffer()`, `dump_recent_logs(n)`, `is_ring_buffer_installed()`.
+- crash-reporter 인터페이스 — `dump_ring_buffer()` / `dump_recent_logs(n)` 가 panic / signal 핸들러에서 직접 호출 가능.
+
+`namui-cli` 는 마이그레이션 영구 제외:
+- CLI 도구이므로 stdout 출력 자체가 사용자 인터페이스. `tracing` 으로 바꾸면 `RUST_LOG` 필터 영향을 받아 UX 가 망가짐.
+- `println!` 유지가 표준 (cargo, rustc 등 다른 Rust CLI 도구와 동일).
+
+### Phase 4 — 미래 작업
+
+- 인게임 콘솔 위젯 (`namui-prebuilt::DebugConsole`) — `dump_recent_logs(n)` 구독해서 화면에 렌더하는 위젯 추가.
+- crash-reporter 브랜치의 실제 리포트 payload 에 ring buffer 덤프 첨부.
+- `tracing-wasm` 도입 검토 (namui 가 wasm-bindgen 채택 시).
+- dylib dispatcher 동기화 API (`install_external_dispatcher`) — 현재는 dylib 단일 dispatcher 가정으로 충분하지만 다중 dylib 로드 시나리오가 발생하면 추가.
+
+## 12. 검증
+
+- `cargo check` / `cargo build` 가 모든 타깃에서 통과해야 한다.
+  - `aarch64-apple-darwin`
+  - `x86_64-pc-windows-msvc` (가능하면)
+  - `wasm32-wasi-web`
+- 기본 `namui::start` 호출만으로 stderr 에 INFO 이상이 출력되는지 수동 확인.
+- `RUST_LOG=trace cargo run` 으로 trace 까지 출력되는지 확인.
+
+## 13. Out of scope (명시적 제외)
+
+- 사용자 게임 코드의 마이그레이션 (사용자가 자기 코드에서 `info!` / `warn!` 등을 직접 채택).
+- 외부 로그 수집 서비스 연동 (Datadog, Sentry 등).
+- `native-runner` 의 tracing 통합 (signal-safety 제약, `eprintln!` 유지).
+- `namui-cli` 의 println 제거 (CLI 인터페이스로 보존).
+- 인게임 콘솔의 UI 구현 (Phase 4).
+- crash-reporter 의 실제 업로드 경로 (Phase 4 / 별도 브랜치).

--- a/namui/namui-cli/webCode/src/imports/importObject.ts
+++ b/namui/namui-cli/webCode/src/imports/importObject.ts
@@ -42,6 +42,16 @@ export function createImportObject({
           }, {} as Record<string, any>)
         : wasiImport;
 
+    const tidForLog =
+        supplies.type === "sub" ? supplies.tid : 0;
+    const consoleStyles: Record<number, string> = {
+        1: "color: #ff4d4f; font-weight: bold",
+        2: "color: #faad14; font-weight: bold",
+        3: "",
+        4: "color: #888",
+        5: "color: #aaa",
+    };
+
     return {
         env: {
             memory,
@@ -61,6 +71,12 @@ export function createImportObject({
                 memory,
             }),
             _hardware_concurrency: () => navigator.hardwareConcurrency,
+            _namui_console_log: (level: number, ptr: number, len: number) => {
+                const bytes = new Uint8Array(memory.buffer, ptr, len).slice();
+                const msg = new TextDecoder().decode(bytes);
+                const style = consoleStyles[level] ?? "";
+                console.log(`%c[${tidForLog}] ${msg}`, style);
+            },
         },
         wasi_snapshot_preview1: wasiSnapshotPreview1,
         wasi: {

--- a/namui/namui-cli/webCode/src/thread/startThread.ts
+++ b/namui/namui-cli/webCode/src/thread/startThread.ts
@@ -46,8 +46,9 @@ export async function startThread(supplies: ThreadStartSupplies) {
     const { module } = supplies;
 
     const env = [
-        "RUST_BACKTRACE=full",
+        `RUST_BACKTRACE=${__NAMUI_RUST_BACKTRACE__ ?? "full"}`,
         `RAYON_NUM_THREADS=${navigator.hardwareConcurrency}`,
+        ...(__NAMUI_RUST_LOG__ ? [`RUST_LOG=${__NAMUI_RUST_LOG__}`] : []),
     ];
 
     const tid = supplies.type === "sub" ? supplies.tid : 0;

--- a/namui/namui-cli/webCode/src/vite-env.d.ts
+++ b/namui/namui-cli/webCode/src/vite-env.d.ts
@@ -24,3 +24,6 @@ declare module "virtual:audio-asset-list" {
     }
     export const audioAssetList: AudioAssetInfo[];
 }
+
+declare const __NAMUI_RUST_LOG__: string | null;
+declare const __NAMUI_RUST_BACKTRACE__: string | null;

--- a/namui/namui-cli/webCode/vite.config.ts
+++ b/namui/namui-cli/webCode/vite.config.ts
@@ -18,6 +18,12 @@ const serverFsAllow = [
 
 export default defineConfig({
     clearScreen: false,
+    define: {
+        __NAMUI_RUST_LOG__: JSON.stringify(process.env.RUST_LOG ?? null),
+        __NAMUI_RUST_BACKTRACE__: JSON.stringify(
+            process.env.RUST_BACKTRACE ?? null,
+        ),
+    },
     server: {
         host: true,
         headers: {

--- a/namui/namui-drawer/Cargo.lock
+++ b/namui/namui-drawer/Cargo.lock
@@ -930,6 +930,7 @@ dependencies = [
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -950,6 +951,7 @@ dependencies = [
  "skia-safe",
  "textwrap",
  "tokio",
+ "tracing",
  "unicode-segmentation",
  "windows",
  "winit",
@@ -1959,7 +1961,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1967,6 +1981,9 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/namui/namui-prebuilt/Cargo.lock
+++ b/namui/namui-prebuilt/Cargo.lock
@@ -269,6 +269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +346,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -746,6 +764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,9 +808,14 @@ dependencies = [
  "namui-particle",
  "namui-rendering-tree",
  "namui-type",
+ "parking_lot",
  "rand",
  "shader-macro",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -848,6 +880,7 @@ dependencies = [
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -923,6 +956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1027,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1060,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1116,7 +1171,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1274,6 +1329,15 @@ name = "shader-macro"
 version = "0.1.0"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1396,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -1518,7 +1588,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1530,6 +1609,57 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1594,6 +1724,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1835,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/namui/namui-prebuilt/src/rich_text/mod.rs
+++ b/namui/namui-prebuilt/src/rich_text/mod.rs
@@ -125,8 +125,8 @@ impl Component for RichText<'_> {
             && (self.default_text_align == TextAlign::Center
                 || self.default_text_align == TextAlign::Right)
         {
-            eprintln!(
-                "Warning: RichText with text_align {:?} requires max_width to be set. Falling back to Left alignment.",
+            warn!(
+                "RichText with text_align {:?} requires max_width to be set. Falling back to Left alignment.",
                 self.default_text_align
             );
             TextAlign::Left

--- a/namui/namui/Cargo.lock
+++ b/namui/namui/Cargo.lock
@@ -269,6 +269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +346,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -755,6 +773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,9 +818,14 @@ dependencies = [
  "namui-particle",
  "namui-rendering-tree",
  "namui-type",
+ "parking_lot",
  "rand",
  "shader-macro",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -850,6 +882,7 @@ dependencies = [
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -925,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1062,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1118,7 +1173,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1276,6 +1331,15 @@ name = "shader-macro"
 version = "0.1.0"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1398,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -1520,7 +1590,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1532,6 +1611,57 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1596,6 +1726,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1837,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/namui/namui/Cargo.toml
+++ b/namui/namui/Cargo.toml
@@ -33,9 +33,19 @@ tokio = { path = "../third-party-forks/tokio/tokio", features = [
     "rt-multi-thread",
     "fs",
 ] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "registry",
+    "fmt",
+    "env-filter",
+    "std",
+] }
+tracing-log = "0.2"
+parking_lot = "0.12"
 
 [target.'cfg(not(target_os="wasi"))'.dependencies]
 bincode = "2.0.0-rc.3"
+tracing-appender = "0.2"
 
 [dev-dependencies]
 float-cmp = "0.9"

--- a/namui/namui/src/ffi.rs
+++ b/namui/namui/src/ffi.rs
@@ -15,7 +15,7 @@ macro_rules! ffi_catch {
                 } else {
                     "unknown panic".to_string()
                 };
-                eprintln!("[namui FFI panic] {msg}");
+                tracing::error!(target: "namui::ffi", "FFI panic: {msg}");
                 std::process::abort();
             }
         }

--- a/namui/namui/src/hooks/looper.rs
+++ b/namui/namui/src/hooks/looper.rs
@@ -61,7 +61,7 @@ impl Looper {
     fn post_run(&mut self, before_run: Instant) {
         let elapsed = crate::time::now() - before_run;
         if elapsed > 33.ms() {
-            println!("Warning: Rendering took {elapsed:?}. Keep it short as possible.",);
+            tracing::warn!(target: "namui::metrics", "Rendering took {elapsed:?}. Keep it short as possible.");
         }
 
         self.render_time_sum += elapsed;
@@ -81,7 +81,7 @@ impl Looper {
                     *count = 0;
                 }
             }
-            println!("\u{0081}{text}");
+            tracing::info!(target: "namui::metrics", "{text}");
             self.one_sec_render_count = 0;
             self.one_sec_timer = std::time::Instant::now();
             self.render_time_sum = 0.ms();

--- a/namui/namui/src/lib.rs
+++ b/namui/namui/src/lib.rs
@@ -26,6 +26,8 @@ use std::{
 pub use system::*;
 pub use tokio;
 pub use tokio::task::{spawn, spawn_local};
+pub use tracing;
+pub use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 
 pub mod particle {
     pub use namui_particle::{Emitter, Particle, ParticleSprites, RenderEmitter};
@@ -54,6 +56,12 @@ fn build_tokio_runtime() -> tokio::runtime::Runtime {
 }
 
 pub fn start(root_component: RootComponent) {
+    system::log::init_log_plugin_with_default();
+    LOOPER.set(Some(Looper::new(root_component)));
+}
+
+pub fn start_with_log_config(root_component: RootComponent, log_config: system::log::LogConfig) {
+    system::log::init_log_plugin(log_config);
     LOOPER.set(Some(Looper::new(root_component)));
 }
 
@@ -126,13 +134,6 @@ fn on_event(event: RawEvent) -> *const u8 {
     });
 
     result
-}
-
-#[macro_export]
-macro_rules! log {
-    ($($arg:tt)*) => {{
-        $println!::log(format!($($arg)*));
-    }}
 }
 
 pub fn render(rendering_trees: impl IntoIterator<Item = RenderingTree>) -> RenderingTree {

--- a/namui/namui/src/system/log/config.rs
+++ b/namui/namui/src/system/log/config.rs
@@ -1,0 +1,78 @@
+use std::path::PathBuf;
+use tracing::Level;
+
+pub struct LogConfig {
+    pub(crate) level: Level,
+    pub(crate) filter: Option<String>,
+    pub(crate) file_output: Option<PathBuf>,
+    pub(crate) app_name: Option<String>,
+    pub(crate) in_game_console: bool,
+    pub(crate) ring_buffer_capacity: usize,
+    pub(crate) ansi: Option<bool>,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            level: Level::INFO,
+            filter: None,
+            file_output: None,
+            app_name: None,
+            in_game_console: false,
+            ring_buffer_capacity: 1024,
+            ansi: None,
+        }
+    }
+}
+
+impl LogConfig {
+    pub fn builder() -> LogConfigBuilder {
+        LogConfigBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct LogConfigBuilder {
+    inner: LogConfig,
+}
+
+impl LogConfigBuilder {
+    pub fn level(mut self, level: Level) -> Self {
+        self.inner.level = level;
+        self
+    }
+
+    pub fn filter(mut self, filter: impl Into<String>) -> Self {
+        self.inner.filter = Some(filter.into());
+        self
+    }
+
+    pub fn file_output(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner.file_output = Some(path.into());
+        self
+    }
+
+    pub fn app_name(mut self, name: impl Into<String>) -> Self {
+        self.inner.app_name = Some(name.into());
+        self
+    }
+
+    pub fn in_game_console(mut self, enabled: bool) -> Self {
+        self.inner.in_game_console = enabled;
+        self
+    }
+
+    pub fn ring_buffer_capacity(mut self, capacity: usize) -> Self {
+        self.inner.ring_buffer_capacity = capacity;
+        self
+    }
+
+    pub fn ansi(mut self, enabled: bool) -> Self {
+        self.inner.ansi = Some(enabled);
+        self
+    }
+
+    pub fn build(self) -> LogConfig {
+        self.inner
+    }
+}

--- a/namui/namui/src/system/log/init.rs
+++ b/namui/namui/src/system/log/init.rs
@@ -1,0 +1,156 @@
+use super::config::LogConfig;
+use super::ring_buffer::{RingBufferHandle, RingBufferLayer, install_ring_buffer};
+use std::sync::Once;
+#[cfg(not(target_os = "wasi"))]
+use tracing_subscriber::fmt;
+use tracing_subscriber::{EnvFilter, prelude::*};
+
+#[cfg(not(target_os = "wasi"))]
+static FILE_GUARD: std::sync::OnceLock<tracing_appender::non_blocking::WorkerGuard> =
+    std::sync::OnceLock::new();
+
+static INIT: Once = Once::new();
+
+pub fn init_log_plugin_with_default() {
+    init_log_plugin(LogConfig::default());
+}
+
+pub fn init_log_plugin(config: LogConfig) {
+    INIT.call_once(|| {
+        install(config);
+        install_panic_hook();
+    });
+}
+
+fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "<non-string panic payload>".to_string()
+        };
+        tracing::error!(target: "namui::panic", "panic at {location}: {payload}");
+        prev(info);
+    }));
+}
+
+fn install(config: LogConfig) {
+    let env_filter = match std::env::var("RUST_LOG") {
+        Ok(_) => EnvFilter::from_default_env(),
+        Err(_) => match &config.filter {
+            Some(f) => EnvFilter::new(f.clone()),
+            None => EnvFilter::new(default_filter(&config.level)),
+        },
+    };
+
+    let ring_layer = if config.in_game_console {
+        let handle = RingBufferHandle::new(config.ring_buffer_capacity);
+        install_ring_buffer(handle.clone());
+        Some(RingBufferLayer::new(handle))
+    } else {
+        None
+    };
+
+    install_platform(env_filter, ring_layer, &config);
+
+    let _ = tracing_log::LogTracer::init();
+}
+
+#[cfg(target_os = "wasi")]
+fn install_platform(
+    env_filter: EnvFilter,
+    ring_layer: Option<RingBufferLayer>,
+    _config: &LogConfig,
+) {
+    use tracing_subscriber::util::SubscriberInitExt;
+    let _ = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(super::wasi_console::WasiConsoleLayer)
+        .with(ring_layer)
+        .try_init();
+}
+
+#[cfg(not(target_os = "wasi"))]
+fn install_platform(
+    env_filter: EnvFilter,
+    ring_layer: Option<RingBufferLayer>,
+    config: &LogConfig,
+) {
+    let ansi_enabled = config.ansi.unwrap_or_else(default_ansi);
+    let stderr_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(ansi_enabled)
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_thread_names(false);
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stderr_layer)
+        .with(ring_layer);
+
+    install_with_file_layer(registry, config);
+}
+
+#[cfg(not(target_os = "wasi"))]
+fn install_with_file_layer<S>(registry: S, config: &LogConfig)
+where
+    S: tracing::Subscriber + Send + Sync,
+    S: for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    let dir = resolve_file_output_dir(config);
+    let Some(dir) = dir else {
+        let _ = registry.try_init();
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("namui::log: failed to create log dir {dir:?}: {e}");
+        let _ = registry.try_init();
+        return;
+    }
+    let file_prefix = config
+        .app_name
+        .clone()
+        .unwrap_or_else(|| "namui".to_string());
+    let file_appender = tracing_appender::rolling::daily(&dir, file_prefix);
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+    let _ = FILE_GUARD.set(guard);
+
+    let file_layer = fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_thread_names(true);
+
+    let _ = registry.with(file_layer).try_init();
+}
+
+#[cfg(not(target_os = "wasi"))]
+fn resolve_file_output_dir(config: &LogConfig) -> Option<std::path::PathBuf> {
+    if let Some(p) = config.file_output.clone() {
+        return Some(p);
+    }
+    let app_name = config.app_name.as_deref()?;
+    super::paths::default_log_dir(app_name)
+}
+
+fn default_filter(level: &tracing::Level) -> String {
+    let lower = level.to_string().to_lowercase();
+    format!("{lower},wgpu=warn,naga=warn,winit=warn,tokio=warn")
+}
+
+#[cfg(not(target_os = "wasi"))]
+fn default_ansi() -> bool {
+    use std::io::IsTerminal;
+    std::io::stderr().is_terminal()
+}

--- a/namui/namui/src/system/log/macros.rs
+++ b/namui/namui/src/system/log/macros.rs
@@ -1,0 +1,171 @@
+#[macro_export]
+macro_rules! info_once {
+    ($($arg:tt)*) => {{
+        static __NAMUI_LOG_ONCE: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+        if !__NAMUI_LOG_ONCE.swap(true, ::std::sync::atomic::Ordering::Relaxed) {
+            $crate::tracing::info!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! warn_once {
+    ($($arg:tt)*) => {{
+        static __NAMUI_LOG_ONCE: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+        if !__NAMUI_LOG_ONCE.swap(true, ::std::sync::atomic::Ordering::Relaxed) {
+            $crate::tracing::warn!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! error_once {
+    ($($arg:tt)*) => {{
+        static __NAMUI_LOG_ONCE: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+        if !__NAMUI_LOG_ONCE.swap(true, ::std::sync::atomic::Ordering::Relaxed) {
+            $crate::tracing::error!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! debug_once {
+    ($($arg:tt)*) => {{
+        static __NAMUI_LOG_ONCE: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+        if !__NAMUI_LOG_ONCE.swap(true, ::std::sync::atomic::Ordering::Relaxed) {
+            $crate::tracing::debug!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! trace_once {
+    ($($arg:tt)*) => {{
+        static __NAMUI_LOG_ONCE: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+        if !__NAMUI_LOG_ONCE.swap(true, ::std::sync::atomic::Ordering::Relaxed) {
+            $crate::tracing::trace!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! info_every_n {
+    ($n:expr, $($arg:tt)*) => {{
+        static __NAMUI_LOG_COUNTER: ::std::sync::atomic::AtomicU64 =
+            ::std::sync::atomic::AtomicU64::new(0);
+        let count = __NAMUI_LOG_COUNTER.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed);
+        if count % ($n as u64) == 0 {
+            $crate::tracing::info!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! warn_every_n {
+    ($n:expr, $($arg:tt)*) => {{
+        static __NAMUI_LOG_COUNTER: ::std::sync::atomic::AtomicU64 =
+            ::std::sync::atomic::AtomicU64::new(0);
+        let count = __NAMUI_LOG_COUNTER.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed);
+        if count % ($n as u64) == 0 {
+            $crate::tracing::warn!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! debug_every_n {
+    ($n:expr, $($arg:tt)*) => {{
+        static __NAMUI_LOG_COUNTER: ::std::sync::atomic::AtomicU64 =
+            ::std::sync::atomic::AtomicU64::new(0);
+        let count = __NAMUI_LOG_COUNTER.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed);
+        if count % ($n as u64) == 0 {
+            $crate::tracing::debug!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! trace_every_n {
+    ($n:expr, $($arg:tt)*) => {{
+        static __NAMUI_LOG_COUNTER: ::std::sync::atomic::AtomicU64 =
+            ::std::sync::atomic::AtomicU64::new(0);
+        let count = __NAMUI_LOG_COUNTER.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed);
+        if count % ($n as u64) == 0 {
+            $crate::tracing::trace!($($arg)*);
+        }
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __namui_throttle_should_emit {
+    ($duration:expr) => {{
+        static __NAMUI_THROTTLE_ORIGIN: ::std::sync::OnceLock<::std::time::Instant> =
+            ::std::sync::OnceLock::new();
+        static __NAMUI_THROTTLE_LAST: ::std::sync::atomic::AtomicU64 =
+            ::std::sync::atomic::AtomicU64::new(u64::MAX);
+        let origin = *__NAMUI_THROTTLE_ORIGIN.get_or_init(::std::time::Instant::now);
+        let now_nanos = ::std::time::Instant::now()
+            .saturating_duration_since(origin)
+            .as_nanos()
+            .min(u64::MAX as u128) as u64;
+        let interval_nanos = ($duration).as_nanos().min(u64::MAX as u128) as u64;
+        let last = __NAMUI_THROTTLE_LAST.load(::std::sync::atomic::Ordering::Relaxed);
+        if last == u64::MAX || now_nanos.saturating_sub(last) >= interval_nanos {
+            __NAMUI_THROTTLE_LAST.store(now_nanos, ::std::sync::atomic::Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! info_throttled {
+    ($duration:expr, $($arg:tt)*) => {{
+        if $crate::__namui_throttle_should_emit!($duration) {
+            $crate::tracing::info!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! warn_throttled {
+    ($duration:expr, $($arg:tt)*) => {{
+        if $crate::__namui_throttle_should_emit!($duration) {
+            $crate::tracing::warn!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! error_throttled {
+    ($duration:expr, $($arg:tt)*) => {{
+        if $crate::__namui_throttle_should_emit!($duration) {
+            $crate::tracing::error!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! debug_throttled {
+    ($duration:expr, $($arg:tt)*) => {{
+        if $crate::__namui_throttle_should_emit!($duration) {
+            $crate::tracing::debug!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! trace_throttled {
+    ($duration:expr, $($arg:tt)*) => {{
+        if $crate::__namui_throttle_should_emit!($duration) {
+            $crate::tracing::trace!($($arg)*);
+        }
+    }};
+}

--- a/namui/namui/src/system/log/mod.rs
+++ b/namui/namui/src/system/log/mod.rs
@@ -1,0 +1,13 @@
+mod config;
+mod init;
+mod macros;
+mod paths;
+mod ring_buffer;
+#[cfg(target_os = "wasi")]
+mod wasi_console;
+
+pub use config::{LogConfig, LogConfigBuilder};
+pub use init::{init_log_plugin, init_log_plugin_with_default};
+pub use ring_buffer::{LogEntry, dump_recent_logs, dump_ring_buffer, is_ring_buffer_installed};
+
+pub use tracing::Level;

--- a/namui/namui/src/system/log/paths.rs
+++ b/namui/namui/src/system/log/paths.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub(crate) fn default_log_dir(app_name: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join("Library/Logs").join(app_name))
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "wasi")))]
+#[allow(dead_code)]
+pub(crate) fn default_log_dir(app_name: &str) -> Option<PathBuf> {
+    if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        return Some(PathBuf::from(state).join(app_name).join("logs"));
+    }
+    let home = std::env::var_os("HOME")?;
+    Some(
+        PathBuf::from(home)
+            .join(".local/state")
+            .join(app_name)
+            .join("logs"),
+    )
+}
+
+#[cfg(windows)]
+#[allow(dead_code)]
+pub(crate) fn default_log_dir(app_name: &str) -> Option<PathBuf> {
+    let base = std::env::var_os("LOCALAPPDATA")?;
+    Some(PathBuf::from(base).join(app_name).join("logs"))
+}
+
+#[cfg(target_os = "wasi")]
+#[allow(dead_code)]
+pub(crate) fn default_log_dir(_app_name: &str) -> Option<PathBuf> {
+    None
+}

--- a/namui/namui/src/system/log/ring_buffer.rs
+++ b/namui/namui/src/system/log/ring_buffer.rs
@@ -1,0 +1,127 @@
+use parking_lot::Mutex;
+use std::{
+    collections::VecDeque,
+    fmt::Write,
+    sync::{Arc, OnceLock},
+    time::SystemTime,
+};
+use tracing::{Event, Subscriber, field::Visit};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub timestamp: SystemTime,
+    pub level: tracing::Level,
+    pub target: String,
+    pub message: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct RingBufferHandle {
+    buffer: Arc<Mutex<VecDeque<LogEntry>>>,
+    capacity: usize,
+}
+
+impl RingBufferHandle {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(capacity.min(1024)))),
+            capacity,
+        }
+    }
+
+    pub(crate) fn push(&self, entry: LogEntry) {
+        let mut buf = self.buffer.lock();
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(entry);
+    }
+
+    pub(crate) fn snapshot(&self, n: usize) -> Vec<LogEntry> {
+        let buf = self.buffer.lock();
+        let len = buf.len();
+        let start = len.saturating_sub(n);
+        buf.iter().skip(start).cloned().collect()
+    }
+}
+
+static RING_BUFFER: OnceLock<RingBufferHandle> = OnceLock::new();
+
+pub(crate) fn install_ring_buffer(handle: RingBufferHandle) {
+    let _ = RING_BUFFER.set(handle);
+}
+
+pub fn dump_ring_buffer() -> Vec<LogEntry> {
+    match RING_BUFFER.get() {
+        Some(h) => h.snapshot(usize::MAX),
+        None => Vec::new(),
+    }
+}
+
+pub fn dump_recent_logs(n: usize) -> Vec<LogEntry> {
+    match RING_BUFFER.get() {
+        Some(h) => h.snapshot(n),
+        None => Vec::new(),
+    }
+}
+
+pub fn is_ring_buffer_installed() -> bool {
+    RING_BUFFER.get().is_some()
+}
+
+pub struct RingBufferLayer {
+    handle: RingBufferHandle,
+}
+
+impl RingBufferLayer {
+    pub(crate) fn new(handle: RingBufferHandle) -> Self {
+        Self { handle }
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            if !self.message.is_empty() {
+                self.message.push(' ');
+            }
+            let _ = write!(self.message, "{}={:?}", field.name(), value);
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            if !self.message.is_empty() {
+                self.message.push(' ');
+            }
+            let _ = write!(self.message, "{}={}", field.name(), value);
+        }
+    }
+}
+
+impl<S> Layer<S> for RingBufferLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.handle.push(LogEntry {
+            timestamp: SystemTime::now(),
+            level: *metadata.level(),
+            target: metadata.target().to_string(),
+            message: visitor.message,
+        });
+    }
+}

--- a/namui/namui/src/system/log/wasi_console.rs
+++ b/namui/namui/src/system/log/wasi_console.rs
@@ -1,0 +1,69 @@
+#![cfg(target_os = "wasi")]
+
+use std::fmt::Write;
+use tracing::{Event, Subscriber, field::Visit};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+unsafe extern "C" {
+    fn _namui_console_log(level: u32, ptr: *const u8, len: usize);
+}
+
+pub(super) struct WasiConsoleLayer;
+
+#[derive(Default)]
+struct ConsoleVisitor {
+    message: String,
+}
+
+impl Visit for ConsoleVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            if !self.message.is_empty() {
+                self.message.push(' ');
+            }
+            let _ = write!(self.message, "{}={:?}", field.name(), value);
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            if !self.message.is_empty() {
+                self.message.push(' ');
+            }
+            let _ = write!(self.message, "{}={}", field.name(), value);
+        }
+    }
+}
+
+impl<S> Layer<S> for WasiConsoleLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level_num = match *metadata.level() {
+            tracing::Level::ERROR => 1u32,
+            tracing::Level::WARN => 2,
+            tracing::Level::INFO => 3,
+            tracing::Level::DEBUG => 4,
+            tracing::Level::TRACE => 5,
+        };
+
+        let mut visitor = ConsoleVisitor::default();
+        event.record(&mut visitor);
+
+        let formatted = format!(
+            "{level} {target}: {msg}",
+            level = metadata.level(),
+            target = metadata.target(),
+            msg = visitor.message,
+        );
+
+        let bytes = formatted.as_bytes();
+        unsafe { _namui_console_log(level_num, bytes.as_ptr(), bytes.len()) };
+    }
+}

--- a/namui/namui/src/system/mod.rs
+++ b/namui/namui/src/system/mod.rs
@@ -1,6 +1,7 @@
 pub mod audio;
 pub mod keyboard;
 pub mod kv_store;
+pub mod log;
 pub mod mouse;
 pub mod screen;
 pub mod time;
@@ -15,6 +16,7 @@ type InitResult = Result<()>;
 static SYSTEM_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub(crate) fn init_system() -> InitResult {
+    log::init_log_plugin_with_default();
     keyboard::init()?;
     screen::init()?;
     time::init()?;

--- a/namui/rendering-tree/Cargo.lock
+++ b/namui/rendering-tree/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -689,6 +690,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -1021,6 +1028,37 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typeid"

--- a/namui/rendering-tree/Cargo.toml
+++ b/namui/rendering-tree/Cargo.toml
@@ -11,6 +11,7 @@ unicode-segmentation = "1.10.1"
 dashmap = "6.1.0"
 bumpalo = "3"
 bincode = { version = "2", features = ["derive"] }
+tracing = "0.1"
 
 [dev-dependencies]
 float-cmp = "0.10.0"

--- a/namui/rendering-tree/src/rendering_tree/special/mouse_cursor.rs
+++ b/namui/rendering-tree/src/rendering_tree/special/mouse_cursor.rs
@@ -156,7 +156,7 @@ impl StandardCursorSpriteSet {
                 .next()
                 .ok_or_else(|| anyhow::anyhow!("Missing cursor name"))?;
             let Some(standard_cursor) = StandardCursor::from_css_cursor_value(name) else {
-                println!("Unknown cursor name: {name} at line {index}, skipping.",);
+                tracing::warn!("Unknown cursor name: {name} at line {index}, skipping.");
                 continue;
             };
             let hotspot_xy = Xy::new(

--- a/namui/sample/spatial-audio/Cargo.lock
+++ b/namui/sample/spatial-audio/Cargo.lock
@@ -266,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +343,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -741,6 +759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,9 +803,14 @@ dependencies = [
  "namui-particle",
  "namui-rendering-tree",
  "namui-type",
+ "parking_lot",
  "rand",
  "shader-macro",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -837,10 +869,13 @@ dependencies = [
 name = "namui-rendering-tree"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "bumpalo",
  "dashmap 6.1.0",
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -916,6 +951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1049,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1112,7 +1169,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1264,6 +1321,15 @@ name = "shader-macro"
 version = "0.1.0"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1396,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -1516,7 +1588,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1528,6 +1609,57 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1592,6 +1724,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1835,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/namui/skia/Cargo.lock
+++ b/namui/skia/Cargo.lock
@@ -353,35 +353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.8.0",
- "block",
- "cocoa-foundation",
- "core-foundation 0.10.1",
- "core-graphics 0.24.0",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.8.0",
- "block",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
- "objc",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,16 +382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,21 +394,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -459,18 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -948,7 +885,7 @@ checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
  "bitflags 2.8.0",
  "block",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types",
  "log",
  "objc",
@@ -974,10 +911,13 @@ dependencies = [
 name = "namui-rendering-tree"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "bumpalo",
  "dashmap",
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -987,8 +927,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "cocoa",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "derive_more",
  "float-cmp",
  "foreign-types",
@@ -996,10 +935,11 @@ dependencies = [
  "metal",
  "namui-rendering-tree",
  "namui-type",
- "objc",
+ "objc2",
  "skia-safe",
  "textwrap",
  "tokio",
+ "tracing",
  "unicode-segmentation",
  "windows",
  "winit",
@@ -1976,7 +1916,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1984,6 +1936,9 @@ name = "tracing-core"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "ttf-parser"
@@ -2613,8 +2568,8 @@ dependencies = [
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation 0.9.4",
- "core-graphics 0.23.2",
+ "core-foundation",
+ "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",

--- a/namui/skia/Cargo.toml
+++ b/namui/skia/Cargo.toml
@@ -21,6 +21,7 @@ textwrap = "0.16.0"
 unicode-segmentation = "1.10.1"
 derive_more = { version = "1.0.0", features = ["debug"] }
 bytes = "1.10.1"
+tracing = "0.1"
 
 [target.'cfg(target_os="wasi")'.dependencies]
 skia-safe = { path = "../third-party-forks/rust-skia/skia-safe", features = [

--- a/namui/skia/src/canvas.rs
+++ b/namui/skia/src/canvas.rs
@@ -6,7 +6,7 @@ impl SkCanvas for skia_safe::Canvas {
     }
     fn draw_text_blob(&self, glyph_ids: GlyphIds, xy: Xy<Px>, font: &Font, paint: &Paint) {
         let Some(text_blob) = NativeTextBlob::from_glyph_ids(glyph_ids, font) else {
-            println!("text_blob not found");
+            tracing::warn!(target: "namui::skia", "text_blob not found for glyph_ids");
             return;
         };
         self.draw_text_blob(text_blob.skia(), xy, NativePaint::get(paint).skia());

--- a/tower-defense/Cargo.lock
+++ b/tower-defense/Cargo.lock
@@ -495,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +648,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1220,6 +1238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,9 +1294,14 @@ dependencies = [
  "namui-particle",
  "namui-rendering-tree",
  "namui-type",
+ "parking_lot",
  "rand",
  "shader-macro",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1334,6 +1366,7 @@ dependencies = [
  "namui-type",
  "skia-safe",
  "textwrap",
+ "tracing",
  "unicode-segmentation",
 ]
 
@@ -1419,6 +1452,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1572,6 +1611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,7 +1739,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1888,6 +1933,15 @@ name = "shader-macro"
 version = "0.1.0"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2083,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -2215,7 +2275,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2227,6 +2296,57 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2350,6 +2470,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2604,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/tower-defense/src/game_state/debug_tools/spiral_place.rs
+++ b/tower-defense/src/game_state/debug_tools/spiral_place.rs
@@ -133,7 +133,7 @@ pub fn place_selected_tower_in_spiral(gs: &mut GameState) {
                         .expect("route should exist after removing a tower");
                     placed_coords = gs.towers.coords();
                     route_coords = gs.route.iter_coords().to_vec();
-                    println!("[Spiral Place] Removed tower at ({}, {})", coord.x, coord.y);
+                    debug!(target: "td::spiral_place", "Removed tower at ({}, {})", coord.x, coord.y);
                 }
             }
             PlanStep::Place(left_top) => {
@@ -155,10 +155,7 @@ pub fn place_selected_tower_in_spiral(gs: &mut GameState) {
                         None,
                     ));
                     placed_at = Some(left_top);
-                    println!(
-                        "[Spiral Place] Placed tower at ({}, {})",
-                        left_top.x, left_top.y
-                    );
+                    debug!(target: "td::spiral_place", "Placed tower at ({}, {})", left_top.x, left_top.y);
                     break;
                 }
             }
@@ -182,7 +179,7 @@ pub fn place_selected_tower_in_spiral(gs: &mut GameState) {
             gs.action(crate::game_state::GameStateAction::StartDefense);
         }
     } else {
-        println!("[Spiral Place] No placement available for this plan iteration.");
+        debug!(target: "td::spiral_place", "No placement available for this plan iteration.");
     }
 }
 

--- a/tower-defense/src/game_state/monster/skill.rs
+++ b/tower-defense/src/game_state/monster/skill.rs
@@ -1,6 +1,5 @@
-use super::*;
 use crate::game_state::GameState;
-use namui::Instant;
+use namui::*;
 use std::ops::Deref;
 
 #[derive(Clone, Copy, State)]
@@ -110,7 +109,7 @@ pub fn activate_monster_skills(game_state: &mut GameState, now: Instant) {
         };
 
         target_monsters.into_iter().for_each(|monster| {
-            println!("Activating skill for monster {}", monster.max_hp);
+            debug!(target: "td::monster::skill", "Activating skill for monster {}", monster.max_hp);
             let mut push_status_effect = |kind| {
                 monster.status_effects.push(MonsterStatusEffect {
                     kind,


### PR DESCRIPTION
## Summary
- Adopt `tracing` + `tracing-subscriber` (Bevy `LogPlugin` pattern): zero-config auto-init, `RUST_LOG` honored, builder customization via `namui::start_with_log_config`.
- wasi console routing: custom `_namui_console_log` host import + `%c` styling (ERROR red / WARN yellow / others toned). All levels go through `console.log` — no JS-frame stack noise.
- Panic hook, ring buffer (crash-reporter hook via `dump_ring_buffer()` / `dump_recent_logs()`), optional daily-rotated file output via `tracing-appender`.
- Migrate internal `println!` / `eprintln!` across `namui`, `namui-prebuilt`, `namui-rendering-tree`, `namui-skia`, `namui-audio-native`, `tower-defense`. `namui-cli` (CLI UX) and `native-runner` (signal-safety) intentionally excluded.
- Full spec at `namui/docs/specs/logging.md`.

## Test plan
- [x] `cargo check` for all touched crates, native (aarch64-apple-darwin) + wasm32-wasip1-threads.
- [ ] Run tower-defense; verify timestamped, color-separated tracing output.
- [ ] `RUST_LOG=trace namui start` toggles verbosity (works on both native and wasi).