### PR TITLE
Increase shop slot immediately on backpack purchased

### DIFF
--- a/tower-defense/src/game_state/upgrade/behavior/backpack.rs
+++ b/tower-defense/src/game_state/upgrade/behavior/backpack.rs
@@ -33,6 +33,8 @@ impl UpgradeBehavior for BackpackUpgrade {
     }
 
     fn acquire(self, game_state: &mut GameState) -> UpgradeUpdateFlags {
+        crate::shop::add_shop_slots(game_state, self.add);
+
         for upgrade in game_state.upgrade_state.upgrades.iter_mut() {
             if let Upgrade::Backpack(upgrade) = &mut upgrade.upgrade {
                 upgrade.add += self.add;

--- a/tower-defense/src/shop/mod.rs
+++ b/tower-defense/src/shop/mod.rs
@@ -89,6 +89,16 @@ pub fn refresh_shop(game_state: &mut GameState) {
     }
 }
 
+pub fn add_shop_slots(game_state: &mut GameState, count: usize) {
+    for _ in 0..count {
+        let slot = generate_shop_slot(game_state);
+        let GameFlow::Shopping(flow) = &mut game_state.flow else {
+            return;
+        };
+        flow.shop.push(slot);
+    }
+}
+
 fn generate_shop_slot(game_state: &GameState) -> ShopSlot {
     let slot_type = thread_rng().gen_range(0..10);
 


### PR DESCRIPTION
- Fix backpack purchase only increasing `shop_slot_expand` without immediately reflecting the new slot in the ongoing shop
- On `acquire`, immediately generate and push new slots to the current shop for the added slot count (no-op when acquired outside the shop)

## Test plan

- Not tested in-game (only verified `cargo clippy` passes)

Closes #1334