### PR TITLE
fix(namui): default Paint anti-alias to true when unset (#1303)

### DIFF
--- a/namui/native-runner/src/main.rs
+++ b/namui/native-runner/src/main.rs
@@ -18,12 +18,13 @@ unsafe extern "C" fn signal_handler(sig: libc::c_int) {
 
 #[cfg(unix)]
 fn install_signal_handlers() {
+    let handler = signal_handler as *const () as libc::sighandler_t;
     unsafe {
-        libc::signal(libc::SIGSEGV, signal_handler as libc::sighandler_t);
-        libc::signal(libc::SIGBUS, signal_handler as libc::sighandler_t);
-        libc::signal(libc::SIGABRT, signal_handler as libc::sighandler_t);
-        libc::signal(libc::SIGILL, signal_handler as libc::sighandler_t);
-        libc::signal(libc::SIGFPE, signal_handler as libc::sighandler_t);
+        libc::signal(libc::SIGSEGV, handler);
+        libc::signal(libc::SIGBUS, handler);
+        libc::signal(libc::SIGABRT, handler);
+        libc::signal(libc::SIGILL, handler);
+        libc::signal(libc::SIGFPE, handler);
     }
 }
 

--- a/namui/rendering-tree/src/skia_types/paint.rs
+++ b/namui/rendering-tree/src/skia_types/paint.rs
@@ -41,9 +41,7 @@ fn new_skia_paint(paint: &Paint) -> skia_safe::Paint {
     if let Some(style) = paint_style {
         skia_paint.set_style(style.into());
     }
-    if let Some(anti_alias) = anti_alias {
-        skia_paint.set_anti_alias(anti_alias);
-    }
+    skia_paint.set_anti_alias(anti_alias.unwrap_or(true));
     if stroke_width > 0.px() {
         skia_paint.set_stroke_width(stroke_width.as_f32());
     }


### PR DESCRIPTION
## Problem

`Paint::default()`'s `anti_alias` is `Option<bool> = None`, and `new_skia_paint()` only called `set_anti_alias` when `Some`. `skia_safe::Paint` defaults AA to `false`, so any path built without explicit `set_anti_alias(true)` rendered without AA.

`rect()` was fine — it sets AA explicitly. But `namui::path()` callsites (route, attack range, halo, paper container, etc.) were not. Surfaced on native skia (Steam Windows / macOS native); hidden in the CanvasKit web build.

## Fix

`new_skia_paint`: treat `None` as "use default (true)" via `anti_alias.unwrap_or(true)`. `Paint` struct and `Default` are unchanged.

Also: clean up `function_casts_as_integer` warnings in `native-runner/src/main.rs`.

## Trade-offs considered

- `Paint::default()` -> `Some(true)`: clearer but `Default = Some(true)` is awkward.
- `Option<bool>` -> `bool`: Flutter style; API breaking.
- Add `set_anti_alias(true)` at every callsite: doesn't fix the wrong default for future code.

Fixes #1303