### PR TITLE
fix(namui-cli): load Mac dev assets via bundle.sqlite

### DIFF
--- a/namui/namui-cli/src/start/dylib_wrapper.rs
+++ b/namui/namui-cli/src/start/dylib_wrapper.rs
@@ -32,8 +32,9 @@ crate-type = ["cdylib"]
 [dependencies]
 {app_name} = {{ path = "{app_dep_path}" }}
 namui = {{ path = "{namui_dep_path}" }}
-namui-audio-native = {{ path = "{namui_dep_path}/audio-native" }}
-namui-kv-store-native = {{ path = "{namui_dep_path}/kv-store-native" }}
+namui-audio-native = {{ path = "{namui_dep_path}/../audio-native" }}
+namui-kv-store-native = {{ path = "{namui_dep_path}/../kv-store-native" }}
+rusqlite = {{ version = "0.31.0", features = ["blob", "bundled"] }}
 
 [profile.dev]
 opt-level = 1
@@ -51,15 +52,35 @@ debug = "line-tables-only"
         format!(
             r#"#[unsafe(no_mangle)]
 pub extern "C" fn namui_main() {{
-    let asset_dir = std::env::current_exe()
+    let exe_dir = std::env::current_exe()
         .expect("Failed to get current exe path")
         .parent()
         .unwrap()
-        .join("asset");
+        .to_path_buf();
+    let bundle_path = exe_dir.join("bundle.sqlite");
     {project_name_underscored}::asset::init_native_assets(|relative_path| {{
-        let path = asset_dir.join(relative_path);
-        std::fs::read(&path)
-            .unwrap_or_else(|e| panic!("Failed to read asset {{}}: {{e}}", path.display()))
+        use std::io::Read;
+        let asset_path = format!("asset/{{}}", relative_path);
+        let conn = rusqlite::Connection::open_with_flags(
+            &bundle_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        ).unwrap_or_else(|e| panic!("Failed to open bundle.sqlite: {{e}}"));
+        let rowid: i64 = conn.query_row(
+            "SELECT rowid FROM bundle WHERE path = ?",
+            [&asset_path],
+            |row| row.get(0),
+        ).unwrap_or_else(|e| panic!("Asset not found in bundle '{{}}': {{e}}", asset_path));
+        let mut blob = conn.blob_open(
+            rusqlite::DatabaseName::Main,
+            "bundle",
+            "data",
+            rowid,
+            true,
+        ).unwrap_or_else(|e| panic!("Failed to open blob for '{{}}': {{e}}", asset_path));
+        let mut data = vec![0u8; blob.len()];
+        blob.read_exact(&mut data)
+            .unwrap_or_else(|e| panic!("Failed to read blob for '{{}}': {{e}}", asset_path));
+        data
     }});
     {project_name_underscored}::main();
 }}

--- a/namui/namui-cli/src/start/mac.rs
+++ b/namui/namui-cli/src/start/mac.rs
@@ -30,6 +30,14 @@ pub fn start(project_path: &Path) -> Result<()> {
 
     let runner_binary = native_runner_dir.join("target/release/native-runner");
 
+    let bundle_path = runner_binary
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("runner binary has no parent dir"))?
+        .join("bundle.sqlite");
+    let bundle_manifest =
+        crate::services::bundle::NamuiBundleManifest::parse(project_path.to_path_buf())?;
+    bundle_manifest.bundle_to_sqlite(&bundle_path)?;
+
     // 3. Generate cdylib wrapper and do initial dylib build
     build_dylib_step(project_path)?;
 


### PR DESCRIPTION
## Problem

`namui start` on macOS launches `native-runner` from `namui/native-runner/target/release/`. The generated `namui_main()` resolved assets via `current_exe().parent().join("asset")` — pointing next to the runner binary, not into the user project. First asset read panicked.

Separately, the generated `target/namui-native/Cargo.toml` listed `namui-audio-native = { path = "{namui}/audio-native" }`, but those crates are siblings of the `namui` crate, not children. The wrong path was inherited from the initial commit but only surfaces when cargo eagerly resolves the manifest.

## Fix

Mirror the Windows binary pattern:

- `start/mac.rs`: bundle project assets into `bundle.sqlite` next to the runner binary (`NamuiBundleManifest::parse` + `bundle_to_sqlite`).
- `start/dylib_wrapper.rs`: generated `namui_main()` opens `current_exe()/bundle.sqlite` via rusqlite and reads each asset as a blob.
- Add `rusqlite = { version = "0.31.0", features = ["blob", "bundled"] }` to the generated `Cargo.toml`.
- Correct `audio-native` / `kv-store-native` paths to `{namui}/../audio-native`.

## Notes

- Asset hot-reload is **not** added: `bundle.sqlite` is regenerated only on `namui start`. The previous code happened to work for live asset edits because it `fs::read`'d directly. Restart `namui start` after touching assets.
- First build pulls `rusqlite` with the `bundled` feature → ~10s extra. Windows already pays this cost.