### PR TITLE
Enable tracing-subscriber ansi feature in namui

### DIFF
--- a/namui/namui/Cargo.toml
+++ b/namui/namui/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "fmt",
     "env-filter",
     "std",
+    "ansi",
 ] }
 tracing-log = "0.2"
 parking_lot = "0.12"

--- a/tower-defense/Cargo.lock
+++ b/tower-defense/Cargo.lock
@@ -1421,6 +1421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",


### PR DESCRIPTION
The namui log layer calls `with_ansi(true)` when stderr is a TTY, but the `tracing-subscriber` dependency was built with `default-features = false` and without the `ansi` feature.

Running through the native runner (e.g. `namui start aarch64-apple-darwin`) attaches a TTY to stderr, so the fmt layer panicked at runtime:

```
thread '<unnamed>' panicked at tracing-subscriber-0.3.23/src/fmt/fmt_layer.rs:337:13:
tracing-subscriber: the `ansi` crate feature is required to enable ANSI terminal colors
```

Add the `ansi` feature so colored terminal output works without panicking.