### PR TITLE
Apply long press to defense start button

### DIFF
--- a/tower-defense/src/hand_panel/action_area.rs
+++ b/tower-defense/src/hand_panel/action_area.rs
@@ -210,6 +210,7 @@ impl Component for HandActionArea {
                                 })
                                 .variant(ButtonVariant::Contained)
                                 .color(ButtonColor::Primary)
+                                .long_press_time(Duration::from_millis(500))
                                 .disabled(!is_active_flow),
                             );
                         })]),


### PR DESCRIPTION
- Apply long press action to the START defense button in the tower placing flow
- Hold for 500ms to start defense; a quick click no longer triggers it, preventing accidentally starting without placing the tower
- Reuses the existing `Button::long_press_time` infra (fill overlay + repeating sound + completion on hold)

## Test plan

- Not tested in-game (only verified `cargo clippy` passes)

Closes #1338