### PR TITLE
chore(deps): fn0-object-storage 0.2.0

### DIFF
--- a/namsh/rs/Cargo.lock
+++ b/namsh/rs/Cargo.lock
@@ -238,9 +238,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fn0-doc-db"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5522d0398e42ab7743ab456b81e2e4eecdece517a0d54e2654271c6354cf72"
+checksum = "9caf94bb4974ae8dd1a38d91e2adcdf4afdd243e901689385aef1e078a0e5668"
 dependencies = [
  "anyhow",
  "bytes",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "fn0-object-storage"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970d41f101a068b18f270fd17ab1c2513a94f9d6581db7bf13f0f5d8abca93e4"
+checksum = "f1f962d5acb40e40ac668903fb9d9442813a6f2ec5866e2c6d79cc02ee2ba484"
 dependencies = [
  "bytes",
  "forte-sdk",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "forte-sdk"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1aaf4d8ecb358a107b03ae0b2381e07ad2b5e4cd170c6df00fba4ca180fcb56"
+checksum = "a88688cc25bedae169905df8727014f803d900b6313aa3bec64be8734a53d2ea"
 dependencies = [
  "anyhow",
  "bytes",

--- a/namsh/rs/Cargo.toml
+++ b/namsh/rs/Cargo.toml
@@ -19,9 +19,9 @@ serde_json = "1"
 sha2 = "0.10"
 tracing = "0.1"
 forte-json = "=0.1.1"
-forte-sdk = "=0.3.5"
-doc-db = { package = "fn0-doc-db", version = "=0.4.3" }
-object-storage = { package = "fn0-object-storage", version = "=0.1.1" }
+forte-sdk = "=0.3.6"
+doc-db = { package = "fn0-doc-db", version = "=0.4.4" }
+object-storage = { package = "fn0-object-storage", version = "=0.2.0" }
 
 [build-dependencies]
 forte-codegen = "=0.1.3"

--- a/namsh/rs/src/actions/intake_crash.rs
+++ b/namsh/rs/src/actions/intake_crash.rs
@@ -158,7 +158,7 @@ pub async fn handler(req: ForteRequest<'_, Input>) -> Output {
 
         let bucket = object_storage::bucket();
         let presigned_put_url = match bucket
-            .presigned_put_url(&r2_key, Duration::from_secs(PRESIGNED_PUT_EXPIRES_SECS))
+            .presigned_put_url(&r2_key, None, Duration::from_secs(PRESIGNED_PUT_EXPIRES_SECS))
             .await
         {
             Ok(u) => u,

--- a/namsh/rs/src/actions/request_pdb_upload.rs
+++ b/namsh/rs/src/actions/request_pdb_upload.rs
@@ -79,7 +79,7 @@ pub async fn handler(req: ForteRequest<'_, Input>) -> Output {
 
     let bucket = object_storage::bucket();
     let pdb_presigned_put_url = match bucket
-        .presigned_put_url(&r2_key, Duration::from_secs(PRESIGNED_PUT_EXPIRES_SECS))
+        .presigned_put_url(&r2_key, None, Duration::from_secs(PRESIGNED_PUT_EXPIRES_SECS))
         .await
     {
         Ok(u) => u,

--- a/namsh/rs/src/route_generated.rs
+++ b/namsh/rs/src/route_generated.rs
@@ -57,7 +57,7 @@ mod proxy {
         { inline :
         "package forte:user; world service-export { import wasi:http/types@0.3.0-rc-2026-03-15; export wasi:http/handler@0.3.0-rc-2026-03-15; }",
         path :
-        "/Users/namse/namseent/namsh/rs/target/wasm32-wasip2/debug/build/namsh-e56b966868918e18/out",
+        "/Users/namse/namseent/namsh/rs/target/wasm32-wasip2/release/build/namsh-b97b353f6635a933/out",
         world : "service-export", default_bindings_module :
         "crate::route_generated::proxy", pub_export_macro : true, async : true, features
         : ["clocks-timezone"], with : { "wasi:http/handler@0.3.0-rc-2026-03-15" :


### PR DESCRIPTION
Picks up `fn0-object-storage` 0.2.0, published today.

`presigned_put_url` now takes `content_length: Option<u64>`. When set, the
size is signed into the URL and R2 rejects a mismatched upload with 403,
so a leaked URL cannot store more than the app intended.

Both namsh call sites pass `None`, keeping current behaviour — the minidump
(`intake_crash`) and PDB (`request_pdb_upload`) upload URLs still accept any
size. Bounding them would need the crash reporter and the PDB uploader to
declare the size, which neither `Input` carries today; that is a protocol
change worth doing separately if we want it.

Also pulls `forte-sdk` to `=0.3.6` and `fn0-doc-db` to `=0.4.4`, which the
new object-storage requires — the previous `=0.3.5` / `=0.4.3` exact pins
conflicted.

Verified with `forte build` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)